### PR TITLE
Give GitHub Actions write permission to create a release on tag push

### DIFF
--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -6,6 +6,9 @@ on:
     tags: ['v*']
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build-installer:
     runs-on: windows-latest


### PR DESCRIPTION
The CI action failed to create the release with a 403, which is why I created it manually. This should give it the right permission to create one.