### PR TITLE
Add language selection dialog to the installer

### DIFF
--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [main]
     tags: ['v*']
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/Calcpad.Wpf/Installer/CalcpadCE.nsi
+++ b/Calcpad.Wpf/Installer/CalcpadCE.nsi
@@ -31,6 +31,11 @@ ManifestDPIAware System
 !define MUI_FINISHPAGE_RUN "$INSTDIR\${APP_EXE}"
 !define MUI_FINISHPAGE_RUN_TEXT "Launch ${APP_NAME}"
 
+; Language dialog settings — remember choice in registry for upgrades
+!define MUI_LANGDLL_REGISTRY_ROOT "HKCU"
+!define MUI_LANGDLL_REGISTRY_KEY "Software\${APP_NAME}"
+!define MUI_LANGDLL_REGISTRY_VALUENAME "InstallerLanguage"
+
 ;--------------------------------
 ; Pages
 
@@ -43,9 +48,18 @@ ManifestDPIAware System
 !insertmacro MUI_UNPAGE_INSTFILES
 
 ;--------------------------------
-; Language
+; Languages
 
 !insertmacro MUI_LANGUAGE "English"
+!insertmacro MUI_LANGUAGE "Bulgarian"
+!insertmacro MUI_LANGUAGE "SimpChinese"
+
+;--------------------------------
+; Installer init — show language selection dialog
+
+Function .onInit
+  !insertmacro MUI_LANGDLL_DISPLAY
+FunctionEnd
 
 ;--------------------------------
 ; Install Section
@@ -81,6 +95,16 @@ Section "Install"
   WriteRegStr HKCU "Software\${APP_NAME}" "InstallPath" "$INSTDIR"
   WriteRegStr HKCU "Software\${APP_NAME}" "Version" "${APP_VERSION}"
 
+  ; Map NSIS language ID to app culture string and write to registry
+  StrCmp $LANGUAGE 1026 0 +3
+    WriteRegStr HKCU "Software\${APP_NAME}" "Language" "bg"
+    Goto lang_done
+  StrCmp $LANGUAGE 2052 0 +3
+    WriteRegStr HKCU "Software\${APP_NAME}" "Language" "zh"
+    Goto lang_done
+  WriteRegStr HKCU "Software\${APP_NAME}" "Language" "en"
+  lang_done:
+
   ; Write uninstall information
   WriteUninstaller "$INSTDIR\Uninstall.exe"
   WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}" "DisplayName" "${APP_NAME}"
@@ -98,6 +122,13 @@ Section "Install"
   IntFmt $0 "0x%08X" $0
   WriteRegDWORD HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}" "EstimatedSize" $0
 SectionEnd
+
+;--------------------------------
+; Uninstaller init — restore language for uninstall UI
+
+Function un.onInit
+  !insertmacro MUI_UNGETLANGUAGE
+FunctionEnd
 
 ;--------------------------------
 ; Uninstall Section

--- a/Calcpad.Wpf/Installer/CalcpadCE.nsi
+++ b/Calcpad.Wpf/Installer/CalcpadCE.nsi
@@ -4,7 +4,7 @@
 ;--------------------------------
 ; General
 
-!define APP_NAME "Calcpad"
+!define APP_NAME "CalcpadCE"
 !ifndef APP_VERSION
   !define APP_VERSION "dev"
 !endif

--- a/Calcpad.Wpf/MainWindow.xaml.cs
+++ b/Calcpad.Wpf/MainWindow.xaml.cs
@@ -27,7 +27,7 @@ namespace Calcpad.Wpf
     public partial class MainWindow : Window
     {
         // Culture
-        private static readonly string _currentCultureName = "en"; // en, bg or zh
+        private static readonly string _currentCultureName = ReadLanguageFromRegistry();
 
         // Static resources
         private static readonly char[] GreekLetters = ['α', 'β', 'χ', 'δ', 'ε', 'φ', 'γ', 'η', 'ι', 'ø', 'κ', 'λ', 'μ', 'ν', 'ο', 'π', 'θ', 'ρ', 'σ', 'τ', 'υ', 'ϑ', 'ω', 'ξ', 'ψ', 'ζ'];
@@ -3901,6 +3901,14 @@ namespace Calcpad.Wpf
         private void RichTextBox_GotKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
         {
             IsWebView2Focused = false;
+        }
+
+        private static string ReadLanguageFromRegistry()
+        {
+            using var key = Registry.CurrentUser.OpenSubKey(@"Software\CalcpadCE");
+            if (key?.GetValue("Language") is string lang && lang is "en" or "bg" or "zh")
+                return lang;
+            return "en";
         }
     }
 }


### PR DESCRIPTION
This adds a dialog when the installer is started to select the language.

The following installer dialogs will be in this language, the application will reflect the setting, it will also be used when uninstalling the application, and when the installer is started the next time when updating the application.

@WeiJunFenYou Can you please give it a try?

Fixes #21