### PR TITLE
Forcibly run the unit tests with a culture using "." as decimal separator

### DIFF
--- a/Calcpad.Tests/TestCultureInitializer.cs
+++ b/Calcpad.Tests/TestCultureInitializer.cs
@@ -1,0 +1,17 @@
+using System.Globalization;
+using System.Runtime.CompilerServices;
+
+namespace Calcpad.Tests;
+
+internal static class TestCultureInitializer
+{
+    [ModuleInitializer]
+    internal static void Initialize()
+    {
+        var culture = CultureInfo.GetCultureInfo("en-US");
+        CultureInfo.DefaultThreadCurrentCulture = culture;
+        CultureInfo.DefaultThreadCurrentUICulture = culture;
+        CultureInfo.CurrentCulture = culture;
+        CultureInfo.CurrentUICulture = culture;
+    }
+}


### PR DESCRIPTION
Otherwise, I get these:

```
C:\Users\Fabian Wolter\git\CalcpadCE\Calcpad.Tests\Matrices\HP\Small\HPUtriangMatrixOperatorTests.cs(290): error TESTERROR: 
      Calcpad.Tests.HPUtriangMatrixOperatorTests.HPUtriangMatrixScalarDivision (< 1ms): Fehlermeldung: Assert.Equal() Failure: Strings dif
      fer
                     ↓ (pos 4)
      Expected: "[1 1.5 2|0 2.5 3|0 0 3.5]"
      Actual:   "[1 1,5 2|0 2,5 3|0 0 3,5]"
                     ↑ (pos 4)
      Stapelverfolgung:
         at Calcpad.Tests.HPUtriangMatrixOperatorTests.HPUtriangMatrixScalarDivision() in C:\Users\Fabian Wolter\git\CalcpadCE\Calcpad.Tes
      ts\Matrices\HP\Small\HPUtriangMatrixOperatorTests.cs:line 290
         at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
         at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
```