### PR TITLE
Add Windows installer

### DIFF
--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -1,0 +1,71 @@
+name: Build Installer
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  workflow_dispatch:
+
+jobs:
+  build-installer:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Determine version
+        id: version
+        shell: bash
+        run: |
+          # Read base version from Directory.Build.props
+          BASE_VERSION=$(sed -n 's/.*<Version>\(.*\)<\/Version>.*/\1/p' Directory.Build.props)
+          SHORT_SHA=$(git rev-parse --short HEAD)
+
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            # Release: version from tag (strip leading 'v')
+            VERSION="${GITHUB_REF#refs/tags/v}"
+            INSTALLER_NAME="CalcpadCE-setup-${VERSION}"
+          else
+            # CI preview: base version (includes -preview) + short hash
+            VERSION="${BASE_VERSION}-${SHORT_SHA}"
+            INSTALLER_NAME="CalcpadCE-setup-${VERSION}"
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "installer_name=$INSTALLER_NAME" >> "$GITHUB_OUTPUT"
+          echo "is_release=$([[ "$GITHUB_REF" == refs/tags/v* ]] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Publish Calcpad WPF
+        run: dotnet publish Calcpad.Wpf/Calcpad.wpf.csproj -c Release -r win-x64 --self-contained false
+
+      - name: Install NSIS
+        run: choco install nsis -y --no-progress
+
+      - name: Build Installer
+        working-directory: Calcpad.Wpf/Installer
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Path Output -Force | Out-Null
+          & "${env:ProgramFiles(x86)}\NSIS\makensis.exe" /DAPP_VERSION="${{ steps.version.outputs.version }}" CalcpadCE.nsi
+
+      - name: Rename installer
+        shell: bash
+        run: mv "Calcpad.Wpf/Installer/Output/CalcpadCE-setup-${{ steps.version.outputs.version }}.exe" "Calcpad.Wpf/Installer/Output/${{ steps.version.outputs.installer_name }}.exe" 2>/dev/null || true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ steps.version.outputs.installer_name }}
+          path: Calcpad.Wpf/Installer/Output/${{ steps.version.outputs.installer_name }}.exe
+
+      - name: Create GitHub Release
+        if: steps.version.outputs.is_release == 'true'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: Calcpad.Wpf/Installer/Output/${{ steps.version.outputs.installer_name }}.exe
+          generate_release_notes: true

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -41,7 +41,7 @@ jobs:
           dotnet-version: '10.0.x'
 
       - name: Publish Calcpad WPF
-        run: dotnet publish Calcpad.Wpf/Calcpad.wpf.csproj -c Release -r win-x64 --self-contained false
+        run: dotnet publish Calcpad.Wpf/Calcpad.wpf.csproj -c Release -r win-x64 --self-contained false -p:Version=${{ steps.version.outputs.version }}
 
       - name: Install NSIS
         run: choco install nsis -y --no-progress

--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,6 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# Installer output
+Calcpad.Wpf/Installer/Output/

--- a/Calcpad.Api/PyCalcpad/PyCalcpad.csproj
+++ b/Calcpad.Api/PyCalcpad/PyCalcpad.csproj
@@ -5,7 +5,6 @@
     <AnalysisLevel>latest</AnalysisLevel>
     <RootNamespace>PyCalcpad</RootNamespace>
     <OutputType>Library</OutputType>
-    <Version>7.6.2</Version>
     <Authors>Nedelcho Ganchovski</Authors>
     <Company>Proektsoft EOOD</Company>
     <GenerateRuntimeConfigFiles>true</GenerateRuntimeConfigFiles>

--- a/Calcpad.Cli/Calcpad.Cli.csproj
+++ b/Calcpad.Cli/Calcpad.Cli.csproj
@@ -5,7 +5,6 @@
     <LangVersion>latest</LangVersion>
     <AnalysisLevel>latest</AnalysisLevel>
     <RootNamespace>Calcpad.Cli</RootNamespace>
-    <Version>7.6.2</Version>
     <Authors>Nedelcho Ganchovski</Authors>
     <Company>Proektsoft EOOD</Company>
     <PackageId>Cli</PackageId>

--- a/Calcpad.Core/Calcpad.Core.csproj
+++ b/Calcpad.Core/Calcpad.Core.csproj
@@ -5,7 +5,6 @@
     <AnalysisLevel>latest</AnalysisLevel>
     <RootNamespace>Calcpad.Core</RootNamespace>
     <OutputType>Library</OutputType>
-    <Version>7.6.2</Version>
     <Authors>Nedelcho Ganchovski</Authors>
     <Company>Proektsoft EOOD</Company>
   </PropertyGroup>

--- a/Calcpad.OpenXml/Calcpad.OpenXml.csproj
+++ b/Calcpad.OpenXml/Calcpad.OpenXml.csproj
@@ -5,7 +5,6 @@
     <AnalysisLevel>latest</AnalysisLevel>
     <RootNamespace>Calcpad.OpenXml</RootNamespace>
     <OutputType>Library</OutputType>
-    <Version>7.6.2</Version>
     <Authors>Nedelcho Ganchovski</Authors>
     <Company>Proektsoft EOOD</Company>
   </PropertyGroup>

--- a/Calcpad.Wpf/Calcpad.wpf.csproj
+++ b/Calcpad.Wpf/Calcpad.wpf.csproj
@@ -11,7 +11,6 @@
     <Authors>Nedelcho Ganchovski</Authors>
     <RootNamespace>Calcpad.Wpf</RootNamespace>
     <Platforms>AnyCPU</Platforms>
-		<Version>7.6.2</Version>
 		<Authors>Nedelcho Ganchovski</Authors>
 		<Company>Proektsoft EOOD</Company>
     <PackageId>Calcpad</PackageId>

--- a/Calcpad.Wpf/Installer/CalcpadCE.nsi
+++ b/Calcpad.Wpf/Installer/CalcpadCE.nsi
@@ -1,0 +1,127 @@
+!include "MUI2.nsh"
+!include "FileFunc.nsh"
+
+;--------------------------------
+; General
+
+!define APP_NAME "Calcpad"
+!ifndef APP_VERSION
+  !define APP_VERSION "dev"
+!endif
+!define APP_PUBLISHER "CalcpadCE Community"
+!define APP_URL "https://calcpad-ce.org/"
+!define APP_EXE "Calcpad.exe"
+!define PUBLISH_DIR "..\bin\Release\net10.0-windows\win-x64\publish"
+
+Name "${APP_NAME} ${APP_VERSION}"
+OutFile "Output\CalcpadCE-setup-${APP_VERSION}.exe"
+InstallDir "$LOCALAPPDATA\Programs\${APP_NAME}"
+InstallDirRegKey HKCU "Software\${APP_NAME}" "InstallPath"
+RequestExecutionLevel user
+SetCompressor /SOLID lzma
+Unicode True
+ManifestDPIAware System
+
+;--------------------------------
+; Interface Settings
+
+!define MUI_ICON "..\resources\calcpad.ico"
+!define MUI_UNICON "..\resources\calcpad.ico"
+!define MUI_ABORTWARNING
+!define MUI_FINISHPAGE_RUN "$INSTDIR\${APP_EXE}"
+!define MUI_FINISHPAGE_RUN_TEXT "Launch ${APP_NAME}"
+
+;--------------------------------
+; Pages
+
+!insertmacro MUI_PAGE_LICENSE "..\..\LICENSE"
+!insertmacro MUI_PAGE_DIRECTORY
+!insertmacro MUI_PAGE_INSTFILES
+!insertmacro MUI_PAGE_FINISH
+
+!insertmacro MUI_UNPAGE_CONFIRM
+!insertmacro MUI_UNPAGE_INSTFILES
+
+;--------------------------------
+; Language
+
+!insertmacro MUI_LANGUAGE "English"
+
+;--------------------------------
+; Install Section
+
+Section "Install"
+  SetOutPath "$INSTDIR"
+  File /r "${PUBLISH_DIR}\*.*"
+
+  ; Create Start Menu shortcuts
+  CreateDirectory "$SMPROGRAMS\${APP_NAME}"
+  CreateShortCut "$SMPROGRAMS\${APP_NAME}\${APP_NAME}.lnk" "$INSTDIR\${APP_EXE}" "" "$INSTDIR\${APP_EXE}" 0
+  CreateShortCut "$SMPROGRAMS\${APP_NAME}\Uninstall ${APP_NAME}.lnk" "$INSTDIR\Uninstall.exe"
+
+  ; Create Desktop shortcut
+  CreateShortCut "$DESKTOP\${APP_NAME}.lnk" "$INSTDIR\${APP_EXE}" "" "$INSTDIR\${APP_EXE}" 0
+
+  ; .cpd file association
+  WriteRegStr HKCU "Software\Classes\.cpd" "" "Calcpad.CpdFile"
+  WriteRegStr HKCU "Software\Classes\Calcpad.CpdFile" "" "Calcpad Document"
+  WriteRegStr HKCU "Software\Classes\Calcpad.CpdFile\DefaultIcon" "" "$INSTDIR\${APP_EXE},0"
+  WriteRegStr HKCU "Software\Classes\Calcpad.CpdFile\shell\open\command" "" '"$INSTDIR\${APP_EXE}" "%1"'
+
+  ; .cpdz file association
+  WriteRegStr HKCU "Software\Classes\.cpdz" "" "Calcpad.CpdzFile"
+  WriteRegStr HKCU "Software\Classes\Calcpad.CpdzFile" "" "Calcpad Protected Document"
+  WriteRegStr HKCU "Software\Classes\Calcpad.CpdzFile\DefaultIcon" "" "$INSTDIR\${APP_EXE},0"
+  WriteRegStr HKCU "Software\Classes\Calcpad.CpdzFile\shell\open\command" "" '"$INSTDIR\${APP_EXE}" "%1"'
+
+  ; Notify shell of association changes
+  System::Call 'shell32::SHChangeNotify(i 0x08000000, i 0, p 0, p 0)'
+
+  ; Write install path to registry
+  WriteRegStr HKCU "Software\${APP_NAME}" "InstallPath" "$INSTDIR"
+  WriteRegStr HKCU "Software\${APP_NAME}" "Version" "${APP_VERSION}"
+
+  ; Write uninstall information
+  WriteUninstaller "$INSTDIR\Uninstall.exe"
+  WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}" "DisplayName" "${APP_NAME}"
+  WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}" "DisplayVersion" "${APP_VERSION}"
+  WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}" "Publisher" "${APP_PUBLISHER}"
+  WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}" "DisplayIcon" "$INSTDIR\${APP_EXE}"
+  WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}" "UninstallString" '"$INSTDIR\Uninstall.exe"'
+  WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}" "URLInfoAbout" "${APP_URL}"
+  WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}" "URLUpdateInfo" "https://github.com/imartincei/CalcpadCE"
+  WriteRegDWORD HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}" "NoModify" 1
+  WriteRegDWORD HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}" "NoRepair" 1
+
+  ; Estimate installed size (KB)
+  ${GetSize} "$INSTDIR" "/S=0K" $0 $1 $2
+  IntFmt $0 "0x%08X" $0
+  WriteRegDWORD HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}" "EstimatedSize" $0
+SectionEnd
+
+;--------------------------------
+; Uninstall Section
+
+Section "Uninstall"
+  ; Remove files and directories
+  RMDir /r "$INSTDIR"
+
+  ; Remove Start Menu shortcuts
+  RMDir /r "$SMPROGRAMS\${APP_NAME}"
+
+  ; Remove Desktop shortcut
+  Delete "$DESKTOP\${APP_NAME}.lnk"
+
+  ; Remove file associations
+  DeleteRegKey HKCU "Software\Classes\.cpd"
+  DeleteRegKey HKCU "Software\Classes\Calcpad.CpdFile"
+  DeleteRegKey HKCU "Software\Classes\.cpdz"
+  DeleteRegKey HKCU "Software\Classes\Calcpad.CpdzFile"
+
+  ; Notify shell of association changes
+  System::Call 'shell32::SHChangeNotify(i 0x08000000, i 0, p 0, p 0)'
+
+  ; Remove registry entries
+  DeleteRegKey HKCU "Software\${APP_NAME}"
+  DeleteRegKey HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}"
+SectionEnd

--- a/Calcpad.Wpf/MainWindow.xaml
+++ b/Calcpad.Wpf/MainWindow.xaml
@@ -3,7 +3,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:wpf="clr-namespace:Calcpad.Wpf"
     xmlns:av="http://schemas.microsoft.com/expression/blend/2008" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="av" x:Class="Calcpad.Wpf.MainWindow"
-    Title=" Calcpad VM 7.6.2"
+    Title=" Calcpad VM"
     Height="800"
     Width="1200"
     WindowStartupLocation="CenterScreen"

--- a/Calcpad.Wpf/MainWindow.xaml.cs
+++ b/Calcpad.Wpf/MainWindow.xaml.cs
@@ -45,8 +45,13 @@ namespace Calcpad.Wpf
                 Path = AppDomain.CurrentDomain.BaseDirectory;
                 Name = AppDomain.CurrentDomain.FriendlyName + ".exe";
                 FullName = System.IO.Path.Combine(Path, Name);
-                Version = Assembly.GetExecutingAssembly().GetName().Version.ToString();
-                Title = " Calcpad VM " + Version[0..(Version.LastIndexOf('.'))];
+                Version = Assembly.GetExecutingAssembly()
+                    .GetCustomAttribute<System.Reflection.AssemblyInformationalVersionAttribute>()?
+                    .InformationalVersion ?? Assembly.GetExecutingAssembly().GetName().Version.ToString();
+                // Strip source link hash appended by SDK (e.g. "+abc123def")
+                var plusIndex = Version.IndexOf('+');
+                if (plusIndex >= 0) Version = Version[..plusIndex];
+                Title = " Calcpad VM " + Version;
                 DocPath = Path + "doc";
                 if (!Directory.Exists(DocPath))
                     DocPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + "\\Calcpad";
@@ -233,6 +238,7 @@ namespace Calcpad.Wpf
             _insertManager = new(RichTextBox);
             _autoCompleteManager = new(RichTextBox, AutoCompleteListBox, Dispatcher, _insertManager);
             _cfn = string.Empty;
+            Title = AppInfo.Title;
             _isTextChangedEnabled = false;
             IsSaved = true;
             _findReplace.RichTextBox = RichTextBox;

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <Version>7.6.3-preview</Version>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
This adds an NSIS installer for the WPF application to use while the WebView application is in development.

The version number is now managed centrally in `Directory.Build.props`, which is automatically picked up by the .NET build system and CI.

The installer is built on every push and uploaded as a GitHub Actions artifact. The filename format will be `CalcpadCE-setup-[upcoming version]-preview-[Git hash].exe`.

When a tag is pushed (e.g., `v7.6.3`), a GitHub release is automatically created and the installer is attached as an asset. The filename will be `CalcpadCE-setup-[version number].exe`. After that, the version number in `Directory.Build.props` must be manually increased matching the next planned version number.

Finally, the version number in the WPF application's title bar is now retrieved from this centralized version property, ensuring it matches the naming scheme of the installer.