### PR TITLE
core: add VAh/VARh apparent and reactive energy units

### DIFF
--- a/Calcpad.Core/BaseTypes/Unit.cs
+++ b/Calcpad.Core/BaseTypes/Unit.cs
@@ -652,6 +652,16 @@ namespace Calcpad.Core
                 {"nWh", J.Scale("nWh", 3.6e-6)},
                 {"pWh", J.Scale("pWh", 3.6e-9)},
 
+                {"VAh",  J.Scale("VAh",  3.6e+3)},
+                {"kVAh", J.Scale("kVAh", 3.6e+6)},
+                {"MVAh", J.Scale("MVAh", 3.6e+9)},
+                {"GVAh", J.Scale("GVAh", 3.6e+12)},
+
+                {"VARh",  J.Scale("VARh",  3.6e+3)},
+                {"kVARh", J.Scale("kVARh", 3.6e+6)},
+                {"MVARh", J.Scale("MVARh", 3.6e+9)},
+                {"GVARh", J.Scale("GVARh", 3.6e+12)},
+
                 {"erg", J.Scale("erg", 1e-7)},
                 {"eV",  J.Scale("eV",  1.6021773300241367e-19)},
                 {"keV", J.Scale("keV", 1.6021773300241367e-16)},

--- a/Calcpad.Tests/Scalars/UnitsTests.cs
+++ b/Calcpad.Tests/Scalars/UnitsTests.cs
@@ -944,6 +944,38 @@
         [Trait("Category", "Energy")]
         public void Test_TWh() => Test("TWh|J", 3.6e+15);
 
+        [Fact]
+        [Trait("Category", "Energy Apparent")]
+        public void Test_VAh() => Test("VAh|J", 3600d);
+
+        [Fact]
+        [Trait("Category", "Energy Apparent")]
+        public void Test_kVAh() => Test("kVAh|J", 3600000d);
+
+        [Fact]
+        [Trait("Category", "Energy Apparent")]
+        public void Test_MVAh() => Test("MVAh|J", 3600000000d);
+
+        [Fact]
+        [Trait("Category", "Energy Apparent")]
+        public void Test_GVAh() => Test("GVAh|J", 3600000000000d);
+
+        [Fact]
+        [Trait("Category", "Energy Reactive")]
+        public void Test_VARh() => Test("VARh|J", 3600d);
+
+        [Fact]
+        [Trait("Category", "Energy Reactive")]
+        public void Test_kVARh() => Test("kVARh|J", 3600000d);
+
+        [Fact]
+        [Trait("Category", "Energy Reactive")]
+        public void Test_MVARh() => Test("MVARh|J", 3600000000d);
+
+        [Fact]
+        [Trait("Category", "Energy Reactive")]
+        public void Test_GVARh() => Test("GVARh|J", 3600000000000d);
+
 
         [Fact]
         [Trait("Category", "Energy")]


### PR DESCRIPTION
Adds VAh, kVAh, MVAh, GVAh (apparent energy) and VARh, kVARh, MVARh, GVARh (reactive energy) to the unit registry, defined as scaled joules following the existing Wh pattern (1 VAh = 1 VARh = 3600 J). Capitalization matches the existing VAR/VA convention. Includes xUnit conversion tests for each new unit.