### PR TITLE
Feature/cpd library manager

### DIFF
--- a/Calcpad.Wpf/LibraryManager.cs
+++ b/Calcpad.Wpf/LibraryManager.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+
+namespace Calcpad.Wpf
+{
+    internal abstract class LibraryNode : INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler PropertyChanged;
+        public string Name { get; protected set; }
+        public string FullPath { get; protected set; }
+        public ObservableCollection<LibraryNode> Children { get; } = new();
+
+        private bool _isExpanded;
+        public bool IsExpanded
+        {
+            get => _isExpanded;
+            set
+            {
+                if (_isExpanded == value) return;
+                _isExpanded = value;
+                OnExpanded();
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsExpanded)));
+            }
+        }
+
+        protected virtual void OnExpanded() { }
+    }
+
+    internal sealed class LibraryFolderNode : LibraryNode
+    {
+        public bool Exists { get; private set; }
+
+        public LibraryFolderNode(string path)
+        {
+            FullPath = path;
+            Refresh();
+        }
+
+        public void Refresh()
+        {
+            Children.Clear();
+            Exists = Directory.Exists(FullPath);
+            Name = Exists ? new DirectoryInfo(FullPath).Name : Path.GetFileName(FullPath);
+            if (!Exists) return;
+
+            IEnumerable<string> files;
+            try { files = Directory.EnumerateFiles(FullPath, "*.cpd", SearchOption.AllDirectories); }
+            catch { return; }
+
+            foreach (var file in files.OrderBy(f => f, StringComparer.OrdinalIgnoreCase))
+                Children.Add(new LibraryFileNode(file));
+        }
+    }
+
+    internal sealed class LibraryFileNode : LibraryNode
+    {
+        private bool _scanned;
+
+        public LibraryFileNode(string path)
+        {
+            FullPath = path;
+            Name = Path.GetFileName(path);
+            // Add a placeholder so the TreeView shows an expansion arrow.
+            Children.Add(new LibraryPlaceholderNode());
+        }
+
+        protected override void OnExpanded()
+        {
+            if (_scanned || !IsExpanded) return;
+            _scanned = true;
+            Children.Clear();
+            foreach (var fn in LibraryScanner.ScanFile(FullPath))
+                Children.Add(new LibraryFunctionNode(FullPath, fn));
+            if (Children.Count == 0)
+                Children.Add(new LibraryPlaceholderNode(MainWindowResources.Library_NoFunctionsFound));
+        }
+
+        public void Rescan()
+        {
+            _scanned = false;
+            Children.Clear();
+            Children.Add(new LibraryPlaceholderNode());
+            if (IsExpanded) OnExpanded();
+        }
+    }
+
+    internal sealed class LibraryFunctionNode : LibraryNode
+    {
+        public LibraryFunction Function { get; }
+        public string FilePath { get; }
+
+        public LibraryFunctionNode(string filePath, LibraryFunction fn)
+        {
+            FilePath = filePath;
+            Function = fn;
+            Name = string.IsNullOrEmpty(fn.Signature) ? fn.Name : $"{fn.Name}({fn.Signature})";
+            FullPath = filePath;
+        }
+    }
+
+    internal sealed class LibraryPlaceholderNode : LibraryNode
+    {
+        public LibraryPlaceholderNode(string label = null)
+        {
+            Name = label ?? "…";
+            FullPath = string.Empty;
+        }
+    }
+
+    internal sealed class LibraryManager
+    {
+        public ObservableCollection<LibraryFolderNode> Folders { get; } = new();
+
+        public void LoadFromSettings(StringCollection persisted)
+        {
+            Folders.Clear();
+            if (persisted is null) return;
+            foreach (var path in persisted)
+                if (!string.IsNullOrWhiteSpace(path))
+                    Folders.Add(new LibraryFolderNode(path));
+        }
+
+        public StringCollection ToSettings()
+        {
+            var sc = new StringCollection();
+            foreach (var f in Folders)
+                sc.Add(f.FullPath);
+            return sc;
+        }
+
+        public bool AddFolder(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path)) return false;
+            var full = Path.GetFullPath(path);
+            if (Folders.Any(f => string.Equals(f.FullPath, full, StringComparison.OrdinalIgnoreCase)))
+                return false;
+            Folders.Add(new LibraryFolderNode(full));
+            return true;
+        }
+
+        public void RemoveFolder(LibraryFolderNode node)
+        {
+            Folders.Remove(node);
+        }
+
+        public void Refresh()
+        {
+            foreach (var f in Folders)
+                f.Refresh();
+        }
+    }
+}

--- a/Calcpad.Wpf/LibraryScanner.cs
+++ b/Calcpad.Wpf/LibraryScanner.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+
+namespace Calcpad.Wpf
+{
+    internal sealed record LibraryFunction(string Name, string Signature, int LineNumber);
+
+    internal static partial class LibraryScanner
+    {
+        // #def name$(args) = ...   or   #def name$  (multi-line block ended by #end def)
+        // Group 1: name (with trailing $ for macros)
+        // Group 2: args (optional)
+        [GeneratedRegex(@"^\s*#def\s+([A-Za-z_][A-Za-z0-9_]*\$?)\s*(?:\(([^)]*)\))?", RegexOptions.CultureInvariant)]
+        private static partial Regex MacroDefRegex();
+
+        // f(x) = expression   (single-line math function definition)
+        // Group 1: name
+        // Group 2: args
+        [GeneratedRegex(@"^\s*([A-Za-z_][A-Za-z_0-9]*)\s*\(([^)]*)\)\s*=", RegexOptions.CultureInvariant)]
+        private static partial Regex MathFuncRegex();
+
+        public static IReadOnlyList<LibraryFunction> ScanFile(string path)
+        {
+            if (string.IsNullOrEmpty(path) || !File.Exists(path))
+                return Array.Empty<LibraryFunction>();
+
+            var results = new List<LibraryFunction>();
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+
+            string[] lines;
+            try { lines = File.ReadAllLines(path); }
+            catch { return Array.Empty<LibraryFunction>(); }
+
+            for (var i = 0; i < lines.Length; i++)
+            {
+                var line = lines[i];
+                if (string.IsNullOrWhiteSpace(line) || line.TrimStart().StartsWith('\''))
+                    continue;
+
+                var m = MacroDefRegex().Match(line);
+                if (m.Success)
+                {
+                    var name = m.Groups[1].Value;
+                    var args = m.Groups[2].Success ? m.Groups[2].Value.Trim() : string.Empty;
+                    var sig = $"{name}({args})";
+                    if (seen.Add(sig))
+                        results.Add(new LibraryFunction(name, args, i + 1));
+                    continue;
+                }
+
+                m = MathFuncRegex().Match(line);
+                if (m.Success)
+                {
+                    var name = m.Groups[1].Value;
+                    var args = m.Groups[2].Value.Trim();
+                    var sig = $"{name}({args})";
+                    if (seen.Add(sig))
+                        results.Add(new LibraryFunction(name, args, i + 1));
+                }
+            }
+
+            return results;
+        }
+    }
+}

--- a/Calcpad.Wpf/MainWindow.xaml
+++ b/Calcpad.Wpf/MainWindow.xaml
@@ -2193,6 +2193,14 @@
                     Margin="4,0,0,0"
                     TabIndex="20"  IsChecked="True"
                     Click="EmbedCheckBox_Click" FontSize="11"/>
+            <CheckBox x:Name="UseRelativePathsCheckBox"
+                    Content="{x:Static wpf:MainWindowResources.Relative}"
+                    ToolTip="{x:Static wpf:MainWindowResources.UseRelativePathsForInsertedImages}"
+                    Height="16"
+                    VerticalAlignment="Top" HorizontalAlignment="Right"
+                    Margin="4,0,0,0"
+                    TabIndex="23" IsChecked="True"
+                    FontSize="11"/>
             <TextBlock Height="18"
                        TextWrapping="Wrap"
                        VerticalAlignment="Top"

--- a/Calcpad.Wpf/MainWindow.xaml
+++ b/Calcpad.Wpf/MainWindow.xaml
@@ -1812,6 +1812,14 @@
                 ToolTip="{x:Static wpf:MainWindowResources.ShowHelp}">
             <Image Source="Resources/help.png" Width="20" Height="20" VerticalAlignment="Center" HorizontalAlignment="Center"/>
         </Button>
+        <Button Grid.Row="0" Click="LibraryButton_Click" x:Name="LibraryButton"
+                HorizontalAlignment="Left" VerticalAlignment="Top"
+                Height="24" Width="24" Margin="325,24,0,0"
+                Focusable="false" IsTabStop="false"
+                Background="{x:Null}" BorderBrush="{x:Null}"
+                ToolTip="{x:Static wpf:MainWindowResources.Library_Tooltip}">
+            <Image Source="Resources/open.png" Width="20" Height="20" VerticalAlignment="Center" HorizontalAlignment="Center"/>
+        </Button>
         <TextBlock Grid.Row="0" TextWrapping="Wrap" FontSize="11.5" Margin="0,6,146,0" Height="16"
             VerticalAlignment="Top"  HorizontalAlignment="Right" Width="110" Foreground="#DA000000"
             Text="{x:Static wpf:MainWindowResources.MaxOutputCount}" />
@@ -2231,7 +2239,79 @@
                            MouseUp="Website_MouseUp"/>
             </StatusBarItem>
         </StatusBar>
-        <Grid x:Name="FramesGrid" Margin="0,1,0,35" Grid.Row="1">
+        <Grid x:Name="MainContentGrid" Grid.Row="1" Margin="0,1,0,35">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition x:Name="LibraryColumn" Width="0"/>
+                <ColumnDefinition x:Name="LibrarySplitterColumn" Width="0"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+            <Border Grid.Column="0" x:Name="LibraryPanel" Visibility="Collapsed"
+                    BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
+                    BorderThickness="0,1,1,1" Background="#FFFAFAFA">
+                <DockPanel LastChildFill="True" Margin="2">
+                    <Border DockPanel.Dock="Top" Padding="2" Background="#FFEFEFEF">
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="{x:Static wpf:MainWindowResources.Library_Title}"
+                                       FontWeight="Bold" VerticalAlignment="Center" Margin="4,0,8,0"/>
+                            <Button x:Name="LibraryAddFolderButton"
+                                    Content="{x:Static wpf:MainWindowResources.Library_AddFolder}"
+                                    ToolTip="{x:Static wpf:MainWindowResources.Library_AddFolder_Tooltip}"
+                                    Click="LibraryAddFolderButton_Click"
+                                    Padding="6,1" Margin="0,0,4,0" FontSize="11"/>
+                            <Button x:Name="LibraryRefreshButton"
+                                    Content="{x:Static wpf:MainWindowResources.Library_Refresh}"
+                                    ToolTip="{x:Static wpf:MainWindowResources.Library_Refresh_Tooltip}"
+                                    Click="LibraryRefreshButton_Click"
+                                    Padding="6,1" FontSize="11"/>
+                        </StackPanel>
+                    </Border>
+                    <TreeView x:Name="LibraryTree"
+                              BorderThickness="0" Background="Transparent"
+                              MouseDoubleClick="LibraryTree_MouseDoubleClick"
+                              FontSize="12">
+                        <TreeView.ItemContainerStyle>
+                            <Style TargetType="TreeViewItem">
+                                <Setter Property="IsExpanded" Value="{Binding IsExpanded, Mode=TwoWay}"/>
+                            </Style>
+                        </TreeView.ItemContainerStyle>
+                        <TreeView.Resources>
+                            <HierarchicalDataTemplate DataType="{x:Type wpf:LibraryFolderNode}" ItemsSource="{Binding Children}">
+                                <StackPanel Orientation="Horizontal">
+                                    <TextBlock Text="📁 " FontFamily="Segoe UI Emoji"/>
+                                    <TextBlock Text="{Binding Name}" FontWeight="SemiBold">
+                                        <TextBlock.ContextMenu>
+                                            <ContextMenu>
+                                                <MenuItem Header="{x:Static wpf:MainWindowResources.Library_RemoveFolder}"
+                                                          Click="LibraryRemoveFolderMenuItem_Click"
+                                                          Tag="{Binding}"/>
+                                            </ContextMenu>
+                                        </TextBlock.ContextMenu>
+                                    </TextBlock>
+                                </StackPanel>
+                            </HierarchicalDataTemplate>
+                            <HierarchicalDataTemplate DataType="{x:Type wpf:LibraryFileNode}" ItemsSource="{Binding Children}">
+                                <StackPanel Orientation="Horizontal">
+                                    <TextBlock Text="📄 " FontFamily="Segoe UI Emoji"/>
+                                    <TextBlock Text="{Binding Name}"/>
+                                </StackPanel>
+                            </HierarchicalDataTemplate>
+                            <HierarchicalDataTemplate DataType="{x:Type wpf:LibraryFunctionNode}">
+                                <StackPanel Orientation="Horizontal">
+                                    <TextBlock Text="ƒ " Foreground="#FF1565C0" FontStyle="Italic"/>
+                                    <TextBlock Text="{Binding Name}"/>
+                                </StackPanel>
+                            </HierarchicalDataTemplate>
+                            <DataTemplate DataType="{x:Type wpf:LibraryPlaceholderNode}">
+                                <TextBlock Text="{Binding Name}" Foreground="Gray" FontStyle="Italic"/>
+                            </DataTemplate>
+                        </TreeView.Resources>
+                    </TreeView>
+                </DockPanel>
+            </Border>
+            <GridSplitter Grid.Column="1" x:Name="LibrarySplitter" Width="4"
+                          HorizontalAlignment="Stretch" Visibility="Collapsed"
+                          Background="#FFE3E3E3"/>
+        <Grid x:Name="FramesGrid" Grid.Column="2">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="120*"/>
                 <ColumnDefinition />
@@ -2799,6 +2879,7 @@
                     TabIndex="22" Click="CodeCheckBox_Click" FontFamily="Segoe UI Semibold" >
                 </CheckBox>
             </Border>
+        </Grid>
         </Grid>
         <TextBlock Grid.Row="0" TextWrapping="Wrap" FontSize="12.5" Margin="0,28,155,0" Height="16"
             VerticalAlignment="Top"  HorizontalAlignment="Right" Width="50"

--- a/Calcpad.Wpf/MainWindow.xaml.cs
+++ b/Calcpad.Wpf/MainWindow.xaml.cs
@@ -709,6 +709,7 @@ namespace Calcpad.Wpf
             ZeroSmallMatrixElementsCheckBox.IsChecked = settings.ZeroSmallMatrixElements;
             MaxOutputCountTextBox.Text = settings.MaxOutputCount.ToString();
             EmbedCheckBox.IsChecked = settings.Embed;
+            UseRelativePathsCheckBox.IsChecked = settings.UseRelativePaths;
             if (settings.WindowLeft > 0) Left = settings.WindowLeft;
             if (settings.WindowTop > 0) Top = settings.WindowTop;
             if (settings.WindowWidth > 0) Width = settings.WindowWidth;
@@ -793,6 +794,7 @@ namespace Calcpad.Wpf
             settings.ZeroSmallMatrixElements = ZeroSmallMatrixElementsCheckBox.IsChecked ?? false;
             settings.MaxOutputCount = int.TryParse(MaxOutputCountTextBox.Text, out int i) ? i : (int)20;
             settings.Embed = EmbedCheckBox.IsChecked ?? false;
+            settings.UseRelativePaths = UseRelativePathsCheckBox.IsChecked ?? false;
             settings.WindowLeft = Left;
             settings.WindowTop = Top;
             settings.WindowWidth = Width;
@@ -2128,17 +2130,47 @@ namespace Calcpad.Wpf
                 InsertImage(dlg.FileName);
         }
 
+        private bool _relativePathWarningShown;
+
+        private string BuildImageSrc(string filePath)
+        {
+            var hasCurrentDoc = !string.IsNullOrEmpty(CurrentFileName);
+            var useRelative = UseRelativePathsCheckBox.IsChecked ?? false;
+
+            if (useRelative && hasCurrentDoc)
+            {
+                var docDir = Path.GetDirectoryName(CurrentFileName);
+                var relative = Path.GetRelativePath(docDir, filePath).Replace('\\', '/');
+                // Path.GetRelativePath returns the original absolute path when the file is on
+                // a different volume — in that case fall through to the absolute branch below.
+                if (!Path.IsPathRooted(relative))
+                {
+                    if (!relative.StartsWith("./", StringComparison.Ordinal) &&
+                        !relative.StartsWith("../", StringComparison.Ordinal))
+                        relative = "./" + relative;
+                    return relative;
+                }
+            }
+            else if (useRelative && !_relativePathWarningShown)
+            {
+                _relativePathWarningShown = true;
+                MessageBox.Show(MainWindowResources.SaveDocumentFirstForRelativePaths,
+                    "CalcpadCE", MessageBoxButton.OK, MessageBoxImage.Information);
+            }
+            else if (hasCurrentDoc)
+            {
+                var fileDir = Path.GetDirectoryName(filePath);
+                if (string.Equals(Path.GetDirectoryName(CurrentFileName), fileDir, StringComparison.OrdinalIgnoreCase))
+                    return "./" + Path.GetFileName(filePath);
+            }
+            return filePath.Replace('\\', '/');
+        }
+
         private void InsertImage(string filePath)
         {
             var fileName = Path.GetFileName(filePath);
             var size = GetImageSize(filePath);
-            var fileDir = Path.GetDirectoryName(filePath);
-            string src;
-            if (!string.IsNullOrEmpty(CurrentFileName) &&
-                string.Equals(Path.GetDirectoryName(CurrentFileName), fileDir, StringComparison.OrdinalIgnoreCase))
-                src = "./" + fileName;
-            else
-                src = filePath.Replace('\\', '/');
+            var src = BuildImageSrc(filePath);
             var p = new Paragraph();
             p.Inlines.Add(new Run($"'<img style=\"height:{size.Height}pt; width:{size.Width}pt;\" src=\"{src}\" alt=\"{fileName}\">"));
             _highlighter.Parse(p, IsComplex, GetLineNumber(p), true);

--- a/Calcpad.Wpf/MainWindow.xaml.cs
+++ b/Calcpad.Wpf/MainWindow.xaml.cs
@@ -2293,18 +2293,13 @@ namespace Calcpad.Wpf
                     return relative;
                 }
             }
-            else if (useRelative && !_relativePathWarningShown)
+            else if (useRelative && !hasCurrentDoc && !_relativePathWarningShown)
             {
                 _relativePathWarningShown = true;
                 MessageBox.Show(MainWindowResources.SaveDocumentFirstForRelativePaths,
                     "CalcpadCE", MessageBoxButton.OK, MessageBoxImage.Information);
             }
-            else if (hasCurrentDoc)
-            {
-                var fileDir = Path.GetDirectoryName(filePath);
-                if (string.Equals(Path.GetDirectoryName(CurrentFileName), fileDir, StringComparison.OrdinalIgnoreCase))
-                    return "./" + Path.GetFileName(filePath);
-            }
+            // Relative paths off (or no saved document): always emit the absolute path.
             return filePath.Replace('\\', '/');
         }
 

--- a/Calcpad.Wpf/MainWindow.xaml.cs
+++ b/Calcpad.Wpf/MainWindow.xaml.cs
@@ -91,6 +91,7 @@ namespace Calcpad.Wpf
         private readonly UndoManager _undoMan;
         private readonly WebView2Wrapper _wv2Warper;
         private readonly InsertManager _insertManager;
+        private readonly LibraryManager _libraryManager = new();
         private readonly AutoCompleteManager _autoCompleteManager;
 
         private readonly string _readmeFileName;
@@ -237,6 +238,8 @@ namespace Calcpad.Wpf
             };
             _insertManager = new(RichTextBox);
             _autoCompleteManager = new(RichTextBox, AutoCompleteListBox, Dispatcher, _insertManager);
+            LibraryTree.ItemsSource = _libraryManager.Folders;
+            _libraryManager.LoadFromSettings(Properties.Settings.Default.LibraryFolders);
             _cfn = string.Empty;
             Title = AppInfo.Title;
             _isTextChangedEnabled = false;
@@ -710,6 +713,7 @@ namespace Calcpad.Wpf
             MaxOutputCountTextBox.Text = settings.MaxOutputCount.ToString();
             EmbedCheckBox.IsChecked = settings.Embed;
             UseRelativePathsCheckBox.IsChecked = settings.UseRelativePaths;
+            SetLibraryPanelVisible(settings.ShowLibraryPanel);
             if (settings.WindowLeft > 0) Left = settings.WindowLeft;
             if (settings.WindowTop > 0) Top = settings.WindowTop;
             if (settings.WindowWidth > 0) Width = settings.WindowWidth;
@@ -795,6 +799,10 @@ namespace Calcpad.Wpf
             settings.MaxOutputCount = int.TryParse(MaxOutputCountTextBox.Text, out int i) ? i : (int)20;
             settings.Embed = EmbedCheckBox.IsChecked ?? false;
             settings.UseRelativePaths = UseRelativePathsCheckBox.IsChecked ?? false;
+            settings.ShowLibraryPanel = LibraryPanel.Visibility == Visibility.Visible;
+            if (LibraryColumn.Width.Value > 0)
+                settings.LibraryPanelWidth = LibraryColumn.Width.Value;
+            settings.LibraryFolders = _libraryManager.ToSettings();
             settings.WindowLeft = Left;
             settings.WindowTop = Top;
             settings.WindowWidth = Width;
@@ -2130,9 +2138,143 @@ namespace Calcpad.Wpf
                 InsertImage(dlg.FileName);
         }
 
+        private void LibraryButton_Click(object sender, RoutedEventArgs e)
+        {
+            SetLibraryPanelVisible(LibraryPanel.Visibility != Visibility.Visible);
+        }
+
+        private void SetLibraryPanelVisible(bool visible)
+        {
+            if (visible)
+            {
+                var w = Properties.Settings.Default.LibraryPanelWidth;
+                if (w < 120) w = 250;
+                LibraryColumn.Width = new GridLength(w);
+                LibrarySplitterColumn.Width = new GridLength(4);
+                LibraryPanel.Visibility = Visibility.Visible;
+                LibrarySplitter.Visibility = Visibility.Visible;
+            }
+            else
+            {
+                if (LibraryColumn.Width.Value > 0)
+                    Properties.Settings.Default.LibraryPanelWidth = LibraryColumn.Width.Value;
+                LibraryColumn.Width = new GridLength(0);
+                LibrarySplitterColumn.Width = new GridLength(0);
+                LibraryPanel.Visibility = Visibility.Collapsed;
+                LibrarySplitter.Visibility = Visibility.Collapsed;
+            }
+        }
+
+        private void LibraryAddFolderButton_Click(object sender, RoutedEventArgs e)
+        {
+            var dlg = new OpenFolderDialog
+            {
+                Title = MainWindowResources.Library_SelectFolderDialog_Title,
+                Multiselect = false
+            };
+            if (dlg.ShowDialog() == true)
+                _libraryManager.AddFolder(dlg.FolderName);
+        }
+
+        private void LibraryRefreshButton_Click(object sender, RoutedEventArgs e)
+        {
+            _libraryManager.Refresh();
+        }
+
+        private void LibraryRemoveFolderMenuItem_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is MenuItem mi && mi.Tag is LibraryFolderNode folder)
+                _libraryManager.RemoveFolder(folder);
+        }
+
+        private void LibraryTree_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            switch (LibraryTree.SelectedItem)
+            {
+                case LibraryFunctionNode fn:
+                    InsertFunctionReference(fn.FilePath, fn.Function);
+                    e.Handled = true;
+                    break;
+                case LibraryFileNode file:
+                    InsertFileInclude(file.FullPath);
+                    e.Handled = true;
+                    break;
+            }
+        }
+
+        private void InsertFileInclude(string filePath)
+        {
+            var path = BuildLinkedPath(filePath);
+            _insertManager.InsertText($"#include {path}\n");
+        }
+
+        private void InsertFunctionReference(string filePath, LibraryFunction fn)
+        {
+            EnsureIncludeAtTop(filePath);
+            // Wrap the args in `{…}` so InsertManager.SelectInsertedText highlights them for quick replacement.
+            var signature = string.IsNullOrEmpty(fn.Signature) ? fn.Name : $"{fn.Name}({{{fn.Signature}}})";
+            _insertManager.InsertText($"' {signature}\n");
+        }
+
+        /// Adds an #include directive for filePath at the top of the document if one isn't already
+        /// present (case-insensitive comparison on canonicalized full paths).
+        private void EnsureIncludeAtTop(string filePath)
+        {
+            var targetFull = Path.GetFullPath(filePath);
+            Paragraph lastIncludeParagraph = null;
+            foreach (var block in _document.Blocks)
+            {
+                if (block is not Paragraph p) continue;
+                var text = new TextRange(p.ContentStart, p.ContentEnd).Text.TrimStart();
+                if (!text.StartsWith("#include", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (lastIncludeParagraph is not null) break;
+                    continue;
+                }
+                lastIncludeParagraph = p;
+                var existing = ExtractIncludePath(text);
+                if (existing is null) continue;
+                try
+                {
+                    var existingFull = Path.IsPathRooted(existing)
+                        ? Path.GetFullPath(existing)
+                        : Path.GetFullPath(existing,
+                            string.IsNullOrEmpty(CurrentFileName) ? Environment.CurrentDirectory : Path.GetDirectoryName(CurrentFileName));
+                    if (string.Equals(existingFull, targetFull, StringComparison.OrdinalIgnoreCase))
+                        return;
+                }
+                catch { /* ignore malformed include paths */ }
+            }
+
+            var path = BuildLinkedPath(filePath);
+            var newPara = new Paragraph();
+            newPara.Inlines.Add(new Run($"#include {path}"));
+            _highlighter.Parse(newPara, IsComplex, GetLineNumber(newPara), true);
+            if (lastIncludeParagraph is not null)
+                _document.Blocks.InsertAfter(lastIncludeParagraph, newPara);
+            else if (_document.Blocks.FirstBlock is not null)
+                _document.Blocks.InsertBefore(_document.Blocks.FirstBlock, newPara);
+            else
+                _document.Blocks.Add(newPara);
+        }
+
+        private static string ExtractIncludePath(string trimmedLine)
+        {
+            // Mirror MacroParser.ParseInclude (Calcpad.Core/Parsers/MacroParser.cs): path runs from
+            // index 8 to the first '#{…}' field marker (if any) or end of line. No quotes supported.
+            var afterKeyword = trimmedLine.AsSpan(8);
+            var sharp = afterKeyword.IndexOf('#');
+            if (sharp >= 0)
+                afterKeyword = afterKeyword[..sharp];
+            return afterKeyword.Trim().ToString();
+        }
+
         private bool _relativePathWarningShown;
 
-        private string BuildImageSrc(string filePath)
+        /// Returns a path string suitable for embedding in the document (image src, #include path, etc.):
+        /// relative to the current document folder when "Use relative paths" is on and the doc is saved,
+        /// otherwise the original absolute path (with forward slashes).
+        private string BuildLinkedPath(string filePath)
         {
             var hasCurrentDoc = !string.IsNullOrEmpty(CurrentFileName);
             var useRelative = UseRelativePathsCheckBox.IsChecked ?? false;
@@ -2170,7 +2312,7 @@ namespace Calcpad.Wpf
         {
             var fileName = Path.GetFileName(filePath);
             var size = GetImageSize(filePath);
-            var src = BuildImageSrc(filePath);
+            var src = BuildLinkedPath(filePath);
             var p = new Paragraph();
             p.Inlines.Add(new Run($"'<img style=\"height:{size.Height}pt; width:{size.Width}pt;\" src=\"{src}\" alt=\"{fileName}\">"));
             _highlighter.Parse(p, IsComplex, GetLineNumber(p), true);

--- a/Calcpad.Wpf/MainWindowResources.Designer.cs
+++ b/Calcpad.Wpf/MainWindowResources.Designer.cs
@@ -1016,6 +1016,33 @@ namespace Calcpad.Wpf {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Relative.
+        /// </summary>
+        public static string Relative {
+            get {
+                return ResourceManager.GetString("Relative", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Use relative paths for inserted images (resolved against the current document folder)..
+        /// </summary>
+        public static string UseRelativePathsForInsertedImages {
+            get {
+                return ResourceManager.GetString("UseRelativePathsForInsertedImages", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Save the document first to insert relative paths. An absolute path was used instead..
+        /// </summary>
+        public static string SaveDocumentFirstForRelativePaths {
+            get {
+                return ResourceManager.GetString("SaveDocumentFirstForRelativePaths", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Enables markdown in comments.
         /// </summary>
         public static string EnablesMarkdownInComments {

--- a/Calcpad.Wpf/MainWindowResources.Designer.cs
+++ b/Calcpad.Wpf/MainWindowResources.Designer.cs
@@ -1042,6 +1042,50 @@ namespace Calcpad.Wpf {
             }
         }
 
+        public static string Library_Tooltip {
+            get { return ResourceManager.GetString("Library_Tooltip", resourceCulture); }
+        }
+
+        public static string Library_Title {
+            get { return ResourceManager.GetString("Library_Title", resourceCulture); }
+        }
+
+        public static string Library_AddFolder {
+            get { return ResourceManager.GetString("Library_AddFolder", resourceCulture); }
+        }
+
+        public static string Library_AddFolder_Tooltip {
+            get { return ResourceManager.GetString("Library_AddFolder_Tooltip", resourceCulture); }
+        }
+
+        public static string Library_RemoveFolder {
+            get { return ResourceManager.GetString("Library_RemoveFolder", resourceCulture); }
+        }
+
+        public static string Library_Refresh {
+            get { return ResourceManager.GetString("Library_Refresh", resourceCulture); }
+        }
+
+        public static string Library_Refresh_Tooltip {
+            get { return ResourceManager.GetString("Library_Refresh_Tooltip", resourceCulture); }
+        }
+
+        public static string Library_NoFunctionsFound {
+            get { return ResourceManager.GetString("Library_NoFunctionsFound", resourceCulture); }
+        }
+
+        public static string Library_FolderNotFound {
+            get { return ResourceManager.GetString("Library_FolderNotFound", resourceCulture); }
+        }
+
+        public static string Library_SelectFolderDialog_Title {
+            get { return ResourceManager.GetString("Library_SelectFolderDialog_Title", resourceCulture); }
+        }
+
+        public static string Library_Hide {
+            get { return ResourceManager.GetString("Library_Hide", resourceCulture); }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Enables markdown in comments.
         /// </summary>

--- a/Calcpad.Wpf/MainWindowResources.bg.resx
+++ b/Calcpad.Wpf/MainWindowResources.bg.resx
@@ -1136,6 +1136,15 @@
   <data name="EmbedPlotsInsideTheHtmlAsBase64EncodedImagesSaveToFilesIfUnchecked" xml:space="preserve">
     <value>Вграждане на графики в HTML като base64 кодирани изображения. Запазване във файлове, ако не е отметнато.</value>
   </data>
+  <data name="Relative" xml:space="preserve">
+    <value>Относителни</value>
+  </data>
+  <data name="UseRelativePathsForInsertedImages" xml:space="preserve">
+    <value>Използвай относителни пътища за вмъкнатите изображения (спрямо папката на текущия документ).</value>
+  </data>
+  <data name="SaveDocumentFirstForRelativePaths" xml:space="preserve">
+    <value>Запазете документа, за да вмъквате относителни пътища. Вместо това беше използван абсолютен път.</value>
+  </data>
   <data name="MultilineExpressionBlock" xml:space="preserve">
     <value>Многоредов блок от изрази</value>
   </data>

--- a/Calcpad.Wpf/MainWindowResources.bg.resx
+++ b/Calcpad.Wpf/MainWindowResources.bg.resx
@@ -1145,6 +1145,39 @@
   <data name="SaveDocumentFirstForRelativePaths" xml:space="preserve">
     <value>Запазете документа, за да вмъквате относителни пътища. Вместо това беше използван абсолютен път.</value>
   </data>
+  <data name="Library_Tooltip" xml:space="preserve">
+    <value>Показване/скриване на панела с библиотеката</value>
+  </data>
+  <data name="Library_Title" xml:space="preserve">
+    <value>Библиотека</value>
+  </data>
+  <data name="Library_AddFolder" xml:space="preserve">
+    <value>+ Папка</value>
+  </data>
+  <data name="Library_AddFolder_Tooltip" xml:space="preserve">
+    <value>Добавяне на папка с .cpd файлове към библиотеката</value>
+  </data>
+  <data name="Library_RemoveFolder" xml:space="preserve">
+    <value>Премахни от библиотеката</value>
+  </data>
+  <data name="Library_Refresh" xml:space="preserve">
+    <value>Опресни</value>
+  </data>
+  <data name="Library_Refresh_Tooltip" xml:space="preserve">
+    <value>Повторно сканиране на папките от библиотеката</value>
+  </data>
+  <data name="Library_NoFunctionsFound" xml:space="preserve">
+    <value>(няма функции)</value>
+  </data>
+  <data name="Library_FolderNotFound" xml:space="preserve">
+    <value>Папката не е намерена: {0}</value>
+  </data>
+  <data name="Library_SelectFolderDialog_Title" xml:space="preserve">
+    <value>Изберете папка от библиотеката</value>
+  </data>
+  <data name="Library_Hide" xml:space="preserve">
+    <value>Скрий панела с библиотеката</value>
+  </data>
   <data name="MultilineExpressionBlock" xml:space="preserve">
     <value>Многоредов блок от изрази</value>
   </data>

--- a/Calcpad.Wpf/MainWindowResources.resx
+++ b/Calcpad.Wpf/MainWindowResources.resx
@@ -1137,6 +1137,15 @@ You can find your unsaved data in
   <data name="EmbedPlotsInsideTheHtmlAsBase64EncodedImagesSaveToFilesIfUnchecked" xml:space="preserve">
     <value>Embed plots inside the Html as base64 encoded images, Save to files if unchecked.</value>
   </data>
+  <data name="Relative" xml:space="preserve">
+    <value>Relative</value>
+  </data>
+  <data name="UseRelativePathsForInsertedImages" xml:space="preserve">
+    <value>Use relative paths for inserted images (resolved against the current document folder).</value>
+  </data>
+  <data name="SaveDocumentFirstForRelativePaths" xml:space="preserve">
+    <value>Save the document first to insert relative paths. An absolute path was used instead.</value>
+  </data>
   <data name="MultilineExpressionBlock" xml:space="preserve">
     <value>Multiline expression block</value>
   </data>

--- a/Calcpad.Wpf/MainWindowResources.resx
+++ b/Calcpad.Wpf/MainWindowResources.resx
@@ -1146,6 +1146,39 @@ You can find your unsaved data in
   <data name="SaveDocumentFirstForRelativePaths" xml:space="preserve">
     <value>Save the document first to insert relative paths. An absolute path was used instead.</value>
   </data>
+  <data name="Library_Tooltip" xml:space="preserve">
+    <value>Show/hide library panel</value>
+  </data>
+  <data name="Library_Title" xml:space="preserve">
+    <value>Library</value>
+  </data>
+  <data name="Library_AddFolder" xml:space="preserve">
+    <value>+ Folder</value>
+  </data>
+  <data name="Library_AddFolder_Tooltip" xml:space="preserve">
+    <value>Add a folder of .cpd files to the library</value>
+  </data>
+  <data name="Library_RemoveFolder" xml:space="preserve">
+    <value>Remove from library</value>
+  </data>
+  <data name="Library_Refresh" xml:space="preserve">
+    <value>Refresh</value>
+  </data>
+  <data name="Library_Refresh_Tooltip" xml:space="preserve">
+    <value>Rescan library folders</value>
+  </data>
+  <data name="Library_NoFunctionsFound" xml:space="preserve">
+    <value>(no functions)</value>
+  </data>
+  <data name="Library_FolderNotFound" xml:space="preserve">
+    <value>Folder not found: {0}</value>
+  </data>
+  <data name="Library_SelectFolderDialog_Title" xml:space="preserve">
+    <value>Select a library folder</value>
+  </data>
+  <data name="Library_Hide" xml:space="preserve">
+    <value>Hide library panel</value>
+  </data>
   <data name="MultilineExpressionBlock" xml:space="preserve">
     <value>Multiline expression block</value>
   </data>

--- a/Calcpad.Wpf/MainWindowResources.zh.resx
+++ b/Calcpad.Wpf/MainWindowResources.zh.resx
@@ -1136,6 +1136,15 @@
   <data name="EmbedPlotsInsideTheHtmlAsBase64EncodedImagesSaveToFilesIfUnchecked" xml:space="preserve">
     <value>将图片作为base64编码图像嵌入Html,若未检查即保存为文件.</value>
   </data>
+  <data name="Relative" xml:space="preserve">
+    <value>相对路径</value>
+  </data>
+  <data name="UseRelativePathsForInsertedImages" xml:space="preserve">
+    <value>插入图像时使用相对路径(相对于当前文档所在文件夹解析)。</value>
+  </data>
+  <data name="SaveDocumentFirstForRelativePaths" xml:space="preserve">
+    <value>请先保存文档以便插入相对路径。本次已改用绝对路径。</value>
+  </data>
   <data name="MultilineExpressionBlock" xml:space="preserve">
     <value>多行表达式块</value>
   </data>

--- a/Calcpad.Wpf/MainWindowResources.zh.resx
+++ b/Calcpad.Wpf/MainWindowResources.zh.resx
@@ -1145,6 +1145,39 @@
   <data name="SaveDocumentFirstForRelativePaths" xml:space="preserve">
     <value>请先保存文档以便插入相对路径。本次已改用绝对路径。</value>
   </data>
+  <data name="Library_Tooltip" xml:space="preserve">
+    <value>显示/隐藏库面板</value>
+  </data>
+  <data name="Library_Title" xml:space="preserve">
+    <value>库</value>
+  </data>
+  <data name="Library_AddFolder" xml:space="preserve">
+    <value>+ 文件夹</value>
+  </data>
+  <data name="Library_AddFolder_Tooltip" xml:space="preserve">
+    <value>将 .cpd 文件夹添加到库中</value>
+  </data>
+  <data name="Library_RemoveFolder" xml:space="preserve">
+    <value>从库中移除</value>
+  </data>
+  <data name="Library_Refresh" xml:space="preserve">
+    <value>刷新</value>
+  </data>
+  <data name="Library_Refresh_Tooltip" xml:space="preserve">
+    <value>重新扫描库文件夹</value>
+  </data>
+  <data name="Library_NoFunctionsFound" xml:space="preserve">
+    <value>(无函数)</value>
+  </data>
+  <data name="Library_FolderNotFound" xml:space="preserve">
+    <value>未找到文件夹: {0}</value>
+  </data>
+  <data name="Library_SelectFolderDialog_Title" xml:space="preserve">
+    <value>选择库文件夹</value>
+  </data>
+  <data name="Library_Hide" xml:space="preserve">
+    <value>隐藏库面板</value>
+  </data>
   <data name="MultilineExpressionBlock" xml:space="preserve">
     <value>多行表达式块</value>
   </data>

--- a/Calcpad.Wpf/Properties/Settings.Designer.cs
+++ b/Calcpad.Wpf/Properties/Settings.Designer.cs
@@ -309,5 +309,17 @@ namespace Calcpad.Wpf.Properties {
                 this["Embed"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool UseRelativePaths {
+            get {
+                return ((bool)(this["UseRelativePaths"]));
+            }
+            set {
+                this["UseRelativePaths"] = value;
+            }
+        }
     }
 }

--- a/Calcpad.Wpf/Properties/Settings.Designer.cs
+++ b/Calcpad.Wpf/Properties/Settings.Designer.cs
@@ -321,5 +321,40 @@ namespace Calcpad.Wpf.Properties {
                 this["UseRelativePaths"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        public global::System.Collections.Specialized.StringCollection LibraryFolders {
+            get {
+                return ((global::System.Collections.Specialized.StringCollection)(this["LibraryFolders"]));
+            }
+            set {
+                this["LibraryFolders"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("250")]
+        public double LibraryPanelWidth {
+            get {
+                return ((double)(this["LibraryPanelWidth"]));
+            }
+            set {
+                this["LibraryPanelWidth"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool ShowLibraryPanel {
+            get {
+                return ((bool)(this["ShowLibraryPanel"]));
+            }
+            set {
+                this["ShowLibraryPanel"] = value;
+            }
+        }
     }
 }

--- a/Calcpad.Wpf/Properties/Settings.settings
+++ b/Calcpad.Wpf/Properties/Settings.settings
@@ -74,5 +74,8 @@
     <Setting Name="Embed" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="UseRelativePaths" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Calcpad.Wpf/Properties/Settings.settings
+++ b/Calcpad.Wpf/Properties/Settings.settings
@@ -77,5 +77,14 @@
     <Setting Name="UseRelativePaths" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="LibraryFolders" Type="System.Collections.Specialized.StringCollection" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
+    <Setting Name="LibraryPanelWidth" Type="System.Double" Scope="User">
+      <Value Profile="(Default)">250</Value>
+    </Setting>
+    <Setting Name="ShowLibraryPanel" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
## Summary

Adds two related improvements to the WPF editor:

1. **"Relative" checkbox** — inserts image `src` attributes relative to the current `.cpd` folder when enabled. Foundation for relative `#include` paths.
2. **Library Manager side panel** — togglable left panel listing user-configured library folders as a tree of folders / files / functions. Double-click a file → `#include` at caret; double-click a function → dedup-aware `#include` at top of document + usage comment at caret with args pre-selected.

Library folders, panel width and visibility persist across sessions. Relative/absolute path resolution is centralized in `BuildLinkedPath`, shared by image inserts and `#include` inserts.

## Screenshot

<img width="1841" height="791" alt="2026-05-28_10h57_31" src="https://github.com/user-attachments/assets/7c938163-b77a-4ca4-8695-f1a6cdff1f83" />

## Implementation notes

- `LibraryScanner` extracts `#def` macros and `f(x) =` math functions via regex with no Core dependency.
- `LibraryManager` holds an `ObservableCollection` of folder nodes; each file scans its functions lazily on TreeView expansion.
- `#include` uses **unquoted** syntax per the existing `MacroParser.ParseInclude` convention (which treats `"` as a comment delimiter and fails on quoted paths).
- 11 new localized strings in English, Bulgarian, and Chinese.

## Test plan

- [x] `dotnet build Calcpad.Wpf` — 0 errors, 0 warnings
- [x] `dotnet test Calcpad.Tests` — 4502 pass / 0 fail / 5 skipped (pre-existing HP matrix)
- [x] Toolbar button toggles library panel, width and folders persisted
- [x] Add Folder → recursive `*.cpd` scan; functions listed on file expansion
- [x] Double-click file → `#include` at caret resolves at F5
- [x] Double-click function → dedup `#include` at top + usage comment at caret
- [x] Remove from library (context menu) and Refresh work
