### PR TITLE
Handle trailing empty lines consistently

### DIFF
--- a/Calcpad.Core/ExtensionMethods.cs
+++ b/Calcpad.Core/ExtensionMethods.cs
@@ -46,8 +46,16 @@ namespace Calcpad.Core
             if (string.IsNullOrEmpty(s))
                 return new SpanLineEnumerator();
 
-            if (s.Length > 1 && s[^2] == '\r')
-                return s.AsSpan(..^2).EnumerateLines();
+            if (s[^1] == '\n')
+            {
+                if (s.Length > 1 && s[^2] == '\r')
+                    return s.AsSpan(..^2).EnumerateLines();
+
+                return s.AsSpan(..^1).EnumerateLines();
+            }
+
+            if (s[^1] == '\r')
+                return s.AsSpan(..^1).EnumerateLines();
 
             return s.AsSpan().EnumerateLines();
         }

--- a/Calcpad.Tests/ExtensionMethodsTests.cs
+++ b/Calcpad.Tests/ExtensionMethodsTests.cs
@@ -1,0 +1,41 @@
+namespace Calcpad.Tests;
+
+public class ExtensionMethodsTests
+{
+    public static TheoryData<string, string[]> EnumerateLinesCases => new()
+    {
+        { string.Empty, Array.Empty<string>() },
+        { "a", ["a"] },
+        { "a\n", ["a"] },
+        { "a\r\n", ["a"] },
+        { "a\r", ["a"] },
+        { "a\nb", ["a", "b"] },
+        { "a\rb", ["a", "b"] },
+        { "a\nb\n", ["a", "b"] },
+        { "a\r\nb\r\n", ["a", "b"] },
+        { "a\rb\r", ["a", "b"] },
+        { "a\n\nb\n", ["a", string.Empty, "b"] },
+        { "a\nb\n\n", ["a", "b", string.Empty] },
+        { "a\r\nb\r\n\r\n", ["a", "b", string.Empty] },
+        { "a\rb\r\r", ["a", "b", string.Empty] },
+        { "\n", [string.Empty] },
+        { "\r\n", [string.Empty] },
+        { "\r", [string.Empty] },
+    };
+
+    [Theory]
+    [MemberData(nameof(EnumerateLinesCases))]
+    public void EnumerateLines_TrimsSingleTerminalLineBreak_Symmetrically(string source, string[] expected)
+    {
+        Assert.Equal(expected, ToLineArray(source));
+    }
+
+    private static string[] ToLineArray(string source)
+    {
+        List<string> lines = [];
+        foreach (var line in source.EnumerateLines())
+            lines.Add(line.ToString());
+
+        return [.. lines];
+    }
+}

--- a/Calcpad.Tests/TrailingNewlineRenderTests.cs
+++ b/Calcpad.Tests/TrailingNewlineRenderTests.cs
@@ -1,0 +1,79 @@
+namespace Calcpad.Tests;
+
+public class TrailingNewlineRenderTests
+{
+    public static TheoryData<string> SingleTrailingLineBreakCases => new()
+    {
+        "5 = 5\n",
+        "5 = 5\r\n",
+        "5 = 5\r",
+    };
+
+    [Theory]
+    [MemberData(nameof(SingleTrailingLineBreakCases))]
+    public void TrailingLineBreak_DoesNotEmitBlankParagraph(string source)
+    {
+        var html = Render(source);
+
+        Assert.Equal(0, CountOccurrences(html, "<p>&nbsp;</p>"));
+        Assert.Equal(0, CountOccurrences(html, "<p></p>"));
+    }
+
+    [Fact]
+    public void MidFileBlankLine_EmitsExactlyOneBlankParagraph()
+    {
+        var html = Render("5 = 5\n\n7 = 7\n");
+
+        Assert.Equal(1, CountOccurrences(html, "<p>&nbsp;</p>"));
+        Assert.Equal(0, CountOccurrences(html, "<p></p>"));
+    }
+
+    [Fact]
+    public void AllLineEndings_ProduceEqualHtml()
+    {
+        var lf = Render("'note\n5 = 5\n");
+        var crlf = Render("'note\r\n5 = 5\r\n");
+        var cr = Render("'note\r5 = 5\r");
+
+        Assert.Equal(lf, crlf);
+        Assert.Equal(lf, cr);
+    }
+
+    [Fact]
+    public void MultipleTrailingLineBreaks_AreSymmetric()
+    {
+        var lf = Render("5 = 5\n\n\n");
+        var crlf = Render("5 = 5\r\n\r\n\r\n");
+        var cr = Render("5 = 5\r\r\r");
+
+        Assert.Equal(lf, crlf);
+        Assert.Equal(lf, cr);
+        Assert.Equal(2, CountOccurrences(lf, "<p>&nbsp;</p>"));
+        Assert.Equal(0, CountOccurrences(lf, "<p></p>"));
+    }
+
+    private static string Render(string source)
+    {
+        var macroParser = new MacroParser();
+        var hasMacroErrors = macroParser.Parse(source, out var expandedSource, null, 0, false);
+        Assert.False(hasMacroErrors);
+
+        var parser = new ExpressionParser();
+        parser.Parse(expandedSource, true, false);
+
+        return parser.HtmlResult;
+    }
+
+    private static int CountOccurrences(string text, string value)
+    {
+        var count = 0;
+        var start = 0;
+        while ((start = text.IndexOf(value, start, StringComparison.Ordinal)) >= 0)
+        {
+            ++count;
+            start += value.Length;
+        }
+
+        return count;
+    }
+}


### PR DESCRIPTION
Currently, trailing empty lines are handled differently depending on whether the file uses CRLF, CR, or LF line endings:

- CRLF: Trailing empty lines are trimmed entirely
- LF or CR: Each trailing empty line produces a `<p>&nbsp;</p>` in the output. Additionally, there is always a `<p>&nbsp;</p>` at the end of each rendered output, regardless of whether there is an empty trailing line or not.

This handles LF (Linux) and CR (macOS) line endings the same way as CRLF (Windows).