### PR TITLE
wpf: add option to insert images with relative paths

### DIFF
--- a/Calcpad.Wpf/MainWindow.xaml
+++ b/Calcpad.Wpf/MainWindow.xaml
@@ -2193,6 +2193,14 @@
                     Margin="4,0,0,0"
                     TabIndex="20"  IsChecked="True"
                     Click="EmbedCheckBox_Click" FontSize="11"/>
+            <CheckBox x:Name="UseRelativePathsCheckBox"
+                    Content="{x:Static wpf:MainWindowResources.Relative}"
+                    ToolTip="{x:Static wpf:MainWindowResources.UseRelativePathsForInsertedImages}"
+                    Height="16"
+                    VerticalAlignment="Top" HorizontalAlignment="Right"
+                    Margin="4,0,0,0"
+                    TabIndex="23" IsChecked="True"
+                    FontSize="11"/>
             <TextBlock Height="18"
                        TextWrapping="Wrap"
                        VerticalAlignment="Top"

--- a/Calcpad.Wpf/MainWindow.xaml.cs
+++ b/Calcpad.Wpf/MainWindow.xaml.cs
@@ -709,6 +709,7 @@ namespace Calcpad.Wpf
             ZeroSmallMatrixElementsCheckBox.IsChecked = settings.ZeroSmallMatrixElements;
             MaxOutputCountTextBox.Text = settings.MaxOutputCount.ToString();
             EmbedCheckBox.IsChecked = settings.Embed;
+            UseRelativePathsCheckBox.IsChecked = settings.UseRelativePaths;
             if (settings.WindowLeft > 0) Left = settings.WindowLeft;
             if (settings.WindowTop > 0) Top = settings.WindowTop;
             if (settings.WindowWidth > 0) Width = settings.WindowWidth;
@@ -793,6 +794,7 @@ namespace Calcpad.Wpf
             settings.ZeroSmallMatrixElements = ZeroSmallMatrixElementsCheckBox.IsChecked ?? false;
             settings.MaxOutputCount = int.TryParse(MaxOutputCountTextBox.Text, out int i) ? i : (int)20;
             settings.Embed = EmbedCheckBox.IsChecked ?? false;
+            settings.UseRelativePaths = UseRelativePathsCheckBox.IsChecked ?? false;
             settings.WindowLeft = Left;
             settings.WindowTop = Top;
             settings.WindowWidth = Width;
@@ -2128,17 +2130,47 @@ namespace Calcpad.Wpf
                 InsertImage(dlg.FileName);
         }
 
+        private bool _relativePathWarningShown;
+
+        private string BuildImageSrc(string filePath)
+        {
+            var hasCurrentDoc = !string.IsNullOrEmpty(CurrentFileName);
+            var useRelative = UseRelativePathsCheckBox.IsChecked ?? false;
+
+            if (useRelative && hasCurrentDoc)
+            {
+                var docDir = Path.GetDirectoryName(CurrentFileName);
+                var relative = Path.GetRelativePath(docDir, filePath).Replace('\\', '/');
+                // Path.GetRelativePath returns the original absolute path when the file is on
+                // a different volume — in that case fall through to the absolute branch below.
+                if (!Path.IsPathRooted(relative))
+                {
+                    if (!relative.StartsWith("./", StringComparison.Ordinal) &&
+                        !relative.StartsWith("../", StringComparison.Ordinal))
+                        relative = "./" + relative;
+                    return relative;
+                }
+            }
+            else if (useRelative && !_relativePathWarningShown)
+            {
+                _relativePathWarningShown = true;
+                MessageBox.Show(MainWindowResources.SaveDocumentFirstForRelativePaths,
+                    "CalcpadCE", MessageBoxButton.OK, MessageBoxImage.Information);
+            }
+            else if (hasCurrentDoc)
+            {
+                var fileDir = Path.GetDirectoryName(filePath);
+                if (string.Equals(Path.GetDirectoryName(CurrentFileName), fileDir, StringComparison.OrdinalIgnoreCase))
+                    return "./" + Path.GetFileName(filePath);
+            }
+            return filePath.Replace('\\', '/');
+        }
+
         private void InsertImage(string filePath)
         {
             var fileName = Path.GetFileName(filePath);
             var size = GetImageSize(filePath);
-            var fileDir = Path.GetDirectoryName(filePath);
-            string src;
-            if (!string.IsNullOrEmpty(CurrentFileName) &&
-                string.Equals(Path.GetDirectoryName(CurrentFileName), fileDir, StringComparison.OrdinalIgnoreCase))
-                src = "./" + fileName;
-            else
-                src = filePath.Replace('\\', '/');
+            var src = BuildImageSrc(filePath);
             var p = new Paragraph();
             p.Inlines.Add(new Run($"'<img style=\"height:{size.Height}pt; width:{size.Width}pt;\" src=\"{src}\" alt=\"{fileName}\">"));
             _highlighter.Parse(p, IsComplex, GetLineNumber(p), true);

--- a/Calcpad.Wpf/MainWindowResources.Designer.cs
+++ b/Calcpad.Wpf/MainWindowResources.Designer.cs
@@ -1016,6 +1016,33 @@ namespace Calcpad.Wpf {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Relative.
+        /// </summary>
+        public static string Relative {
+            get {
+                return ResourceManager.GetString("Relative", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Use relative paths for inserted images (resolved against the current document folder)..
+        /// </summary>
+        public static string UseRelativePathsForInsertedImages {
+            get {
+                return ResourceManager.GetString("UseRelativePathsForInsertedImages", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Save the document first to insert relative paths. An absolute path was used instead..
+        /// </summary>
+        public static string SaveDocumentFirstForRelativePaths {
+            get {
+                return ResourceManager.GetString("SaveDocumentFirstForRelativePaths", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Enables markdown in comments.
         /// </summary>
         public static string EnablesMarkdownInComments {

--- a/Calcpad.Wpf/MainWindowResources.bg.resx
+++ b/Calcpad.Wpf/MainWindowResources.bg.resx
@@ -1136,6 +1136,15 @@
   <data name="EmbedPlotsInsideTheHtmlAsBase64EncodedImagesSaveToFilesIfUnchecked" xml:space="preserve">
     <value>Вграждане на графики в HTML като base64 кодирани изображения. Запазване във файлове, ако не е отметнато.</value>
   </data>
+  <data name="Relative" xml:space="preserve">
+    <value>Относителни</value>
+  </data>
+  <data name="UseRelativePathsForInsertedImages" xml:space="preserve">
+    <value>Използвай относителни пътища за вмъкнатите изображения (спрямо папката на текущия документ).</value>
+  </data>
+  <data name="SaveDocumentFirstForRelativePaths" xml:space="preserve">
+    <value>Запазете документа, за да вмъквате относителни пътища. Вместо това беше използван абсолютен път.</value>
+  </data>
   <data name="MultilineExpressionBlock" xml:space="preserve">
     <value>Многоредов блок от изрази</value>
   </data>

--- a/Calcpad.Wpf/MainWindowResources.resx
+++ b/Calcpad.Wpf/MainWindowResources.resx
@@ -1137,6 +1137,15 @@ You can find your unsaved data in
   <data name="EmbedPlotsInsideTheHtmlAsBase64EncodedImagesSaveToFilesIfUnchecked" xml:space="preserve">
     <value>Embed plots inside the Html as base64 encoded images, Save to files if unchecked.</value>
   </data>
+  <data name="Relative" xml:space="preserve">
+    <value>Relative</value>
+  </data>
+  <data name="UseRelativePathsForInsertedImages" xml:space="preserve">
+    <value>Use relative paths for inserted images (resolved against the current document folder).</value>
+  </data>
+  <data name="SaveDocumentFirstForRelativePaths" xml:space="preserve">
+    <value>Save the document first to insert relative paths. An absolute path was used instead.</value>
+  </data>
   <data name="MultilineExpressionBlock" xml:space="preserve">
     <value>Multiline expression block</value>
   </data>

--- a/Calcpad.Wpf/MainWindowResources.zh.resx
+++ b/Calcpad.Wpf/MainWindowResources.zh.resx
@@ -1136,6 +1136,15 @@
   <data name="EmbedPlotsInsideTheHtmlAsBase64EncodedImagesSaveToFilesIfUnchecked" xml:space="preserve">
     <value>将图片作为base64编码图像嵌入Html,若未检查即保存为文件.</value>
   </data>
+  <data name="Relative" xml:space="preserve">
+    <value>相对路径</value>
+  </data>
+  <data name="UseRelativePathsForInsertedImages" xml:space="preserve">
+    <value>插入图像时使用相对路径(相对于当前文档所在文件夹解析)。</value>
+  </data>
+  <data name="SaveDocumentFirstForRelativePaths" xml:space="preserve">
+    <value>请先保存文档以便插入相对路径。本次已改用绝对路径。</value>
+  </data>
   <data name="MultilineExpressionBlock" xml:space="preserve">
     <value>多行表达式块</value>
   </data>

--- a/Calcpad.Wpf/Properties/Settings.Designer.cs
+++ b/Calcpad.Wpf/Properties/Settings.Designer.cs
@@ -309,5 +309,17 @@ namespace Calcpad.Wpf.Properties {
                 this["Embed"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool UseRelativePaths {
+            get {
+                return ((bool)(this["UseRelativePaths"]));
+            }
+            set {
+                this["UseRelativePaths"] = value;
+            }
+        }
     }
 }

--- a/Calcpad.Wpf/Properties/Settings.settings
+++ b/Calcpad.Wpf/Properties/Settings.settings
@@ -74,5 +74,8 @@
     <Setting Name="Embed" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="UseRelativePaths" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
Adds a "Relative" checkbox in the status bar (next to "Embed") that, when enabled, writes image src attributes relative to the current .cpd file using Path.GetRelativePath. Defaults to on. Falls back to an absolute path on cross-volume inserts and shows a one-shot info dialog when the document hasn't been saved yet. Paste-Image (Ctrl+V) inherits the same behavior via InsertImage.