### PR TITLE
Fix more unstable tests

### DIFF
--- a/Calcpad.Tests/Matrices/HP/Large/HPColumnMatrixComparison.cs
+++ b/Calcpad.Tests/Matrices/HP/Large/HPColumnMatrixComparison.cs
@@ -34,7 +34,7 @@
             RandomMatrixA,
             $"c = {func}(a)",
             $"c_hp = {func}(hp(a))",
-            "r = abs(c - c_hp) ≤ 10^-14*abs(c)"
+            TestCalc.CompareWithTolerance("c", "c_hp", "10^-14")
         ];
 
         private static string[] InterpolationTestHelper(string func) => [
@@ -43,7 +43,7 @@
             RandomMatrixA,
             $"c = {func}(i; 1; a)",
             $"c_hp = {func}(i; 1; hp(a))",
-            "r = abs(c - c_hp) ≤ 10^-14*abs(c)"
+            TestCalc.CompareWithTolerance("c", "c_hp", "10^-14")
 ];
 
         [Fact]
@@ -937,7 +937,7 @@
                 RandomMatrixA,
                 "c = mnorm_i(a)",
                 "c_hp = mnorm_i(hp(a))",
-                "r = abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithTolerance("c", "c_hp", "10^-12")
             ]);
             Assert.Equal(1, result);
         }

--- a/Calcpad.Tests/Matrices/HP/Large/HPColumnMatrixComparison.cs
+++ b/Calcpad.Tests/Matrices/HP/Large/HPColumnMatrixComparison.cs
@@ -881,7 +881,7 @@
                 RandomMatrixB,
                 "c = fprod(a; b)",
                 "c_hp = fprod(hp(a); hp(b))",
-                "abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithToleranceDirect("c", "c_hp", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -922,7 +922,7 @@
                 RandomMatrixA,
                 "c = mnorm_2(a)",
                 "c_hp = mnorm_2(hp(a))",
-                "abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithToleranceDirect("c", "c_hp", "10^-12")
             ]);
             Assert.Equal(1, result);
         }

--- a/Calcpad.Tests/Matrices/HP/Large/HPColumnMatrixComparisonInFunction.cs
+++ b/Calcpad.Tests/Matrices/HP/Large/HPColumnMatrixComparisonInFunction.cs
@@ -883,7 +883,7 @@
                 RandomMatrixA,
                 RandomMatrixB,
                 "f(a; b) = fprod(a; b)",
-                "abs(f(a; b) - f(hp(a); hp(b)) ≤ 10^-12*abs(f(a; b)))"
+                TestCalc.CompareWithToleranceDirect("f(a; b)", "f(hp(a); hp(b))", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -922,7 +922,7 @@
                 "n = 200",
                 RandomMatrixA,
                 "f(a) = mnorm_2(a)",
-                "abs(f(a) - f(hp(a))) ≤ 10^-12*abs(f(a))"
+                TestCalc.CompareWithToleranceDirect("f(a)", "f(hp(a))", "10^-12")
             ]);
             Assert.Equal(1, result);
         }

--- a/Calcpad.Tests/Matrices/HP/Large/HPColumnMatrixComparisonInFunction.cs
+++ b/Calcpad.Tests/Matrices/HP/Large/HPColumnMatrixComparisonInFunction.cs
@@ -34,7 +34,7 @@
             RandomMatrixA,
             $"f(a) = {func}(a)",
             $"c_hp = {func}(hp(a))",
-            "r = abs(f(a) - f(hp(a))) ≤ 10^-14*abs(f(a))"
+            TestCalc.CompareWithTolerance("f(a)", "f(hp(a))", "10^-14")
         ];
 
         private static string[] InterpolationTestHelper(string func) => [
@@ -43,7 +43,7 @@
             "j = 1",
             RandomMatrixA,
             $"f(i; j; a) = {func}(i; 1; a)",
-            "r = abs(f(i; j; a) - f(i; j; hp(a))) ≤ 10^-14*abs(f(i; j; a))"
+            TestCalc.CompareWithTolerance("f(i; j; a)", "f(i; j; hp(a))", "10^-14")
 ];
 
         [Fact]
@@ -77,7 +77,7 @@
                 $"f(a; b) = a * b",
                 "a_hp = hp(a)",
                 "b_hp = hp(b)",
-                "r = abs(f(a; b) - f(a_hp; b_hp)) ≤ 10^-14*abs(f(a; b))",
+                TestCalc.CompareWithTolerance("f(a; b)", "f(a_hp; b_hp)", "10^-14"),
                 "mcount(r; 0)"
             ]);
             Assert.Equal(0, result);
@@ -936,7 +936,7 @@
                 "n = 500",
                 RandomMatrixA,
                 "f(a) = mnorm_i(a)",
-                "r = abs(f(a) - f(hp(a))) ≤ 10^-12*abs(f(a))"
+                TestCalc.CompareWithTolerance("f(a)", "f(hp(a))", "10^-12")
             ]);
             Assert.Equal(1, result);
         }

--- a/Calcpad.Tests/Matrices/HP/Large/HPDiagonalMatrixComparison.cs
+++ b/Calcpad.Tests/Matrices/HP/Large/HPDiagonalMatrixComparison.cs
@@ -744,7 +744,7 @@
                 RandomMatrixB,
                 "c = fprod(a; b)",
                 "c_hp = fprod(hp(a); hp(b))",
-                "abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithToleranceDirect("c", "c_hp", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -785,7 +785,7 @@
                 RandomMatrixA,
                 "c = mnorm_2(a)",
                 "c_hp = mnorm_2(hp(a))",
-                "abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithToleranceDirect("c", "c_hp", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -815,7 +815,7 @@
                 WellConditionedMatrix,
                 "c = cond_1(a)",
                 "c_hp = cond_1(hp(a))",
-                "abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithToleranceDirect("c", "c_hp", "10^-12")
                 ]);
             Assert.Equal(1, result);
         }
@@ -830,7 +830,7 @@
                 WellConditionedMatrix,
                 "c = cond_2(a)",
                 "c_hp = cond_2(hp(a))",
-                "abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithToleranceDirect("c", "c_hp", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -845,7 +845,7 @@
                 WellConditionedMatrix,
                 "c = cond_e(a)",
                 "c_hp = cond_e(hp(a))",
-                "abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithToleranceDirect("c", "c_hp", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -860,7 +860,7 @@
                 WellConditionedMatrix,
                 "c = cond_i(a)",
                 "c_hp = cond_i(hp(a))",
-                "abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithToleranceDirect("c", "c_hp", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -875,7 +875,7 @@
                 RandomMatrixA,
                 "c = det(a)",
                 "c_hp = det(hp(a))",
-                "abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithToleranceDirect("c", "c_hp", "10^-12")
             ]);
             Assert.Equal(1, result);
         }

--- a/Calcpad.Tests/Matrices/HP/Large/HPDiagonalMatrixComparison.cs
+++ b/Calcpad.Tests/Matrices/HP/Large/HPDiagonalMatrixComparison.cs
@@ -34,7 +34,7 @@
             RandomMatrixA,
             $"c = {func}(a)",
             $"c_hp = {func}(hp(a))",
-            "r = abs(c - c_hp) ≤ 10^-14*abs(c)"
+            TestCalc.CompareWithTolerance("c", "c_hp", "10^-14")
         ];
 
         private static string[] InterpolationTestHelper(string func) => [
@@ -45,7 +45,7 @@
             RandomMatrixA,
             $"c = {func}(i; j; a)",
             $"c_hp = {func}(i; j; hp(a))",
-            "r = abs(c - c_hp) ≤ 10^-14*abs(c)"
+            TestCalc.CompareWithTolerance("c", "c_hp", "10^-14")
 ];
 
         private static string[] PositiveDefiniteTestHelper(string func, string tol) => [
@@ -800,7 +800,7 @@
                 RandomMatrixA,
                 "c = mnorm_i(a)",
                 "c_hp = mnorm_i(hp(a))",
-                "r = abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithTolerance("c", "c_hp", "10^-12")
             ]);
             Assert.Equal(1, result);
         }

--- a/Calcpad.Tests/Matrices/HP/Large/HPDiagonalMatrixComparisonInFunction.cs
+++ b/Calcpad.Tests/Matrices/HP/Large/HPDiagonalMatrixComparisonInFunction.cs
@@ -32,7 +32,7 @@
             RandomMatrixA,
             $"f(a) = {func}(a)",
             $"c_hp = {func}(hp(a))",
-            "r = abs(f(a) - f(hp(a))) ≤ 10^-14*abs(f(a))"
+            TestCalc.CompareWithTolerance("f(a)", "f(hp(a))", "10^-14")
         ];
 
         private static string[] InterpolationTestHelper(string func) => [
@@ -42,7 +42,7 @@
             "j = random(n - 1) + 1",
             RandomMatrixA,
             $"f(i; j; a) = {func}(i; j; a)",
-            "r = abs(f(i; j; a) - f(i; j; hp(a))) ≤ 10^-14*abs(f(i; j; a))"
+            TestCalc.CompareWithTolerance("f(i; j; a)", "f(i; j; hp(a))", "10^-14")
 ];
 
         private static string[] PositiveDefiniteTestHelper(string func, string tol) => [
@@ -449,7 +449,7 @@
                 RandomMatrixB,
                 "f(a; b) = a * b",
                 "c_hp = matmul(hp(a); hp(b))",
-                "r = abs(f(a; b) - c_hp) ≤ 10^-14*abs(f(a; b))",
+                TestCalc.CompareWithTolerance("f(a; b)", "c_hp", "10^-14"),
                 "mcount(r; 0)"
             ]);
             Assert.Equal(0, result);
@@ -949,7 +949,7 @@
                 RandomMatrixA,
                 "f(a) = mnorm_i(a)",
                 "c_hp = mnorm_i(hp(a))",
-                "r = abs(f(a) - f(hp(a))) ≤ 10^-12*abs(f(a))"
+                TestCalc.CompareWithTolerance("f(a)", "f(hp(a))", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -1070,7 +1070,7 @@
                 "n = 250",
                 WellConditionedMatrix,
                 "f(a) = adj(a)",
-                "r = abs(f(a) - f(hp(a))) ≤ 10^-8*abs(f(a))",
+                TestCalc.CompareWithTolerance("f(a)", "f(hp(a))", "10^-8"),
                 "mcount(r; 0)"
             ]);
             Assert.Equal(0, result);
@@ -1085,7 +1085,7 @@
                 "n = 250",
                 WellConditionedMatrix,
                 "f(a) = cofactor(a)",
-                "r = abs(f(a) - f(hp(a))) ≤ 10^-8*abs(f(a))",
+                TestCalc.CompareWithTolerance("f(a)", "f(hp(a))", "10^-8"),
                 "mcount(r; 0)"
                 ]);
             Assert.Equal(0, result);
@@ -1100,7 +1100,7 @@
                 "n = 250",
                 WellConditionedMatrix,
                 "f(a) = eigenvals(a)",
-                "r = abs(f(a) - f(hp(a))) ≤ 10^-12*abs(f(a))",
+                TestCalc.CompareWithTolerance("f(a)", "f(hp(a))", "10^-12"),
                 "count(r; 0; 1)"
             ]);
             Assert.Equal(0, result);
@@ -1193,7 +1193,7 @@
                 "n = 250",
                 WellConditionedMatrix,
                 "f(a) = inverse(a)",
-                "r = abs(f(a) - f(hp(a))) ≤ 10^-8*abs(f(a))",
+                TestCalc.CompareWithTolerance("f(a)", "f(hp(a))", "10^-8"),
                 "mcount(r; 0)"
             ]);
             Assert.Equal(0, result);

--- a/Calcpad.Tests/Matrices/HP/Large/HPDiagonalMatrixComparisonInFunction.cs
+++ b/Calcpad.Tests/Matrices/HP/Large/HPDiagonalMatrixComparisonInFunction.cs
@@ -894,7 +894,7 @@
                 RandomMatrixA,
                 RandomMatrixB,
                 "f(a; b) = fprod(a; b)",
-                "abs(f(a; b) - f(hp(a); hp(b))) ≤ 10^-12*abs(f(a; b))"
+                TestCalc.CompareWithToleranceDirect("f(a; b)", "f(hp(a); hp(b))", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -934,7 +934,7 @@
                 RandomMatrixA,
                 "f(a) = mnorm_2(a)",
                 "c_hp = mnorm_2(hp(a))",
-                "abs(f(a) - f(hp(a))) ≤ 10^-12*abs(f(a))"
+                TestCalc.CompareWithToleranceDirect("f(a)", "f(hp(a))", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -963,7 +963,7 @@
                 "n = 250",
                 WellConditionedMatrix,
                 "f(a) = cond_1(a)",
-                "abs(f(a) - f(hp(a))) ≤ 10^-12*abs(f(a))"
+                TestCalc.CompareWithToleranceDirect("f(a)", "f(hp(a))", "10^-12")
                 ]);
             Assert.Equal(1, result);
         }
@@ -977,7 +977,7 @@
                 "n = 200",
                 WellConditionedMatrix,
                 "f(a) = cond_2(a)",
-                "abs(f(a) - f(hp(a))) ≤ 10^-12*abs(f(a))"
+                TestCalc.CompareWithToleranceDirect("f(a)", "f(hp(a))", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -991,7 +991,7 @@
                 "n = 250",
                 WellConditionedMatrix,
                 "f(a) = cond_e(a)",
-                "abs(f(a) - f(hp(a))) ≤ 10^-12*abs(f(a))"
+                TestCalc.CompareWithToleranceDirect("f(a)", "f(hp(a))", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -1005,7 +1005,7 @@
                 "n = 250",
                 WellConditionedMatrix,
                 "f(a) = cond_i(a)",
-                "abs(f(a) - f(hp(a))) ≤ 10^-12*abs(f(a))"
+                TestCalc.CompareWithToleranceDirect("f(a)", "f(hp(a))", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -1019,7 +1019,7 @@
                 "n = 250",
                 RandomMatrixA,
                 "f(a) = det(a)",
-                "abs(f(a) - f(hp(a))) ≤ 10^-12*abs(f(a))"
+                TestCalc.CompareWithToleranceDirect("f(a)", "f(hp(a))", "10^-12")
             ]);
             Assert.Equal(1, result);
         }

--- a/Calcpad.Tests/Matrices/HP/Large/HPLowerTriangularMatrixComparison.cs
+++ b/Calcpad.Tests/Matrices/HP/Large/HPLowerTriangularMatrixComparison.cs
@@ -747,7 +747,7 @@
                 RandomMatrixB,
                 "c = fprod(a; b)",
                 "c_hp = fprod(hp(a); hp(b))",
-                "abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithToleranceDirect("c", "c_hp", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -788,7 +788,7 @@
                 RandomMatrixA,
                 "c = mnorm_2(a)",
                 "c_hp = mnorm_2(hp(a))",
-                "abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithToleranceDirect("c", "c_hp", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -818,7 +818,7 @@
                 WellConditionedMatrix,
                 "c = cond_1(a)",
                 "c_hp = cond_1(hp(a))",
-                "abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithToleranceDirect("c", "c_hp", "10^-12")
                 ]);
             Assert.Equal(1, result);
         }
@@ -833,7 +833,7 @@
                 WellConditionedMatrix,
                 "c = cond_2(a)",
                 "c_hp = cond_2(hp(a))",
-                "abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithToleranceDirect("c", "c_hp", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -848,7 +848,7 @@
                 WellConditionedMatrix,
                 "c = cond_e(a)",
                 "c_hp = cond_e(hp(a))",
-                "abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithToleranceDirect("c", "c_hp", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -863,7 +863,7 @@
                 WellConditionedMatrix,
                 "c = cond_i(a)",
                 "c_hp = cond_i(hp(a))",
-                "abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithToleranceDirect("c", "c_hp", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -878,7 +878,7 @@
                 WellConditionedMatrix,
                 "c = det(a)",
                 "c_hp = det(hp(a))",
-                "abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithToleranceDirect("c", "c_hp", "10^-12")
             ]);
             Assert.Equal(1, result);
         }

--- a/Calcpad.Tests/Matrices/HP/Large/HPLowerTriangularMatrixComparison.cs
+++ b/Calcpad.Tests/Matrices/HP/Large/HPLowerTriangularMatrixComparison.cs
@@ -34,7 +34,7 @@
             RandomMatrixA,
             $"c = {func}(a)",
             $"c_hp = {func}(hp(a))",
-            "r = abs(c - c_hp) ≤ 10^-14*abs(c)"
+            TestCalc.CompareWithTolerance("c", "c_hp", "10^-14")
         ];
 
         private static string[] InterpolationTestHelper(string func) => [
@@ -44,7 +44,7 @@
             RandomMatrixA,
             $"c = {func}(i; j; a)",
             $"c_hp = {func}(i; j; hp(a))",
-            "r = abs(c - c_hp) ≤ 10^-14*abs(c)"
+            TestCalc.CompareWithTolerance("c", "c_hp", "10^-14")
         ];
 
         private static readonly string[] PositiveDefiniteArray = [
@@ -803,7 +803,7 @@
                 RandomMatrixA,
                 "c = mnorm_i(a)",
                 "c_hp = mnorm_i(hp(a))",
-                "r = abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithTolerance("c", "c_hp", "10^-12")
             ]);
             Assert.Equal(1, result);
         }

--- a/Calcpad.Tests/Matrices/HP/Large/HPLowerTriangularMatrixComparisonInFunction.cs
+++ b/Calcpad.Tests/Matrices/HP/Large/HPLowerTriangularMatrixComparisonInFunction.cs
@@ -32,7 +32,7 @@
             "n = 500",
             RandomMatrixA,
             $"f(a) = {func}(a)",
-            "r = abs(f(a) - f(hp(a))) ≤ 10^-14*abs(f(a))"
+            TestCalc.CompareWithTolerance("f(a)", "f(hp(a))", "10^-14")
         ];
 
         private static string[] InterpolationTestHelper(string func) => [
@@ -41,7 +41,7 @@
             "j = random(n - 1) + 1",
             RandomMatrixA,
             $"f(i; j; a) = {func}(i; j; a)",
-            "r = abs(f(i; j; a) - f(i; j; hp(a))) ≤ 10^-14*abs(f(i; j; a))"
+            TestCalc.CompareWithTolerance("f(i; j; a)", "f(i; j; hp(a))", "10^-14")
         ];
 
         private static readonly string[] PositiveDefiniteArray = [
@@ -949,7 +949,7 @@
                 "n = 500",
                 RandomMatrixA,
                 "f(a) = mnorm_i(a)",
-                "r = abs(f(a) - f(hp(a))) ≤ 10^-12*abs(f(a))"
+                TestCalc.CompareWithTolerance("f(a)", "f(hp(a))", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -1070,7 +1070,7 @@
                 "n = 250",
                 WellConditionedMatrix,
                 "f(a) = adj(a)",
-                "r = abs(f(a) - f(hp(a))) ≤ 10^-8*abs(f(a))",
+                TestCalc.CompareWithTolerance("f(a)", "f(hp(a))", "10^-8"),
                 "mcount(r; 0)"
             ]);
             Assert.Equal(0, result);
@@ -1085,7 +1085,7 @@
                 "n = 250",
                 WellConditionedMatrix,
                 "f(a) = cofactor(a)",
-                "r = abs(f(a) - f(hp(a))) ≤ 10^-8*abs(f(a))",
+                TestCalc.CompareWithTolerance("f(a)", "f(hp(a))", "10^-8"),
                 "mcount(r; 0)"
                 ]);
             Assert.Equal(0, result);
@@ -1141,7 +1141,7 @@
                 "n = 250",
                 WellConditionedMatrix,
                 "f(a) = inverse(a)",
-                "r = abs(f(a) - f(hp(a))) ≤ 10^-8*abs(f(a))",
+                TestCalc.CompareWithTolerance("f(a)", "f(hp(a))", "10^-8"),
                 "mcount(r; 0)"
             ]);
             Assert.Equal(0, result);

--- a/Calcpad.Tests/Matrices/HP/Large/HPLowerTriangularMatrixComparisonInFunction.cs
+++ b/Calcpad.Tests/Matrices/HP/Large/HPLowerTriangularMatrixComparisonInFunction.cs
@@ -896,7 +896,7 @@
                 RandomMatrixA,
                 RandomMatrixB,
                 "f(a; b) = fprod(a; b)",
-                "abs(f(a; b) - f(hp(a); hp(b))) ≤ 10^-12*abs(f(a; b))"
+                TestCalc.CompareWithToleranceDirect("f(a; b)", "f(hp(a); hp(b))", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -935,7 +935,7 @@
                 "n = 200",
                 RandomMatrixA,
                 "f(a) = mnorm_2(a)",
-                "abs(f(a) - f(hp(a))) ≤ 10^-12*abs(f(a))"
+                TestCalc.CompareWithToleranceDirect("f(a)", "f(hp(a))", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -963,7 +963,7 @@
                 "n = 250",
                 WellConditionedMatrix,
                 "f(a) = cond_1(a)",
-                "abs(f(a) - f(hp(a))) ≤ 10^-12*abs(f(a))"
+                TestCalc.CompareWithToleranceDirect("f(a)", "f(hp(a))", "10^-12")
                 ]);
             Assert.Equal(1, result);
         }
@@ -977,7 +977,7 @@
                 "n = 200",
                 WellConditionedMatrix,
                 "f(a)  = cond_2(a)",
-                "abs(f(a)  - f(hp(a))) ≤ 10^-12*abs(f(a))"
+                TestCalc.CompareWithToleranceDirect("f(a) ", "f(hp(a))", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -991,7 +991,7 @@
                 "n = 250",
                 WellConditionedMatrix,
                 "f(a) = cond_e(a)",
-                "abs(f(a) - f(hp(a))) ≤ 10^-12*abs(f(a))"
+                TestCalc.CompareWithToleranceDirect("f(a)", "f(hp(a))", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -1005,7 +1005,7 @@
                 "n = 250",
                 WellConditionedMatrix,
                 "f(a) = cond_i(a)",
-                "abs(f(a) - f(hp(a))) ≤ 10^-12*abs(f(a))"
+                TestCalc.CompareWithToleranceDirect("f(a)", "f(hp(a))", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -1019,7 +1019,7 @@
                 "n = 250",
                 WellConditionedMatrix,
                 "f(a) = det(a)",
-                "abs(f(a) - f(hp(a))) ≤ 10^-12*abs(f(a))"
+                TestCalc.CompareWithToleranceDirect("f(a)", "f(hp(a))", "10^-12")
             ]);
             Assert.Equal(1, result);
         }

--- a/Calcpad.Tests/Matrices/HP/Large/HPMatrixComparison.cs
+++ b/Calcpad.Tests/Matrices/HP/Large/HPMatrixComparison.cs
@@ -1051,7 +1051,7 @@
                 RandomSquareMatrix,
                 "c = det(a)",
                 "c_hp = det(hp(a))",
-                TestCalc.CompareWithToleranceDirect("c", "c_hp", "10^-12")
+                TestCalc.CompareWithToleranceDirect("c", "c_hp", "10^-8")
             ]);
             Assert.Equal(1, result);
         }

--- a/Calcpad.Tests/Matrices/HP/Large/HPMatrixComparison.cs
+++ b/Calcpad.Tests/Matrices/HP/Large/HPMatrixComparison.cs
@@ -38,7 +38,7 @@
             RandomMatrixA,
             $"c = {func}(a)",
             $"c_hp = {func}(hp(a))",
-            "r = abs(c - c_hp) ≤ 10^-14*abs(c)"
+            TestCalc.CompareWithTolerance("c", "c_hp", "10^-14")
         ];
 
         private static string[] InterpolationTestHelper(string func) => [
@@ -49,7 +49,7 @@
             RandomMatrixA,
             $"c = {func}(i; j; a)",
             $"c_hp = {func}(i; j; hp(a))",
-            "r = abs(c - c_hp) ≤ 10^-14*abs(c)"
+            TestCalc.CompareWithTolerance("c", "c_hp", "10^-14")
         ];
 
         private static readonly string[] PositiveDefiniteArray = [
@@ -976,7 +976,7 @@
                 RandomMatrixA,
                 "c = mnorm_i(a)",
                 "c_hp = mnorm_i(hp(a))",
-                "r = abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithTolerance("c", "c_hp", "10^-12")
             ]);
             Assert.Equal(1, result);
         }

--- a/Calcpad.Tests/Matrices/HP/Large/HPMatrixComparison.cs
+++ b/Calcpad.Tests/Matrices/HP/Large/HPMatrixComparison.cs
@@ -917,7 +917,7 @@
                 RandomMatrixB,
                 "c = fprod(a; b)",
                 "c_hp = fprod(hp(a); hp(b))",
-                "abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithToleranceDirect("c", "c_hp", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -960,7 +960,7 @@
                 RandomMatrixA,
                 "c = mnorm_2(a)",
                 "c_hp = mnorm_2(hp(a))",
-                "abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithToleranceDirect("c", "c_hp", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -991,7 +991,7 @@
                 WellConditionedMatrix,
                 "c = cond_1(a)",
                 "c_hp = cond_1(hp(a))",
-                "abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithToleranceDirect("c", "c_hp", "10^-12")
                 ]);
             Assert.Equal(1, result);
         }
@@ -1006,7 +1006,7 @@
                 WellConditionedMatrix,
                 "c = cond_2(a)",
                 "c_hp = cond_2(hp(a))",
-                "abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithToleranceDirect("c", "c_hp", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -1021,7 +1021,7 @@
                 WellConditionedMatrix,
                 "c = cond_e(a)",
                 "c_hp = cond_e(hp(a))",
-                "abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithToleranceDirect("c", "c_hp", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -1036,7 +1036,7 @@
                 WellConditionedMatrix,
                 "c = cond_i(a)",
                 "c_hp = cond_i(hp(a))",
-                "abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithToleranceDirect("c", "c_hp", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -1051,7 +1051,7 @@
                 RandomSquareMatrix,
                 "c = det(a)",
                 "c_hp = det(hp(a))",
-                "abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithToleranceDirect("c", "c_hp", "10^-12")
             ]);
             Assert.Equal(1, result);
         }

--- a/Calcpad.Tests/Matrices/HP/Large/HPMatrixComparisonInFunction.cs
+++ b/Calcpad.Tests/Matrices/HP/Large/HPMatrixComparisonInFunction.cs
@@ -1049,7 +1049,7 @@
                 RandomSquareMatrix,
                 "c = det(a)",
                 "c_hp = det(hp(a))",
-                TestCalc.CompareWithToleranceDirect("c", "c_hp", "10^-12")
+                TestCalc.CompareWithToleranceDirect("c", "c_hp", "10^-8")
             ]);
             Assert.Equal(1, result);
         }

--- a/Calcpad.Tests/Matrices/HP/Large/HPMatrixComparisonInFunction.cs
+++ b/Calcpad.Tests/Matrices/HP/Large/HPMatrixComparisonInFunction.cs
@@ -37,7 +37,7 @@
             "n = 500",
             RandomMatrixA,
             $"f(a) = {func}(a)",
-            "r = abs(f(a) - f(hp(a))) ≤ 10^-14*abs(f(a))"
+            TestCalc.CompareWithTolerance("f(a)", "f(hp(a))", "10^-14")
         ];
 
         private static string[] InterpolationTestHelper(string func) => [
@@ -47,7 +47,7 @@
             "j = random(n - 1) + 1",
             RandomMatrixA,
             $"f(i; j; a) = {func}(i; j; a)",
-            "r = abs(f(i; j; a) - f(i; j; hp(a))) ≤ 10^-14*abs(f(i; j; a))"
+            TestCalc.CompareWithTolerance("f(i; j; a)", "f(i; j; hp(a))", "10^-14")
         ];
 
         private static readonly string[] PositiveDefiniteArray = [
@@ -974,7 +974,7 @@
                 RandomMatrixA,
                 "c = mnorm_i(a)",
                 "c_hp = mnorm_i(hp(a))",
-                "r = abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithTolerance("c", "c_hp", "10^-12")
             ]);
             Assert.Equal(1, result);
         }

--- a/Calcpad.Tests/Matrices/HP/Large/HPMatrixComparisonInFunction.cs
+++ b/Calcpad.Tests/Matrices/HP/Large/HPMatrixComparisonInFunction.cs
@@ -915,7 +915,7 @@
                 RandomMatrixB,
                 "c = fprod(a; b)",
                 "c_hp = fprod(hp(a); hp(b))",
-                "abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithToleranceDirect("c", "c_hp", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -958,7 +958,7 @@
                 RandomMatrixA,
                 "c = mnorm_2(a)",
                 "c_hp = mnorm_2(hp(a))",
-                "abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithToleranceDirect("c", "c_hp", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -989,7 +989,7 @@
                 WellConditionedMatrix,
                 "c = cond_1(a)",
                 "c_hp = cond_1(hp(a))",
-                "abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithToleranceDirect("c", "c_hp", "10^-12")
                 ]);
             Assert.Equal(1, result);
         }
@@ -1004,7 +1004,7 @@
                 WellConditionedMatrix,
                 "c = cond_2(a)",
                 "c_hp = cond_2(hp(a))",
-                "abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithToleranceDirect("c", "c_hp", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -1019,7 +1019,7 @@
                 WellConditionedMatrix,
                 "c = cond_e(a)",
                 "c_hp = cond_e(hp(a))",
-                "abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithToleranceDirect("c", "c_hp", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -1034,7 +1034,7 @@
                 WellConditionedMatrix,
                 "c = cond_i(a)",
                 "c_hp = cond_i(hp(a))",
-                "abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithToleranceDirect("c", "c_hp", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -1049,7 +1049,7 @@
                 RandomSquareMatrix,
                 "c = det(a)",
                 "c_hp = det(hp(a))",
-                "abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithToleranceDirect("c", "c_hp", "10^-12")
             ]);
             Assert.Equal(1, result);
         }

--- a/Calcpad.Tests/Matrices/HP/Large/HPSymmetricMatrixComparison.cs
+++ b/Calcpad.Tests/Matrices/HP/Large/HPSymmetricMatrixComparison.cs
@@ -38,7 +38,7 @@ namespace Calcpad.Tests
             RandomMatrixA,
             $"c = {func}(a)",
             $"c_hp = {func}(hp(a))",
-            "r = abs(c - c_hp) ≤ 10^-14*abs(c)"
+            TestCalc.CompareWithTolerance("c", "c_hp", "10^-14")
         ];
 
         private static string[] InterpolationTestHelper(string func) => [
@@ -48,7 +48,7 @@ namespace Calcpad.Tests
             RandomMatrixA,
             $"c = {func}(i; j; a)",
             $"c_hp = {func}(i; j; hp(a))",
-            "r = abs(c - c_hp) ≤ 10^-14*abs(c)"
+            TestCalc.CompareWithTolerance("c", "c_hp", "10^-14")
         ];
 
         private static readonly string[] PositiveDefiniteArray = [
@@ -807,7 +807,7 @@ namespace Calcpad.Tests
                 RandomMatrixA,
                 "c = mnorm_i(a)",
                 "c_hp = mnorm_i(hp(a))",
-                "r = abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithTolerance("c", "c_hp", "10^-12")
             ]);
             Assert.Equal(1, result);
         }

--- a/Calcpad.Tests/Matrices/HP/Large/HPSymmetricMatrixComparison.cs
+++ b/Calcpad.Tests/Matrices/HP/Large/HPSymmetricMatrixComparison.cs
@@ -751,7 +751,7 @@ namespace Calcpad.Tests
                 RandomMatrixB,
                 "c = fprod(a; b)",
                 "c_hp = fprod(hp(a); hp(b))",
-                "abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithToleranceDirect("c", "c_hp", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -792,7 +792,7 @@ namespace Calcpad.Tests
                 RandomMatrixA,
                 "c = mnorm_2(a)",
                 "c_hp = mnorm_2(hp(a))",
-                "abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithToleranceDirect("c", "c_hp", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -823,7 +823,7 @@ namespace Calcpad.Tests
                 WellConditionedMatrix,
                 "c = cond_1(a)",
                 "c_hp = cond_1(hp(a))",
-                "abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithToleranceDirect("c", "c_hp", "10^-12")
                 ]);
             Assert.Equal(1, result);
         }
@@ -839,7 +839,7 @@ namespace Calcpad.Tests
                 WellConditionedMatrix,
                 "c = cond_2(a)",
                 "c_hp = cond_2(hp(a))",
-                "abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithToleranceDirect("c", "c_hp", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -855,7 +855,7 @@ namespace Calcpad.Tests
                 WellConditionedMatrix,
                 "c = cond_e(a)",
                 "c_hp = cond_e(hp(a))",
-                "abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithToleranceDirect("c", "c_hp", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -871,7 +871,7 @@ namespace Calcpad.Tests
                 WellConditionedMatrix,
                 "c = cond_i(a)",
                 "c_hp = cond_i(hp(a))",
-                "abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithToleranceDirect("c", "c_hp", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -887,7 +887,7 @@ namespace Calcpad.Tests
                 WellConditionedMatrix,
                 "c = det(a)",
                 "c_hp = det(hp(a))",
-                "abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithToleranceDirect("c", "c_hp", "10^-12")
             ]);
             Assert.Equal(1, result);
         }

--- a/Calcpad.Tests/Matrices/HP/Large/HPSymmetricMatrixComparisonInFunction.cs
+++ b/Calcpad.Tests/Matrices/HP/Large/HPSymmetricMatrixComparisonInFunction.cs
@@ -456,7 +456,7 @@ namespace Calcpad.Tests
                 RandomMatrixB,
                 "f(a; b) = a * b",
                 "c_hp = matmul(hp(a); hp(b))",
-                TestCalc.CompareWithTolerance("f(a; b)", "c_hp", "10^-14"),
+                TestCalc.CompareWithTolerance("f(a; b)", "c_hp", "10^-13"),
                 "mcount(r; 0)"
             ]);
             Assert.Equal(0, result);

--- a/Calcpad.Tests/Matrices/HP/Large/HPSymmetricMatrixComparisonInFunction.cs
+++ b/Calcpad.Tests/Matrices/HP/Large/HPSymmetricMatrixComparisonInFunction.cs
@@ -901,7 +901,7 @@ namespace Calcpad.Tests
                 RandomMatrixA,
                 RandomMatrixB,
                 "f(a; b) = fprod(a; b)",
-                "abs(f(a; b) - f(hp(a); hp(b))) ≤ 10^-12*abs(f(a; b))"
+                TestCalc.CompareWithToleranceDirect("f(a; b)", "f(hp(a); hp(b))", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -940,7 +940,7 @@ namespace Calcpad.Tests
                 "n = 200",
                 RandomMatrixA,
                 "f(a) = mnorm_2(a)",
-                "abs(f(a) - f(hp(a))) ≤ 10^-12*abs(f(a))"
+                TestCalc.CompareWithToleranceDirect("f(a)", "f(hp(a))", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -969,7 +969,7 @@ namespace Calcpad.Tests
                 OrthogonalMatrix,
                 WellConditionedMatrix,
                 "f(a) = cond_1(a)",
-                "abs(f(a) - f(hp(a))) ≤ 10^-12*abs(f(a))"
+                TestCalc.CompareWithToleranceDirect("f(a)", "f(hp(a))", "10^-12")
                 ]);
             Assert.Equal(1, result);
         }
@@ -984,7 +984,7 @@ namespace Calcpad.Tests
                 OrthogonalMatrix,
                 WellConditionedMatrix,
                 "f(a) = cond_2(a)",
-                "abs(f(a) - f(hp(a))) ≤ 10^-12*abs(f(a))"
+                TestCalc.CompareWithToleranceDirect("f(a)", "f(hp(a))", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -999,7 +999,7 @@ namespace Calcpad.Tests
                 OrthogonalMatrix,
                 WellConditionedMatrix,
                 "f(a) = cond_e(a)",
-                "abs(f(a) - f(hp(a))) ≤ 10^-12*abs(f(a))"
+                TestCalc.CompareWithToleranceDirect("f(a)", "f(hp(a))", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -1014,7 +1014,7 @@ namespace Calcpad.Tests
                 OrthogonalMatrix,
                 WellConditionedMatrix,
                 "f(a) = cond_i(a)",
-                "abs(f(a) - f(hp(a))) ≤ 10^-12*abs(f(a))"
+                TestCalc.CompareWithToleranceDirect("f(a)", "f(hp(a))", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -1029,7 +1029,7 @@ namespace Calcpad.Tests
                 OrthogonalMatrix,
                 WellConditionedMatrix,
                 "f(a) = det(a)",
-                "abs(f(a) - f(hp(a))) ≤ 10^-12*abs(f(a))"
+                TestCalc.CompareWithToleranceDirect("f(a)", "f(hp(a))", "10^-12")
             ]);
             Assert.Equal(1, result);
         }

--- a/Calcpad.Tests/Matrices/HP/Large/HPSymmetricMatrixComparisonInFunction.cs
+++ b/Calcpad.Tests/Matrices/HP/Large/HPSymmetricMatrixComparisonInFunction.cs
@@ -37,7 +37,7 @@ namespace Calcpad.Tests
             "n = 500",
             RandomMatrixA,
             $"f(a) = {func}(a)",
-            "r = abs(f(a) - f(hp(a))) ≤ 10^-14*abs(f(a))"
+            TestCalc.CompareWithTolerance("f(a)", "f(hp(a))", "10^-14")
         ];
 
         private static string[] InterpolationTestHelper(string func) => [
@@ -46,7 +46,7 @@ namespace Calcpad.Tests
             "j = random(n - 1) + 1",
             RandomMatrixA,
             $"f(i; j; a) = {func}(i; j; a)",
-            "r = abs(f(i; j; a) - f(i; j; hp(a))) ≤ 10^-14*abs(f(i; j; a))"
+            TestCalc.CompareWithTolerance("f(i; j; a)", "f(i; j; hp(a))", "10^-14")
         ];
 
         private static readonly string[] PositiveDefiniteArray = [
@@ -456,7 +456,7 @@ namespace Calcpad.Tests
                 RandomMatrixB,
                 "f(a; b) = a * b",
                 "c_hp = matmul(hp(a); hp(b))",
-                "r = abs(f(a; b) - c_hp) ≤ 10^-14*abs(f(a; b))",
+                TestCalc.CompareWithTolerance("f(a; b)", "c_hp", "10^-14"),
                 "mcount(r; 0)"
             ]);
             Assert.Equal(0, result);
@@ -954,7 +954,7 @@ namespace Calcpad.Tests
                 "n = 500",
                 RandomMatrixA,
                 "f(a) = mnorm_i(a)",
-                "r = abs(f(a) - f(hp(a))) ≤ 10^-12*abs(f(a))"
+                TestCalc.CompareWithTolerance("f(a)", "f(hp(a))", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -1082,7 +1082,7 @@ namespace Calcpad.Tests
                 WellConditionedMatrix,
                 "f(a) = adj(a)",
                 "c_hp = adj(hp(a))",
-                "r = abs(f(a) - f(hp(a))) ≤ 10^-8*abs(f(a))",
+                TestCalc.CompareWithTolerance("f(a)", "f(hp(a))", "10^-8"),
                 "mcount(r; 0)"
             ]);
             Assert.Equal(0, result);
@@ -1098,7 +1098,7 @@ namespace Calcpad.Tests
                 OrthogonalMatrix,
                 WellConditionedMatrix,
                 "f(a) = cofactor(a)",
-                "r = abs(f(a) - f(hp(a))) ≤ 10^-8*abs(f(a))",
+                TestCalc.CompareWithTolerance("f(a)", "f(hp(a))", "10^-8"),
                 "mcount(r; 0)"
                 ]);
             Assert.Equal(0, result);
@@ -1113,7 +1113,7 @@ namespace Calcpad.Tests
                 "n = 250",
                 RandomMatrixA,
                 "f(a) = eigenvals(a)",
-                "r = abs(f(a) - f(hp(a))) ≤ 10^-10*abs(f(a))",
+                TestCalc.CompareWithTolerance("f(a)", "f(hp(a))", "10^-10"),
                 "count(r; 0; 1)"
             ]);
             Assert.Equal(0, result);
@@ -1209,7 +1209,7 @@ namespace Calcpad.Tests
                 OrthogonalMatrix,
                 WellConditionedMatrix,
                 "f(a) = inverse(a)",
-                "r = abs(f(a) - f(hp(a))) ≤ 10^-8*abs(f(a))",
+                TestCalc.CompareWithTolerance("f(a)", "f(hp(a))", "10^-8"),
                 "mcount(r; 0)"
             ]);
             Assert.Equal(0, result);

--- a/Calcpad.Tests/Matrices/HP/Large/HPUpperTriangularMatrixComparison.cs
+++ b/Calcpad.Tests/Matrices/HP/Large/HPUpperTriangularMatrixComparison.cs
@@ -750,7 +750,7 @@
                 RandomMatrixB,
                 "c = fprod(a; b)",
                 "c_hp = fprod(hp(a); hp(b))",
-                "abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithToleranceDirect("c", "c_hp", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -791,7 +791,7 @@
                 RandomMatrixA,
                 "c = mnorm_2(a)",
                 "c_hp = mnorm_2(hp(a))",
-                "abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithToleranceDirect("c", "c_hp", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -821,7 +821,7 @@
                 WellConditionedMatrix,
                 "c = cond_1(a)",
                 "c_hp = cond_1(hp(a))",
-                "abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithToleranceDirect("c", "c_hp", "10^-12")
                 ]);
             Assert.Equal(1, result);
         }
@@ -836,7 +836,7 @@
                 WellConditionedMatrix,
                 "c = cond_2(a)",
                 "c_hp = cond_2(hp(a))",
-                "abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithToleranceDirect("c", "c_hp", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -851,7 +851,7 @@
                 WellConditionedMatrix,
                 "c = cond_e(a)",
                 "c_hp = cond_e(hp(a))",
-                "abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithToleranceDirect("c", "c_hp", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -866,7 +866,7 @@
                 WellConditionedMatrix,
                 "c = cond_i(a)",
                 "c_hp = cond_i(hp(a))",
-                "abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithToleranceDirect("c", "c_hp", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -881,7 +881,7 @@
                 WellConditionedMatrix,
                 "c = det(a)",
                 "c_hp = det(hp(a))",
-                "abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithToleranceDirect("c", "c_hp", "10^-12")
             ]);
             Assert.Equal(1, result);
         }

--- a/Calcpad.Tests/Matrices/HP/Large/HPUpperTriangularMatrixComparison.cs
+++ b/Calcpad.Tests/Matrices/HP/Large/HPUpperTriangularMatrixComparison.cs
@@ -36,7 +36,7 @@
             RandomMatrixA,
             $"c = {func}(a)",
             $"c_hp = {func}(hp(a))",
-            "r = abs(c - c_hp) ≤ 10^-14*abs(c)"
+            TestCalc.CompareWithTolerance("c", "c_hp", "10^-14")
         ];
 
         private static string[] InterpolationTestHelper(string func) => [
@@ -47,7 +47,7 @@
             RandomMatrixA,
             $"c = {func}(i; j; a)",
             $"c_hp = {func}(i; j; hp(a))",
-            "r = abs(c - c_hp) ≤ 10^-14*abs(c)"
+            TestCalc.CompareWithTolerance("c", "c_hp", "10^-14")
 ];
 
         private static readonly string[] PositiveDefiniteArray = [
@@ -806,7 +806,7 @@
                 RandomMatrixA,
                 "c = mnorm_i(a)",
                 "c_hp = mnorm_i(hp(a))",
-                "r = abs(c - c_hp) ≤ 10^-12*abs(c)"
+                TestCalc.CompareWithTolerance("c", "c_hp", "10^-12")
             ]);
             Assert.Equal(1, result);
         }

--- a/Calcpad.Tests/Matrices/HP/Large/HPUpperTriangularMatrixComparison.cs
+++ b/Calcpad.Tests/Matrices/HP/Large/HPUpperTriangularMatrixComparison.cs
@@ -106,7 +106,7 @@
         public void HPUpperTriangularMatrixMultiplication()
         {
             var calc = new TestCalc(new());
-            var result = calc.Run(OperatorTestHelper('*', "10^-12"));
+            var result = calc.Run(OperatorTestHelper('*', "10^-11"));
             Assert.Equal(0, result);
         }
 

--- a/Calcpad.Tests/Matrices/HP/Large/HPUpperTriangularMatrixComparisonInFunction.cs
+++ b/Calcpad.Tests/Matrices/HP/Large/HPUpperTriangularMatrixComparisonInFunction.cs
@@ -901,7 +901,7 @@
                 RandomMatrixA,
                 RandomMatrixB,
                 "f(a; b) = fprod(a; b)",
-                "abs(f(a; b) - f(hp(a); hp(b))) ≤ 10^-12*abs(f(a; b))"
+                TestCalc.CompareWithToleranceDirect("f(a; b)", "f(hp(a); hp(b))", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -940,7 +940,7 @@
                 "n = 200",
                 RandomMatrixA,
                 "f(a) = mnorm_2(a)",
-                "abs(f(a) - f(hp(a))) ≤ 10^-12*abs(f(a))"
+                TestCalc.CompareWithToleranceDirect("f(a)", "f(hp(a))", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -969,7 +969,7 @@
                 WellConditionedMatrix,
                 "f(a) = cond_1(a)",
                 "c_hp = cond_1(hp(a))",
-                "abs(f(a) - f(hp(a))) ≤ 10^-12*abs(f(a))"
+                TestCalc.CompareWithToleranceDirect("f(a)", "f(hp(a))", "10^-12")
                 ]);
             Assert.Equal(1, result);
         }
@@ -983,7 +983,7 @@
                 "n = 200",
                 WellConditionedMatrix,
                 "f(a) = cond_2(a)",
-                "abs(f(a) - f(hp(a))) ≤ 10^-12*abs(f(a))"
+                TestCalc.CompareWithToleranceDirect("f(a)", "f(hp(a))", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -997,7 +997,7 @@
                 "n = 250",
                 WellConditionedMatrix,
                 "f(a) = cond_e(a)",
-                "abs(f(a) - f(hp(a))) ≤ 10^-12*abs(f(a))"
+                TestCalc.CompareWithToleranceDirect("f(a)", "f(hp(a))", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -1011,7 +1011,7 @@
                 "n = 250",
                 WellConditionedMatrix,
                 "f(a) = cond_i(a)",
-                "abs(f(a) - f(hp(a))) ≤ 10^-12*abs(f(a))"
+                TestCalc.CompareWithToleranceDirect("f(a)", "f(hp(a))", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -1025,7 +1025,7 @@
                 "n = 250",
                 WellConditionedMatrix,
                 "f(a) = det(a)",
-                "abs(f(a) - f(hp(a))) ≤ 10^-12*abs(f(a))"
+                TestCalc.CompareWithToleranceDirect("f(a)", "f(hp(a))", "10^-12")
             ]);
             Assert.Equal(1, result);
         }

--- a/Calcpad.Tests/Matrices/HP/Large/HPUpperTriangularMatrixComparisonInFunction.cs
+++ b/Calcpad.Tests/Matrices/HP/Large/HPUpperTriangularMatrixComparisonInFunction.cs
@@ -99,7 +99,7 @@
         public void HPUpperTriangularMatrixMultiplication()
         {
             var calc = new TestCalc(new());
-            var result = calc.Run(OperatorTestHelper('*', "10^-12"));
+            var result = calc.Run(OperatorTestHelper('*', "10^-11"));
             Assert.Equal(0, result);
         }
 

--- a/Calcpad.Tests/Matrices/HP/Large/HPUpperTriangularMatrixComparisonInFunction.cs
+++ b/Calcpad.Tests/Matrices/HP/Large/HPUpperTriangularMatrixComparisonInFunction.cs
@@ -33,7 +33,7 @@
             "n = 500",
             RandomMatrixA,
             $"f(a) = {func}(a)",
-            "r = abs(f(a) - f(hp(a))) ≤ 10^-14*abs(f(a))"
+            TestCalc.CompareWithTolerance("f(a)", "f(hp(a))", "10^-14")
         ];
 
         private static string[] InterpolationTestHelper(string func) => [
@@ -43,7 +43,7 @@
             "j = random(n - 1) + 1",
             RandomMatrixA,
             $"f(i; j; a) = {func}(i; j; a)",
-            "r = abs(f(i; j; a) - f(i; j; hp(a))) ≤ 10^-14*abs(f(i; j; a))"
+            TestCalc.CompareWithTolerance("f(i; j; a)", "f(i; j; hp(a))", "10^-14")
 ];
 
         private static readonly string[] PositiveDefiniteArray = [
@@ -954,7 +954,7 @@
                 "n = 500",
                 RandomMatrixA,
                 "f(a) = mnorm_i(a)",
-                "r = abs(f(a) - f(hp(a))) ≤ 10^-12*abs(f(a))"
+                TestCalc.CompareWithTolerance("f(a)", "f(hp(a))", "10^-12")
             ]);
             Assert.Equal(1, result);
         }
@@ -1077,7 +1077,7 @@
                 "n = 250",
                 WellConditionedMatrix,
                 "f(a) = adj(a)",
-                "r = abs(f(a) - f(hp(a))) ≤ 10^-8*abs(f(a))",
+                TestCalc.CompareWithTolerance("f(a)", "f(hp(a))", "10^-8"),
                 "mcount(r; 0)"
             ]);
             Assert.Equal(0, result);
@@ -1092,7 +1092,7 @@
                 "n = 250",
                 WellConditionedMatrix,
                 "f(a) = cofactor(a)",
-                "r = abs(f(a) - f(hp(a))) ≤ 10^-8*abs(f(a))",
+                TestCalc.CompareWithTolerance("f(a)", "f(hp(a))", "10^-8"),
                 "mcount(r; 0)"
                 ]);
             Assert.Equal(0, result);
@@ -1146,7 +1146,7 @@
                 "n = 250",
                 WellConditionedMatrix,
                 "f(a) = inverse(a)",
-                "r = abs(f(a) - f(hp(a))) ≤ 10^-8*abs(f(a))",
+                TestCalc.CompareWithTolerance("f(a)", "f(hp(a))", "10^-8"),
                 "mcount(r; 0)"
             ]);
             Assert.Equal(0, result);

--- a/Calcpad.Tests/TestCalc.cs
+++ b/Calcpad.Tests/TestCalc.cs
@@ -15,6 +15,9 @@ namespace Calcpad.Tests
         internal static string CompareWithTolerance(string a, string b, string tolerance) =>
             $"r = abs({a} - {b}) ≤ {tolerance}*max(abs({a}); 1)";
 
+        internal static string CompareWithToleranceDirect(string a, string b, string tolerance) =>
+            $"abs({a} - {b}) ≤ {tolerance}*max(abs({a}); 1)";
+
         private readonly MathParser _parser = new(settings);
 
         public double Run(string expression)

--- a/Calcpad.Tests/Vectors/HP/HPVectorComparisonLarge.cs
+++ b/Calcpad.Tests/Vectors/HP/HPVectorComparisonLarge.cs
@@ -30,7 +30,7 @@
             "a = random(fill(vector(n); 1))",
             $"c = {f}(a)",
             $"c_hp = {f}(hp(a))",
-            "r = abs(c - c_hp) ≤ 10^-14*abs(c)"
+            TestCalc.CompareWithTolerance("c", "c_hp", "10^-14")
         ];
 
 


### PR DESCRIPTION
This applies the combination of absolute and relative comparison to further tests like introduced in #41.

For some test, the required tolerance was too narrow. I ran those over and over again while making the tolerance wider, until they passed reliably. I ran each test 1000 times.