### PR TITLE
Disable format on save, but trim trailling spaces and multiple new lines at the file end

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,10 @@
 {
-    "[csharp]": {
-        "editor.formatOnSave": false,
-        "files.trimTrailingWhitespace": false
-    },
-    "[xml]": {
-        "files.trimFinalNewlines": false
-    },
+    "editor.formatOnSave": false,
+    "files.trimTrailingWhitespace": true,
+    "files.trimFinalNewlines": true,
+    "files.insertFinalNewline": true,
     "[markdown]": {
-        "editor.formatOnSave": false
+        // Two trailing spaces in Markdown signal a line break in the rendered output.
+        "files.trimTrailingWhitespace": false,
     }
 }


### PR DESCRIPTION
There's quite a huge amount of random trailling spaces in all files in the repo. The default setting in VSCode is to trim those, which is reasonable, but prone to merge conflicts, it makes it hard to read PR diffs, and it is quite annoying as @javila already figured out (and me too).

This VSCode config trims those when saving. Also, it removes any excessive new lines at the file end, and it adds exactly one newline at the end of each file.

If and when you agree with this, all files should be trimmed in one go to solve any future merge conflicts.