### PR TITLE
WPF: display the working filename in the window titlebar first

### DIFF
--- a/Calcpad.Wpf/MainWindow.xaml.cs
+++ b/Calcpad.Wpf/MainWindow.xaml.cs
@@ -115,7 +115,7 @@ namespace Calcpad.Wpf
                         _cfn = Path.Combine(DocumentPath, value);
                     else
                         SetCurrentDirectory(path);
-                    Title = AppInfo.Title + " - " + Path.GetFileName(value);
+                    Title = Path.GetFileName(value) + " -" + AppInfo.Title;
                     _tempDir = Path.GetFileNameWithoutExtension(value) + '\\';
                 }
             }


### PR DESCRIPTION
This displays the important thing first (the filename). Otherwise, the application's name and version is displayed and the filename you are currently working on is cropped. That makes it hard to switch between windows if you have multiple instances of CalcpadCE open.

`AppInfo.Title` already contains the space, therefore the `" -"`.