### PR TITLE
Add RPM and tarball builds

### DIFF
--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -19,6 +19,8 @@ jobs:
       installer_name: ${{ steps.version.outputs.installer_name }}
       portable_name: ${{ steps.version.outputs.portable_name }}
       deb_name: ${{ steps.version.outputs.deb_name }}
+      rpm_name: ${{ steps.version.outputs.rpm_name }}
+      tarball_name: ${{ steps.version.outputs.tarball_name }}
       is_release: ${{ steps.version.outputs.is_release }}
     steps:
       - name: Checkout
@@ -36,17 +38,23 @@ jobs:
             INSTALLER_NAME="CalcpadCE-setup-${VERSION}"
             PORTABLE_NAME="CalcpadCE-portable-${VERSION}"
             DEB_NAME="Calcpad.${VERSION}"
+            RPM_NAME="CalcpadCE.${VERSION}"
+            TARBALL_NAME="CalcpadCE-${VERSION}"
           else
             VERSION="${BASE_VERSION}-${SHORT_SHA}"
             INSTALLER_NAME="CalcpadCE-setup-${VERSION}"
             PORTABLE_NAME="CalcpadCE-portable-${VERSION}"
             DEB_NAME="Calcpad.${VERSION}"
+            RPM_NAME="CalcpadCE.${VERSION}"
+            TARBALL_NAME="CalcpadCE-${VERSION}"
           fi
 
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "installer_name=$INSTALLER_NAME" >> "$GITHUB_OUTPUT"
           echo "portable_name=$PORTABLE_NAME" >> "$GITHUB_OUTPUT"
           echo "deb_name=$DEB_NAME" >> "$GITHUB_OUTPUT"
+          echo "rpm_name=$RPM_NAME" >> "$GITHUB_OUTPUT"
+          echo "tarball_name=$TARBALL_NAME" >> "$GITHUB_OUTPUT"
           echo "is_release=$([[ "$GITHUB_REF" == refs/tags/v* ]] && echo true || echo false)" >> "$GITHUB_OUTPUT"
 
   build-windows:
@@ -134,9 +142,74 @@ jobs:
           name: ${{ needs.determine-version.outputs.deb_name }}-${{ matrix.rid }}
           path: Calcpad.Cli/bin/Release/net10.0/${{ matrix.rid }}/*.deb
 
+  build-rpm:
+    needs: determine-version
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rid: [linux-x64, linux-arm64]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Install RPM tools
+        run: sudo apt-get update && sudo apt-get install -y rpm
+
+      - name: Restore packages
+        working-directory: Calcpad.Cli
+        run: dotnet restore Calcpad.Cli.csproj -r ${{ matrix.rid }}
+
+      - name: Build .rpm package
+        working-directory: Calcpad.Cli
+        run: dotnet msbuild Calcpad.Cli.csproj -t:CreateRpm -p:Configuration=Release -p:Version=${{ needs.determine-version.outputs.version }} -p:PackagePrefix=CalcpadCE -p:RuntimeIdentifier=${{ matrix.rid }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ needs.determine-version.outputs.rpm_name }}-${{ matrix.rid }}
+          path: Calcpad.Cli/bin/Release/net10.0/${{ matrix.rid }}/*.rpm
+
+  build-tarball:
+    needs: determine-version
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rid: [linux-x64, linux-arm64]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Publish self-contained
+        run: >
+          dotnet publish Calcpad.Cli/Calcpad.Cli.csproj
+          -c Release -r ${{ matrix.rid }} --self-contained true
+          -p:Version=${{ needs.determine-version.outputs.version }}
+          -o tarball-output
+
+      - name: Create tarball
+        run: |
+          mv tarball-output "${{ needs.determine-version.outputs.tarball_name }}"
+          tar cjf "${{ needs.determine-version.outputs.tarball_name }}-${{ matrix.rid }}.tar.bz2" "${{ needs.determine-version.outputs.tarball_name }}"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ needs.determine-version.outputs.tarball_name }}-${{ matrix.rid }}
+          path: ${{ needs.determine-version.outputs.tarball_name }}-${{ matrix.rid }}.tar.bz2
+
   release:
     if: needs.determine-version.outputs.is_release == 'true'
-    needs: [determine-version, build-windows, build-deb]
+    needs: [determine-version, build-windows, build-deb, build-rpm, build-tarball]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -157,6 +230,20 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           pattern: ${{ needs.determine-version.outputs.deb_name }}-*
+          path: artifacts/
+          merge-multiple: true
+
+      - name: Download .rpm packages
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ${{ needs.determine-version.outputs.rpm_name }}-*
+          path: artifacts/
+          merge-multiple: true
+
+      - name: Download tarballs
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ${{ needs.determine-version.outputs.tarball_name }}-*
           path: artifacts/
           merge-multiple: true
 

--- a/Calcpad.Cli/Calcpad.Cli.csproj
+++ b/Calcpad.Cli/Calcpad.Cli.csproj
@@ -35,8 +35,6 @@
 
   <ItemGroup>
     <DebDependency Include="dotnet-runtime-10.0" />
-    <DebDependency Include="wkhtmltopdf" />
-    <RpmDependency Include="wkhtmltopdf" />
     <RpmDependency Include="dotnet-runtime-10.0" />
   </ItemGroup>
 

--- a/Calcpad.Cli/Calcpad.Cli.csproj
+++ b/Calcpad.Cli/Calcpad.Cli.csproj
@@ -101,18 +101,17 @@
   <PropertyGroup>
     <PostInstallScript>
       <![CDATA[
-      mkdir -p "/home/$SUDO_USER/calcpad" \
-      && cp -a "/usr/share/CalcpadCE/Examples" "/home/$SUDO_USER/calcpad/Examples" \
-      && cp -a "/usr/share/CalcpadCE/doc" "/home/$SUDO_USER/calcpad/doc" \
-      && mkdir -p "/home/$SUDO_USER/calcpad/syntax/Sublime" \
-      && cp -a "/usr/share/CalcpadCE/Syntax/Sublime" "/home/$SUDO_USER/calcpad/syntax" \
-      && mkdir -p "/home/$SUDO_USER/.config/calcpad/" \
-      && cp "/usr/share/CalcpadCE/Settings.xml" "/home/$SUDO_USER/.config/calcpad/Settings.xml" \
-      && cp -a "/usr/share/CalcpadCE/Fonts" "/usr/share/fonts/opentype" \
-      && chown -R $SUDO_USER "/home/$SUDO_USER/calcpad" "/home/$SUDO_USER/.config/calcpad/" \
-      && rm -rf "/usr/share/CalcpadCE/Examples"
+      mkdir -p /usr/share/fonts/CalcpadCE
+      cp -a /usr/share/CalcpadCE/Fonts/* /usr/share/fonts/CalcpadCE/
+      fc-cache -f /usr/share/fonts/CalcpadCE 2>/dev/null || true
       ]]>
     </PostInstallScript>
+    <PostRemoveScript>
+      <![CDATA[
+      rm -rf /usr/share/fonts/CalcpadCE
+      fc-cache -f 2>/dev/null || true
+      ]]>
+    </PostRemoveScript>
   </PropertyGroup>
 
 </Project>

--- a/Calcpad.Cli/Calcpad.Cli.csproj
+++ b/Calcpad.Cli/Calcpad.Cli.csproj
@@ -13,6 +13,7 @@
     <StartupObject>Calcpad.Cli.Program</StartupObject>
     <SymlinkAppHostInBin>false</SymlinkAppHostInBin>
     <SkipDebDependencies>true</SkipDebDependencies>
+    <SkipRpmDependencies>true</SkipRpmDependencies>
   </PropertyGroup>
 
   <ItemGroup>
@@ -36,6 +37,7 @@
     <DebDependency Include="dotnet-runtime-10.0" />
     <DebDependency Include="wkhtmltopdf" />
     <RpmDependency Include="wkhtmltopdf" />
+    <RpmDependency Include="dotnet-runtime-10.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This adds support for building .rpm and .tar packages for 64-bit Linux and ARM64 (e.g., Raspberry Pi).

I also removed the step that copies files directly into the user's home directory during installation. This is an anti-pattern because those files get overwritten on upgrades and are left behind during uninstallation. Instead, the files now simply only reside in `/usr/share/CalcpadCE`.

Additionally, fonts are now copied to the correct system location, and the font cache is automatically updated during installation.

I also removed the dependency to wkhtmltopdf, because this package does not exist under CentOS, and it is optional, too.