### PR TITLE
Fix flaky tests

### DIFF
--- a/Calcpad.Tests/Matrices/HP/Large/HPColumnMatrixComparison.cs
+++ b/Calcpad.Tests/Matrices/HP/Large/HPColumnMatrixComparison.cs
@@ -78,7 +78,7 @@
                 "a_hp = hp(a)",
                 "b_hp = hp(b)",
                 $"c_hp = a_hp * b_hp",
-                "r = abs(c - c_hp) ≤ 10^-14*abs(c)",
+                TestCalc.CompareWithTolerance("c", "c_hp", "10^-14"),
                 "mcount(r; 0)"
             ]);
             Assert.Equal(0, result);

--- a/Calcpad.Tests/Matrices/HP/Large/HPDiagonalMatrixComparison.cs
+++ b/Calcpad.Tests/Matrices/HP/Large/HPDiagonalMatrixComparison.cs
@@ -53,7 +53,7 @@
             WellConditionedMatrix,
             $"c = {func}(a)",
             $"c_hp = {func}(hp(a))",
-            $"r = abs(c - c_hp) ≤ {tol}*abs(c)",
+            TestCalc.CompareWithTolerance("c", "c_hp", tol),
             "mcount(r; 0)"
         ];
 
@@ -63,7 +63,7 @@
             "b = random(fill(vector(n); 1))",
             $"c = {func}(a; b)",
             $"c_hp = {func}(hp(a); hp(b))",
-            $"r = abs(c - c_hp) ≤ {tol}*abs(c)",
+            TestCalc.CompareWithTolerance("c", "c_hp", tol),
             "count(r; 0; 1)"
         ];
 
@@ -73,7 +73,7 @@
             "b = random(mfill(matrix(n; 2); 1))",
             $"c = {func}(a; b)",
             $"c_hp = {func}(hp(a); hp(b))",
-            $"r = abs(c - c_hp) ≤ {tol}*abs(c)",
+            TestCalc.CompareWithTolerance("c", "c_hp", tol),
             "mcount(r; 0)"
         ];
 
@@ -929,7 +929,7 @@
                 WellConditionedMatrix,
                 "c = adj(a)",
                 "c_hp = adj(hp(a))",
-                "r = abs(c - c_hp) ≤ 10^-8*abs(c)",
+                TestCalc.CompareWithTolerance("c", "c_hp", "10^-8"),
                 "mcount(r; 0)"
             ]);
             Assert.Equal(0, result);
@@ -945,7 +945,7 @@
                 WellConditionedMatrix,
                 "c = cofactor(a)",
                 "c_hp = cofactor(hp(a))",
-                "r = abs(c - c_hp) ≤ 10^-8*abs(c)",
+                TestCalc.CompareWithTolerance("c", "c_hp", "10^-8"),
                 "mcount(r; 0)"
                 ]);
             Assert.Equal(0, result);
@@ -961,7 +961,7 @@
                 WellConditionedMatrix,
                 "c = eigenvals(a)",
                 "c_hp = eigenvals(hp(a))",
-                "r = abs(c - c_hp) ≤ 10^-12*abs(c)",
+                TestCalc.CompareWithTolerance("c", "c_hp", "10^-12"),
                 "count(r; 0; 1)"
             ]);
             Assert.Equal(0, result);
@@ -1059,7 +1059,7 @@
                 WellConditionedMatrix,
                 "c = inverse(a)",
                 "c_hp = inverse(hp(a))",
-                "r = abs(c - c_hp) ≤ 10^-8*abs(c)",
+                TestCalc.CompareWithTolerance("c", "c_hp", "10^-8"),
                 "mcount(r; 0)"
             ]);
             Assert.Equal(0, result);

--- a/Calcpad.Tests/Matrices/HP/Large/HPDiagonalMatrixComparisonInFunction.cs
+++ b/Calcpad.Tests/Matrices/HP/Large/HPDiagonalMatrixComparisonInFunction.cs
@@ -49,7 +49,7 @@
             "n = 250",
             WellConditionedMatrix,
             $"f(a) = {func}(a)",
-            $"r = abs(f(a) - f(hp(a))) ≤ {tol}*abs(f(a))",
+            TestCalc.CompareWithTolerance("f(a)", "f(hp(a))", tol),
             "mcount(r; 0)"
         ];
 
@@ -58,7 +58,7 @@
             WellConditionedMatrix,
             "b = random(fill(vector(n); 1))",
             $"f(a; b) = {func}(a; b)",
-            $"r = abs(f(a; b) - f(hp(a); hp(b))) ≤ {tol}*abs(f(a; b))",
+            TestCalc.CompareWithTolerance("f(a; b)", "f(hp(a); hp(b))", tol),
             "count(r; 0; 1)"
         ];
 
@@ -67,7 +67,7 @@
             WellConditionedMatrix,
             "b = random(mfill(matrix(n; 2); 1))",
             $"f(a; b) = {func}(a; b)",
-            $"r = abs(f(a; b) - f(hp(a); hp(b))) ≤ {tol}*abs(f(a; b))",
+            TestCalc.CompareWithTolerance("f(a; b)", "f(hp(a); hp(b))", tol),
             "mcount(r; 0)"
         ];
 

--- a/Calcpad.Tests/Matrices/HP/Large/HPLowerTriangularMatrixComparison.cs
+++ b/Calcpad.Tests/Matrices/HP/Large/HPLowerTriangularMatrixComparison.cs
@@ -58,7 +58,7 @@
             PositiveDefiniteArray.Concat([
             $"c = {func}(a)",
             $"c_hp = {func}(hp(a))",
-            $"r = abs(c - c_hp) ≤ {tol}*abs(c)",
+            TestCalc.CompareWithTolerance("c", "c_hp", tol),
             "mcount(r; 0)"
         ]).ToArray();
 
@@ -67,7 +67,7 @@
             "b = random(fill(vector(n); 1))",
             $"c = {func}(a; b)",
             $"c_hp = {func}(hp(a); hp(b))",
-            $"r = abs(c - c_hp) ≤ {tol}*abs(c)",
+            TestCalc.CompareWithTolerance("c", "c_hp", tol),
             "count(r; 0; 1)"
          ]).ToArray();
 
@@ -76,7 +76,7 @@
             "b = random(mfill(matrix(n; 2); 1))",
             $"c = {func}(a; b)",
             $"c_hp = {func}(hp(a); hp(b))",
-            $"r = abs(c - c_hp) ≤ {tol}*abs(c)",
+            TestCalc.CompareWithTolerance("c", "c_hp", tol),
             "mcount(r; 0)"
          ]).ToArray();
 
@@ -932,7 +932,7 @@
                 WellConditionedMatrix,
                 "c = adj(a)",
                 "c_hp = adj(hp(a))",
-                "r = abs(c - c_hp) ≤ 10^-8*abs(c)",
+                TestCalc.CompareWithTolerance("c", "c_hp", "10^-8"),
                 "mcount(r; 0)"
             ]);
             Assert.Equal(0, result);
@@ -948,7 +948,7 @@
                 WellConditionedMatrix,
                 "c = cofactor(a)",
                 "c_hp = cofactor(hp(a))",
-                "r = abs(c - c_hp) ≤ 10^-8*abs(c)",
+                TestCalc.CompareWithTolerance("c", "c_hp", "10^-8"),
                 "mcount(r; 0)"
                 ]);
             Assert.Equal(0, result);
@@ -1005,7 +1005,7 @@
                 WellConditionedMatrix,
                 "c = inverse(a)",
                 "c_hp = inverse(hp(a))",
-                "r = abs(c - c_hp) ≤ 10^-8*abs(c)",
+                TestCalc.CompareWithTolerance("c", "c_hp", "10^-8"),
                 "mcount(r; 0)"
             ]);
             Assert.Equal(0, result);

--- a/Calcpad.Tests/Matrices/HP/Large/HPLowerTriangularMatrixComparisonInFunction.cs
+++ b/Calcpad.Tests/Matrices/HP/Large/HPLowerTriangularMatrixComparisonInFunction.cs
@@ -54,7 +54,7 @@
         private static string[] PositiveDefiniteTestHelper(string func, string tol) =>
             PositiveDefiniteArray.Concat([
             $"f(a) = {func}(a)",
-            $"r = abs(f(a) - f(hp(a))) ≤ {tol}*abs(f(a))",
+            TestCalc.CompareWithTolerance("f(a)", "f(hp(a))", tol),
             "mcount(r; 0)"
         ]).ToArray();
 
@@ -62,7 +62,7 @@
             PositiveDefiniteArray.Concat([
             "b = random(fill(vector(n); 1))",
             $"f(a; b) = {func}(a; b)",
-            $"r = abs(f(a; b) - f(hp(a); hp(b))) ≤ {tol}*abs(f(a; b))",
+            TestCalc.CompareWithTolerance("f(a; b)", "f(hp(a); hp(b))", tol),
             "count(r; 0; 1)"
          ]).ToArray();
 
@@ -70,7 +70,7 @@
             PositiveDefiniteArray.Concat([
             "b = random(mfill(matrix(n; 2); 1))",
             $"f(a; b) = {func}(a; b)",
-            $"r = abs(f(a; b) - f(hp(a); hp(b))) ≤ {tol}*abs(f(a; b))",
+            TestCalc.CompareWithTolerance("f(a; b)", "f(hp(a); hp(b))", tol),
             "mcount(r; 0)"
          ]).ToArray();
 

--- a/Calcpad.Tests/Matrices/HP/Large/HPMatrixComparison.cs
+++ b/Calcpad.Tests/Matrices/HP/Large/HPMatrixComparison.cs
@@ -64,7 +64,7 @@
             PositiveDefiniteArray.Concat([
             $"c = {func}(a)",
             $"c_hp = {func}(hp(a))",
-            $"r = abs(c - c_hp) ≤ {tol}*abs(c)",
+            TestCalc.CompareWithTolerance("c", "c_hp", tol),
             "mcount(r; 0)"
         ]).ToArray();
 
@@ -73,7 +73,7 @@
             "b = random(fill(vector(n); 1))",
             $"c = {func}(a; b)",
             $"c_hp = {func}(hp(a); hp(b))",
-            $"r = abs(c - c_hp) ≤ {tol}*abs(c)",
+            TestCalc.CompareWithTolerance("c", "c_hp", tol),
             "count(r; 0; 1)"
         ]).ToArray();
 
@@ -82,7 +82,7 @@
             "b = random(mfill(matrix(n; 2); 1))",
             $"c = {func}(a; b)",
             $"c_hp = {func}(hp(a); hp(b))",
-            $"r = abs(c - c_hp) ≤ {tol}*abs(c)",
+            TestCalc.CompareWithTolerance("c", "c_hp", tol),
             "mcount(r; 0)"
         ]).ToArray();
 
@@ -1105,7 +1105,7 @@
                 WellConditionedMatrix,
                 "c = adj(a)",
                 "c_hp = adj(hp(a))",
-                "r = abs(c - c_hp) ≤ 10^-8*abs(c)",
+                TestCalc.CompareWithTolerance("c", "c_hp", "10^-8"),
                 "mcount(r; 0)"
             ]);
             Assert.Equal(0, result);
@@ -1121,7 +1121,7 @@
                 WellConditionedMatrix,
                 "c = cofactor(a)",
                 "c_hp = cofactor(hp(a))",
-                "r = abs(c - c_hp) ≤ 10^-8*abs(c)",
+                TestCalc.CompareWithTolerance("c", "c_hp", "10^-8"),
                 "mcount(r; 0)"
                 ]);
             Assert.Equal(0, result);
@@ -1178,7 +1178,7 @@
                 WellConditionedMatrix,
                 "c = inverse(a)",
                 "c_hp = inverse(hp(a))",
-                "r = abs(c - c_hp) ≤ 10^-8*abs(c)",
+                TestCalc.CompareWithTolerance("c", "c_hp", "10^-8"),
                 "mcount(r; 0)"
             ]);
             Assert.Equal(0, result);

--- a/Calcpad.Tests/Matrices/HP/Large/HPMatrixComparisonInFunction.cs
+++ b/Calcpad.Tests/Matrices/HP/Large/HPMatrixComparisonInFunction.cs
@@ -61,7 +61,7 @@
         private static string[] PositiveDefiniteTestHelper(string func, string tol) =>
             PositiveDefiniteArray.Concat([
             $"f(a) = {func}(a)",
-            $"r = abs(f(a) - f(hp(a))) ≤ {tol}*abs(f(hp(a)))",
+            TestCalc.CompareWithTolerance("f(a)", "f(hp(a))", tol),
             "mcount(r; 0)"
         ]).ToArray();
 
@@ -69,7 +69,7 @@
             PositiveDefiniteArray.Concat([
             "b = random(fill(vector(n); 1))",
             $"f(a; b) = {func}(a; b)",
-            $"r = abs(f(a; b) - f(hp(a); hp(b))) ≤ {tol}*abs(f(a; b))",
+            TestCalc.CompareWithTolerance("f(a; b)", "f(hp(a); hp(b))", tol),
             "count(r; 0; 1)"
         ]).ToArray();
 
@@ -78,7 +78,7 @@
             "b = random(mfill(matrix(n; 2); 1))",
             $"f(a; b) = {func}(a; b)",
             $"c_hp = {func}(hp(a); hp(b))",
-            $"r = abs(f(a; b) - f(hp(a); hp(b))) ≤ {tol}*abs(f(a; b))",
+            TestCalc.CompareWithTolerance("f(a; b)", "f(hp(a); hp(b))", tol),
             "mcount(r; 0)"
         ]).ToArray();
 
@@ -1103,7 +1103,7 @@
                 WellConditionedMatrix,
                 "c = adj(a)",
                 "c_hp = adj(hp(a))",
-                "r = abs(c - c_hp) ≤ 10^-8*abs(c)",
+                TestCalc.CompareWithTolerance("c", "c_hp", "10^-8"),
                 "mcount(r; 0)"
             ]);
             Assert.Equal(0, result);
@@ -1119,7 +1119,7 @@
                 WellConditionedMatrix,
                 "c = cofactor(a)",
                 "c_hp = cofactor(hp(a))",
-                "r = abs(c - c_hp) ≤ 10^-8*abs(c)",
+                TestCalc.CompareWithTolerance("c", "c_hp", "10^-8"),
                 "mcount(r; 0)"
                 ]);
             Assert.Equal(0, result);
@@ -1176,7 +1176,7 @@
                 WellConditionedMatrix,
                 "c = inverse(a)",
                 "c_hp = inverse(hp(a))",
-                "r = abs(c - c_hp) ≤ 10^-8*abs(c)",
+                TestCalc.CompareWithTolerance("c", "c_hp", "10^-8"),
                 "mcount(r; 0)"
             ]);
             Assert.Equal(0, result);

--- a/Calcpad.Tests/Matrices/HP/Large/HPSymmetricMatrixComparison.cs
+++ b/Calcpad.Tests/Matrices/HP/Large/HPSymmetricMatrixComparison.cs
@@ -62,7 +62,7 @@ namespace Calcpad.Tests
             PositiveDefiniteArray.Concat([
             $"c = {func}(a)",
             $"c_hp = {func}(hp(a))",
-            $"r = abs(c - c_hp) ≤ {tol}*abs(c)",
+            TestCalc.CompareWithTolerance("c", "c_hp", tol),
             "mcount(r; 0)"
         ]).ToArray();
 
@@ -71,7 +71,7 @@ namespace Calcpad.Tests
             "b = random(fill(vector(n); 1))",
             $"c = {func}(a; b)",
             $"c_hp = {func}(hp(a); hp(b))",
-            $"r = abs(c - c_hp) ≤ {tol}*abs(c)",
+            TestCalc.CompareWithTolerance("c", "c_hp", tol),
             "count(r; 0; 1)"
         ]).ToArray();
 
@@ -80,7 +80,7 @@ namespace Calcpad.Tests
             "b = random(mfill(matrix(n; 2); 1))",
             $"c = {func}(a; b)",
             $"c_hp = {func}(hp(a); hp(b))",
-            $"r = abs(c - c_hp) ≤ {tol}*abs(c)",
+            TestCalc.CompareWithTolerance("c", "c_hp", tol),
             "mcount(r; 0)"
         ]).ToArray();
 
@@ -942,7 +942,7 @@ namespace Calcpad.Tests
                 WellConditionedMatrix,
                 "c = adj(a)",
                 "c_hp = adj(hp(a))",
-                "r = abs(c - c_hp) ≤ 10^-8*abs(c)",
+                TestCalc.CompareWithTolerance("c", "c_hp", "10^-8"),
                 "mcount(r; 0)"
             ]);
             Assert.Equal(0, result);
@@ -959,7 +959,7 @@ namespace Calcpad.Tests
                 WellConditionedMatrix,
                 "c = cofactor(a)",
                 "c_hp = cofactor(hp(a))",
-                "r = abs(c - c_hp) ≤ 10^-8*abs(c)",
+                TestCalc.CompareWithTolerance("c", "c_hp", "10^-8"),
                 "mcount(r; 0)"
                 ]);
             Assert.Equal(0, result);
@@ -975,7 +975,7 @@ namespace Calcpad.Tests
                 RandomMatrixA,
                 "c = eigenvals(a)",
                 "c_hp = eigenvals(hp(a))",
-                "r = abs(c - c_hp) ≤ 10^-10*abs(c)",
+                TestCalc.CompareWithTolerance("c", "c_hp", "10^-10"),
                 "count(r; 0; 1)"
             ]);
             Assert.Equal(0, result);
@@ -1074,7 +1074,7 @@ namespace Calcpad.Tests
                 WellConditionedMatrix,
                 "c = inverse(a)",
                 "c_hp = inverse(hp(a))",
-                "r = abs(c - c_hp) ≤ 10^-8*abs(c)",
+                TestCalc.CompareWithTolerance("c", "c_hp", "10^-8"),
                 "mcount(r; 0)"
             ]);
             Assert.Equal(0, result);

--- a/Calcpad.Tests/Matrices/HP/Large/HPSymmetricMatrixComparisonInFunction.cs
+++ b/Calcpad.Tests/Matrices/HP/Large/HPSymmetricMatrixComparisonInFunction.cs
@@ -59,7 +59,7 @@ namespace Calcpad.Tests
         private static string[] PositiveDefiniteTestHelper(string func, string tol) =>
             PositiveDefiniteArray.Concat([
             $"f(a) = {func}(a)",
-            $"r = abs(f(a) - f(hp(a))) ≤ {tol}*abs(f(a))",
+            TestCalc.CompareWithTolerance("f(a)", "f(hp(a))", tol),
             "mcount(r; 0)"
         ]).ToArray();
 
@@ -68,7 +68,7 @@ namespace Calcpad.Tests
             "b = random(fill(vector(n); 1))",
             $"f(a; b) = {func}(a; b)",
             $"c_hp = {func}(hp(a); hp(b))",
-            $"r = abs(f(a; b) - f(hp(a); hp(b))) ≤ {tol}*abs(f(a; b))",
+            TestCalc.CompareWithTolerance("f(a; b)", "f(hp(a); hp(b))", tol),
             "count(r; 0; 1)"
         ]).ToArray();
 
@@ -76,7 +76,7 @@ namespace Calcpad.Tests
             PositiveDefiniteArray.Concat([
             "b = random(mfill(matrix(n; 2); 1))",
             $"f(a; b) = {func}(a; b)",
-            $"r = abs(f(a; b) - f(hp(a); hp(b))) ≤ {tol}*abs(f(a; b))",
+            TestCalc.CompareWithTolerance("f(a; b)", "f(hp(a); hp(b))", tol),
             "mcount(r; 0)"
         ]).ToArray();
 

--- a/Calcpad.Tests/Matrices/HP/Large/HPUpperTriangularMatrixComparison.cs
+++ b/Calcpad.Tests/Matrices/HP/Large/HPUpperTriangularMatrixComparison.cs
@@ -61,7 +61,7 @@
             PositiveDefiniteArray.Concat([
             $"c = {func}(a)",
             $"c_hp = {func}(hp(a))",
-            $"r = abs(c - c_hp) ≤ {tol}*abs(c)",
+            TestCalc.CompareWithTolerance("c", "c_hp", tol),
             "mcount(r; 0)"
         ]).ToArray();
 
@@ -70,7 +70,7 @@
             "b = random(fill(vector(n); 1))",
             $"c = {func}(a; b)",
             $"c_hp = {func}(hp(a); hp(b))",
-            $"r = abs(c - c_hp) ≤ {tol}*abs(c)",
+            TestCalc.CompareWithTolerance("c", "c_hp", tol),
             "count(r; 0; 1)"
          ]).ToArray();
 
@@ -79,7 +79,7 @@
             "b = random(mfill(matrix(n; 2); 1))",
             $"c = {func}(a; b)",
             $"c_hp = {func}(hp(a); hp(b))",
-            $"r = abs(c - c_hp) ≤ {tol}*abs(c)",
+            TestCalc.CompareWithTolerance("c", "c_hp", tol),
             "mcount(r; 0)"
          ]).ToArray();
 
@@ -936,7 +936,7 @@
                 WellConditionedMatrix,
                 "c = adj(a)",
                 "c_hp = adj(hp(a))",
-                "r = abs(c - c_hp) ≤ 10^-8*abs(c)",
+                TestCalc.CompareWithTolerance("c", "c_hp", "10^-8"),
                 "mcount(r; 0)"
             ]);
             Assert.Equal(0, result);
@@ -952,7 +952,7 @@
                 WellConditionedMatrix,
                 "c = cofactor(a)",
                 "c_hp = cofactor(hp(a))",
-                "r = abs(c - c_hp) ≤ 10^-8*abs(c)",
+                TestCalc.CompareWithTolerance("c", "c_hp", "10^-8"),
                 "mcount(r; 0)"
                 ]);
             Assert.Equal(0, result);
@@ -1009,7 +1009,7 @@
                 WellConditionedMatrix,
                 "c = inverse(a)",
                 "c_hp = inverse(hp(a))",
-                "r = abs(c - c_hp) ≤ 10^-8*abs(c)",
+                TestCalc.CompareWithTolerance("c", "c_hp", "10^-8"),
                 "mcount(r; 0)"
             ]);
             Assert.Equal(0, result);

--- a/Calcpad.Tests/Matrices/HP/Large/HPUpperTriangularMatrixComparisonInFunction.cs
+++ b/Calcpad.Tests/Matrices/HP/Large/HPUpperTriangularMatrixComparisonInFunction.cs
@@ -56,7 +56,7 @@
         private static string[] PositiveDefiniteTestHelper(string func, string tol) =>
             PositiveDefiniteArray.Concat([
             $"f(a) = {func}(a)",
-            $"r = abs(f(a) - f(hp(a))) ≤ {tol}*abs(f(a))",
+            TestCalc.CompareWithTolerance("f(a)", "f(hp(a))", tol),
             "mcount(r; 0)"
         ]).ToArray();
 
@@ -64,7 +64,7 @@
             PositiveDefiniteArray.Concat([
             "b = random(fill(vector(n); 1))",
             $"f(a; b) = {func}(a; b)",
-            $"r = abs(f(a; b) - f(hp(a); hp(b))) ≤ {tol}*abs(f(a; b))",
+            TestCalc.CompareWithTolerance("f(a; b)", "f(hp(a); hp(b))", tol),
             "count(r; 0; 1)"
          ]).ToArray();
 
@@ -72,7 +72,7 @@
             PositiveDefiniteArray.Concat([
             "b = random(mfill(matrix(n; 2); 1))",
             $"f(a; b) = {func}(a; b)",
-            $"r = abs(f(a; b) - f(hp(a); hp(b))) ≤ {tol}*abs(f(a; b))",
+            TestCalc.CompareWithTolerance("f(a; b)", "f(hp(a); hp(b))", tol),
             "mcount(r; 0)"
          ]).ToArray();
 

--- a/Calcpad.Tests/TestCalc.cs
+++ b/Calcpad.Tests/TestCalc.cs
@@ -4,6 +4,17 @@ namespace Calcpad.Tests
 {
     internal class TestCalc(MathSettings settings)
     {
+        // Prints Calcpad code for comparing two expressions.
+        //
+        // If the first argument is smaller than 1, the absolute tolerance is used.
+        // Otherwise, the relative tolerance is used.
+        //
+        // The combination of relative and absolute tolerance cover the case of near zero values:
+        // Lets say a=10^-6 and tolerance=10^-12.
+        // If compared only relatively, the right "≤" operand in the implementation would be 10^-6 * 10^-12 = 10^-18, which is beyond double precision.
+        internal static string CompareWithTolerance(string a, string b, string tolerance) =>
+            $"r = abs({a} - {b}) ≤ {tolerance}*max(abs({a}); 1)";
+
         private readonly MathParser _parser = new(settings);
 
         public double Run(string expression)

--- a/Calcpad.Tests/TestCalcTests.cs
+++ b/Calcpad.Tests/TestCalcTests.cs
@@ -1,0 +1,56 @@
+namespace Calcpad.Tests;
+
+public class TestCalcTests
+{
+    [Fact]
+    public void CompareWithTolerance_UsesAbsoluteTolerance_NearZero()
+    {
+        var calc = new TestCalc(new());
+        var result = calc.Run([
+            "c = 10^-8",
+            "c_hp = c + 5*10^-13",
+            TestCalc.CompareWithTolerance("c", "c_hp", "10^-12")
+        ]);
+
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public void CompareWithTolerance_UsesRelativeTolerance_ForLargerValues()
+    {
+        var calc = new TestCalc(new());
+        var result = calc.Run([
+            "c = 10^6",
+            "c_hp = c + 5*10^-7",
+            TestCalc.CompareWithTolerance("c", "c_hp", "10^-12")
+        ]);
+
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public void CompareWithTolerance_Fails_WhenAbsoluteToleranceIsExceeded_NearZero()
+    {
+        var calc = new TestCalc(new());
+        var result = calc.Run([
+            "c = 10^-8",
+            "c_hp = c + 2*10^-12",
+            TestCalc.CompareWithTolerance("c", "c_hp", "10^-12")
+        ]);
+
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public void CompareWithTolerance_Fails_WhenRelativeToleranceIsExceeded_ForLargerValues()
+    {
+        var calc = new TestCalc(new());
+        var result = calc.Run([
+            "c = 10^6",
+            "c_hp = c + 2*10^-6",
+            TestCalc.CompareWithTolerance("c", "c_hp", "10^-12")
+        ]);
+
+        Assert.Equal(0, result);
+    }
+}


### PR DESCRIPTION
Fixes #38

Problem was that floating point numbers were compared with a *relative* tolerance. This is good for medium and large numbers, because the tolerance also increases, but near zero, this approach fails. Here is an example:

This is the bad code:
`r = abs({a} - {b}) ≤ {tolerance}*abs({a}`

Lets say a=10^-6 and tolerance=10^-12.
Then, the right operand equates to 10^-6 * 10^-12 = 10^-18, which is beyond the calculation precision.

This does happen only sometimes, because the input test values are generated randomly. If there is a single near-zero value generated, a test fails.

This is the fix I applied:
If the first argument is smaller than 1, the absolute tolerance is used.
Otherwise, the relative tolerance is used.

This is the failure rate I measured. There were more flaky tests.

- HPMatrixComparison
  - HPMatrixMsolve 8%
- HPMatrixComparisonInFunction
  - HPMatrixInverse 2%
  - HPMatrixMsolve 2%
- HPSymmetricMatrixComparison
  - HPSymmetricMatrixMsolve 7%