### PR TITLE
Fix unexpected behavior in variable substitution rendering

### DIFF
--- a/Calcpad.Core/Parsers/MathParser/MathParser.Output.cs
+++ b/Calcpad.Core/Parsers/MathParser/MathParser.Output.cs
@@ -89,8 +89,8 @@ namespace Calcpad.Core
                                     if (eqLen < 0)
                                         eqLen = equation.LastIndexOf(globalAssignment);
 
-                                    eqLen = equation.Length - eqLen - assignment.Length;
-                                    if (subst.Length != eqLen)
+                                    eqLen += assignment.Length;
+                                    if (!equation.AsSpan(eqLen).SequenceEqual(subst))
                                     {
                                         if (_parser.VariableSubstitution != VariableSubstitutionOptions.SubstitutionsOnly)
                                         {

--- a/Examples/Engineering/Formatting/Beam Design with Markdown.html.stub
+++ b/Examples/Engineering/Formatting/Beam Design with Markdown.html.stub
@@ -414,6 +414,8 @@ circle.Series1 {fill:Tomato;}
    <sub>Ed</sub>
    =
    <var>A</var>
+   = 60
+   <i>kN</i>
   </span>
  </p>
  <p>

--- a/Examples/Engineering/Pendulums/Double Damped Pendulum Animated.html.stub
+++ b/Examples/Engineering/Pendulums/Double Damped Pendulum Animated.html.stub
@@ -1382,6 +1382,18 @@
     </span>
     2
    </span>
+   = 0
+   <i>s</i>
+   <sup class="unit">-1</sup>
+   +
+   <span class="dvc">
+    0.00654
+    <i>s</i>
+    <sup class="unit">-1</sup>
+    <span class="dvl">
+    </span>
+    2
+   </span>
    = 0.00327
    <i>s</i>
    <sup class="unit">-1</sup>
@@ -1609,6 +1621,18 @@
     </span>
     2
    </span>
+   = 0
+   <i>s</i>
+   <sup class="unit">-1</sup>
+   +
+   <span class="dvc">
+    0.00654
+    <i>s</i>
+    <sup class="unit">-1</sup>
+    <span class="dvl">
+    </span>
+    2
+   </span>
    = 0.00327
    <i>s</i>
    <sup class="unit">-1</sup>
@@ -1821,6 +1845,12 @@
    +
    <var>k</var>
    <sub>3ω1</sub>
+   = 0
+   <i>s</i>
+   <sup class="unit">-1</sup>
+   + 0.00654
+   <i>s</i>
+   <sup class="unit">-1</sup>
    = 0.00654
    <i>s</i>
    <sup class="unit">-1</sup>

--- a/Examples/Structural/Frames/Multi-Story Frame.html.stub
+++ b/Examples/Structural/Frames/Multi-Story Frame.html.stub
@@ -1008,6 +1008,16 @@
     <i>m</i>
     <sup class="unit">2</sup>
    </span>
+   = 2.5
+   <i>m</i>
+   · 2
+   <span class="dvc">
+    <i>kN</i>
+    <span class="dvl">
+    </span>
+    <i>m</i>
+    <sup class="unit">2</sup>
+   </span>
    = 5
    <i>kN</i>
    <i class="unit">∕</i>

--- a/Examples/Structural/Nonlinear/Third Order Geometric Nonlinearity Analysis of a Double-Strut Biot System.html.stub
+++ b/Examples/Structural/Nonlinear/Third Order Geometric Nonlinearity Analysis of a Double-Strut Biot System.html.stub
@@ -474,6 +474,21 @@
     <var>v</var>
     <b class="b0">|</b>
    </span>
+   =
+   <span class="dvc">
+    <b class="b0">|</b>
+    134.51
+    <i>mm</i>
+    − 134.51
+    <i>mm</i>
+    <b class="b0">|</b>
+    <span class="dvl">
+    </span>
+    <b class="b0">|</b>
+    134.51
+    <i>mm</i>
+    <b class="b0">|</b>
+   </span>
    = 9×10
    <sup>-6</sup>
   </span>

--- a/Examples/Structural/Reinforced Concrete/Column Design for Biaxial Bending and Axial Force (with Units).html.stub
+++ b/Examples/Structural/Reinforced Concrete/Column Design for Biaxial Bending and Axial Force (with Units).html.stub
@@ -1116,6 +1116,38 @@ circle.Series1 {fill:Tomato;}
      <sub>2</sub>
      <span class="b1">)</span>
      <sup class="raised">2</sup>
+     = 8
+     <i>cm</i>
+     <sup class="unit">2</sup>
+     ·
+     <span class="b1">(</span>
+     <span class="dvc">
+      700
+      <i>mm</i>
+      <span class="dvl">
+      </span>
+      2
+     </span>
+     − 50
+     <i>mm</i>
+     <span class="b1">)</span>
+     <sup class="raised">2</sup>
+     + 8
+     <i>cm</i>
+     <sup class="unit">2</sup>
+     ·
+     <span class="b1">(</span>
+     <span class="dvc">
+      700
+      <i>mm</i>
+      <span class="dvl">
+      </span>
+      2
+     </span>
+     − 50
+     <i>mm</i>
+     <span class="b1">)</span>
+     <sup class="raised">2</sup>
      = 14400
      <i>cm</i>
      <sup class="unit">4</sup>

--- a/Tests/HP/Matrices/Operators/matrix-operator-scalar/hp-full-rectangular-with-units.html.stub
+++ b/Tests/HP/Matrices/Operators/matrix-operator-scalar/hp-full-rectangular-with-units.html.stub
@@ -70,6 +70,12 @@
    +
    <var>m2</var>
    =
+   <b>
+    <var>m1</var>
+   </b>
+   + 2.71
+   <i>s</i>
+   =
    <span class="matrix">
     <span class="tr">
      <span class="td">
@@ -132,6 +138,14 @@
    ;
    <var>m2</var>
    )  =
+   <var>f</var>
+   (
+   <b>
+    <var>m1</var>
+   </b>
+   ; 2.71
+   <i>s</i>
+   )  =
    <span class="matrix">
     <span class="tr">
      <span class="td">
@@ -182,6 +196,12 @@
    </b>
    −
    <var>m2</var>
+   =
+   <b>
+    <var>m1</var>
+   </b>
+   − 2.71
+   <i>s</i>
    =
    <span class="matrix">
     <span class="tr">
@@ -245,6 +265,14 @@
    ;
    <var>m2</var>
    )  =
+   <var>f</var>
+   (
+   <b>
+    <var>m1</var>
+   </b>
+   ; 2.71
+   <i>s</i>
+   )  =
    <span class="matrix">
     <span class="tr">
      <span class="td">
@@ -301,6 +329,12 @@
    </b>
    ·
    <var>m2</var>
+   =
+   <b>
+    <var>m1</var>
+   </b>
+   · 2.71
+   <i>s</i>
    =
    <span class="matrix">
     <span class="tr">
@@ -364,6 +398,14 @@
    </b>
    ;
    <var>m2</var>
+   )  =
+   <var>f</var>
+   (
+   <b>
+    <var>m1</var>
+   </b>
+   ; 2.71
+   <i>s</i>
    )  =
    <span class="matrix">
     <span class="tr">
@@ -416,6 +458,16 @@
     <span class="dvl">
     </span>
     <var>m2</var>
+   </span>
+   =
+   <span class="dvc">
+    <b>
+     <var>m1</var>
+    </b>
+    <span class="dvl">
+    </span>
+    2.71
+    <i>s</i>
    </span>
    =
    <span class="matrix">
@@ -481,6 +533,14 @@
    </b>
    ;
    <var>m2</var>
+   )  =
+   <var>f</var>
+   (
+   <b>
+    <var>m1</var>
+   </b>
+   ; 2.71
+   <i>s</i>
    )  =
    <span class="matrix">
     <span class="tr">
@@ -739,6 +799,12 @@
    \
    <var>m2</var>
    =
+   <b>
+    <var>m1</var>
+   </b>
+   \2.71
+   <i>s</i>
+   =
    <span class="matrix">
     <span class="tr">
      <span class="td">
@@ -800,6 +866,14 @@
    ;
    <var>m2</var>
    )  =
+   <var>f</var>
+   (
+   <b>
+    <var>m1</var>
+   </b>
+   ; 2.71
+   <i>s</i>
+   )  =
    <span class="matrix">
     <span class="tr">
      <span class="td">
@@ -847,6 +921,13 @@
    </b>
    <em>/</em>
    <var>m2</var>
+   =
+   <b>
+    <var>m1</var>
+   </b>
+   <em>/</em>
+   2.71
+   <i>s</i>
    =
    <span class="matrix">
     <span class="tr">
@@ -908,6 +989,14 @@
    </b>
    ;
    <var>m2</var>
+   )  =
+   <var>f</var>
+   (
+   <b>
+    <var>m1</var>
+   </b>
+   ; 2.71
+   <i>s</i>
    )  =
    <span class="matrix">
     <span class="tr">
@@ -1168,6 +1257,12 @@
    ≡
    <var>m2</var>
    =
+   <b>
+    <var>m1</var>
+   </b>
+   ≡ 2.71
+   <i>s</i>
+   =
    <span class="matrix">
     <span class="tr">
      <span class="td">
@@ -1229,6 +1324,14 @@
    ;
    <var>m2</var>
    )  =
+   <var>f</var>
+   (
+   <b>
+    <var>m1</var>
+   </b>
+   ; 2.71
+   <i>s</i>
+   )  =
    <span class="matrix">
     <span class="tr">
      <span class="td">
@@ -1276,6 +1379,12 @@
    </b>
    ≠
    <var>m2</var>
+   =
+   <b>
+    <var>m1</var>
+   </b>
+   ≠ 2.71
+   <i>s</i>
    =
    <span class="matrix">
     <span class="tr">
@@ -1337,6 +1446,14 @@
    </b>
    ;
    <var>m2</var>
+   )  =
+   <var>f</var>
+   (
+   <b>
+    <var>m1</var>
+   </b>
+   ; 2.71
+   <i>s</i>
    )  =
    <span class="matrix">
     <span class="tr">
@@ -1386,6 +1503,12 @@
    &lt;
    <var>m2</var>
    =
+   <b>
+    <var>m1</var>
+   </b>
+   &lt; 2.71
+   <i>s</i>
+   =
    <span class="matrix">
     <span class="tr">
      <span class="td">
@@ -1447,6 +1570,14 @@
    ;
    <var>m2</var>
    )  =
+   <var>f</var>
+   (
+   <b>
+    <var>m1</var>
+   </b>
+   ; 2.71
+   <i>s</i>
+   )  =
    <span class="matrix">
     <span class="tr">
      <span class="td">
@@ -1494,6 +1625,12 @@
    </b>
    &gt;
    <var>m2</var>
+   =
+   <b>
+    <var>m1</var>
+   </b>
+   &gt; 2.71
+   <i>s</i>
    =
    <span class="matrix">
     <span class="tr">
@@ -1555,6 +1692,14 @@
    </b>
    ;
    <var>m2</var>
+   )  =
+   <var>f</var>
+   (
+   <b>
+    <var>m1</var>
+   </b>
+   ; 2.71
+   <i>s</i>
    )  =
    <span class="matrix">
     <span class="tr">
@@ -1604,6 +1749,12 @@
    ≥
    <var>m2</var>
    =
+   <b>
+    <var>m1</var>
+   </b>
+   ≥ 2.71
+   <i>s</i>
+   =
    <span class="matrix">
     <span class="tr">
      <span class="td">
@@ -1665,6 +1816,14 @@
    ;
    <var>m2</var>
    )  =
+   <var>f</var>
+   (
+   <b>
+    <var>m1</var>
+   </b>
+   ; 2.71
+   <i>s</i>
+   )  =
    <span class="matrix">
     <span class="tr">
      <span class="td">
@@ -1712,6 +1871,12 @@
    </b>
    ≤
    <var>m2</var>
+   =
+   <b>
+    <var>m1</var>
+   </b>
+   ≤ 2.71
+   <i>s</i>
    =
    <span class="matrix">
     <span class="tr">
@@ -1773,6 +1938,14 @@
    </b>
    ;
    <var>m2</var>
+   )  =
+   <var>f</var>
+   (
+   <b>
+    <var>m1</var>
+   </b>
+   ; 2.71
+   <i>s</i>
    )  =
    <span class="matrix">
     <span class="tr">
@@ -1825,6 +1998,12 @@
    and
    <var>m2</var>
    =
+   <b>
+    <var>m1</var>
+   </b>
+   and 2.71
+   <i>s</i>
+   =
    <span class="matrix">
     <span class="tr">
      <span class="td">
@@ -1886,6 +2065,14 @@
    ;
    <var>m2</var>
    )  =
+   <var>f</var>
+   (
+   <b>
+    <var>m1</var>
+   </b>
+   ; 2.71
+   <i>s</i>
+   )  =
    <span class="matrix">
     <span class="tr">
      <span class="td">
@@ -1933,6 +2120,12 @@
    </b>
    or
    <var>m2</var>
+   =
+   <b>
+    <var>m1</var>
+   </b>
+   or 2.71
+   <i>s</i>
    =
    <span class="matrix">
     <span class="tr">
@@ -1995,6 +2188,14 @@
    ;
    <var>m2</var>
    )  =
+   <var>f</var>
+   (
+   <b>
+    <var>m1</var>
+   </b>
+   ; 2.71
+   <i>s</i>
+   )  =
    <span class="matrix">
     <span class="tr">
      <span class="td">
@@ -2042,6 +2243,12 @@
    </b>
    xor
    <var>m2</var>
+   =
+   <b>
+    <var>m1</var>
+   </b>
+   xor 2.71
+   <i>s</i>
    =
    <span class="matrix">
     <span class="tr">
@@ -2103,6 +2310,14 @@
    </b>
    ;
    <var>m2</var>
+   )  =
+   <var>f</var>
+   (
+   <b>
+    <var>m1</var>
+   </b>
+   ; 2.71
+   <i>s</i>
    )  =
    <span class="matrix">
     <span class="tr">

--- a/Tests/HP/Matrices/Operators/scalar-operator-matrix/hp-full-rectangular-with-units.html.stub
+++ b/Tests/HP/Matrices/Operators/scalar-operator-matrix/hp-full-rectangular-with-units.html.stub
@@ -69,6 +69,12 @@
    <b>
     <var>m2</var>
    </b>
+   = 3.49
+   <i>s</i>
+   +
+   <b>
+    <var>m2</var>
+   </b>
    =
    <span class="matrix">
     <span class="tr">
@@ -132,6 +138,14 @@
     <var>m2</var>
    </b>
    )  =
+   <var>f</var>
+   ( 3.49
+   <i>s</i>
+   ;
+   <b>
+    <var>m2</var>
+   </b>
+   )  =
    <span class="matrix">
     <span class="tr">
      <span class="td">
@@ -178,6 +192,12 @@
    </b>
    =
    <var>m1</var>
+   −
+   <b>
+    <var>m2</var>
+   </b>
+   = 3.49
+   <i>s</i>
    −
    <b>
     <var>m2</var>
@@ -245,6 +265,14 @@
     <var>m2</var>
    </b>
    )  =
+   <var>f</var>
+   ( 3.49
+   <i>s</i>
+   ;
+   <b>
+    <var>m2</var>
+   </b>
+   )  =
    <span class="matrix">
     <span class="tr">
      <span class="td">
@@ -297,6 +325,12 @@
    </b>
    =
    <var>m1</var>
+   ·
+   <b>
+    <var>m2</var>
+   </b>
+   = 3.49
+   <i>s</i>
    ·
    <b>
     <var>m2</var>
@@ -360,6 +394,14 @@
    <var>f</var>
    (
    <var>m1</var>
+   ;
+   <b>
+    <var>m2</var>
+   </b>
+   )  =
+   <var>f</var>
+   ( 3.49
+   <i>s</i>
    ;
    <b>
     <var>m2</var>
@@ -411,6 +453,16 @@
    =
    <span class="dvc">
     <var>m1</var>
+    <span class="dvl">
+    </span>
+    <b>
+     <var>m2</var>
+    </b>
+   </span>
+   =
+   <span class="dvc">
+    3.49
+    <i>s</i>
     <span class="dvl">
     </span>
     <b>
@@ -479,6 +531,14 @@
    <var>f</var>
    (
    <var>m1</var>
+   ;
+   <b>
+    <var>m2</var>
+   </b>
+   )  =
+   <var>f</var>
+   ( 3.49
+   <i>s</i>
    ;
    <b>
     <var>m2</var>
@@ -639,6 +699,12 @@
    <b>
     <var>m2</var>
    </b>
+   = 3.49
+   <i>s</i>
+   \
+   <b>
+    <var>m2</var>
+   </b>
    =
    <span class="matrix">
     <span class="tr">
@@ -703,6 +769,14 @@
     <var>m2</var>
    </b>
    )  =
+   <var>f</var>
+   ( 3.49
+   <i>s</i>
+   ;
+   <b>
+    <var>m2</var>
+   </b>
+   )  =
    <span class="matrix">
     <span class="tr">
      <span class="td">
@@ -748,6 +822,12 @@
    </b>
    =
    <var>m1</var>
+   <em>/</em>
+   <b>
+    <var>m2</var>
+   </b>
+   = 3.49
+   <i>s</i>
    <em>/</em>
    <b>
     <var>m2</var>
@@ -811,6 +891,14 @@
    <var>f</var>
    (
    <var>m1</var>
+   ;
+   <b>
+    <var>m2</var>
+   </b>
+   )  =
+   <var>f</var>
+   ( 3.49
+   <i>s</i>
    ;
    <b>
     <var>m2</var>
@@ -1076,6 +1164,12 @@
    <b>
     <var>m2</var>
    </b>
+   = 3.49
+   <i>s</i>
+   ≡
+   <b>
+    <var>m2</var>
+   </b>
    =
    <span class="matrix">
     <span class="tr">
@@ -1138,6 +1232,14 @@
     <var>m2</var>
    </b>
    )  =
+   <var>f</var>
+   ( 3.49
+   <i>s</i>
+   ;
+   <b>
+    <var>m2</var>
+   </b>
+   )  =
    <span class="matrix">
     <span class="tr">
      <span class="td">
@@ -1181,6 +1283,12 @@
    </b>
    =
    <var>m1</var>
+   ≠
+   <b>
+    <var>m2</var>
+   </b>
+   = 3.49
+   <i>s</i>
    ≠
    <b>
     <var>m2</var>
@@ -1247,6 +1355,14 @@
     <var>m2</var>
    </b>
    )  =
+   <var>f</var>
+   ( 3.49
+   <i>s</i>
+   ;
+   <b>
+    <var>m2</var>
+   </b>
+   )  =
    <span class="matrix">
     <span class="tr">
      <span class="td">
@@ -1290,6 +1406,12 @@
    </b>
    =
    <var>m1</var>
+   &lt;
+   <b>
+    <var>m2</var>
+   </b>
+   = 3.49
+   <i>s</i>
    &lt;
    <b>
     <var>m2</var>
@@ -1356,6 +1478,14 @@
     <var>m2</var>
    </b>
    )  =
+   <var>f</var>
+   ( 3.49
+   <i>s</i>
+   ;
+   <b>
+    <var>m2</var>
+   </b>
+   )  =
    <span class="matrix">
     <span class="tr">
      <span class="td">
@@ -1399,6 +1529,12 @@
    </b>
    =
    <var>m1</var>
+   &gt;
+   <b>
+    <var>m2</var>
+   </b>
+   = 3.49
+   <i>s</i>
    &gt;
    <b>
     <var>m2</var>
@@ -1465,6 +1601,14 @@
     <var>m2</var>
    </b>
    )  =
+   <var>f</var>
+   ( 3.49
+   <i>s</i>
+   ;
+   <b>
+    <var>m2</var>
+   </b>
+   )  =
    <span class="matrix">
     <span class="tr">
      <span class="td">
@@ -1508,6 +1652,12 @@
    </b>
    =
    <var>m1</var>
+   ≥
+   <b>
+    <var>m2</var>
+   </b>
+   = 3.49
+   <i>s</i>
    ≥
    <b>
     <var>m2</var>
@@ -1574,6 +1724,14 @@
     <var>m2</var>
    </b>
    )  =
+   <var>f</var>
+   ( 3.49
+   <i>s</i>
+   ;
+   <b>
+    <var>m2</var>
+   </b>
+   )  =
    <span class="matrix">
     <span class="tr">
      <span class="td">
@@ -1617,6 +1775,12 @@
    </b>
    =
    <var>m1</var>
+   ≤
+   <b>
+    <var>m2</var>
+   </b>
+   = 3.49
+   <i>s</i>
    ≤
    <b>
     <var>m2</var>
@@ -1678,6 +1842,14 @@
    <var>f</var>
    (
    <var>m1</var>
+   ;
+   <b>
+    <var>m2</var>
+   </b>
+   )  =
+   <var>f</var>
+   ( 3.49
+   <i>s</i>
    ;
    <b>
     <var>m2</var>
@@ -1733,6 +1905,12 @@
    <b>
     <var>m2</var>
    </b>
+   = 3.49
+   <i>s</i>
+   and
+   <b>
+    <var>m2</var>
+   </b>
    =
    <span class="matrix">
     <span class="tr">
@@ -1795,6 +1973,14 @@
     <var>m2</var>
    </b>
    )  =
+   <var>f</var>
+   ( 3.49
+   <i>s</i>
+   ;
+   <b>
+    <var>m2</var>
+   </b>
+   )  =
    <span class="matrix">
     <span class="tr">
      <span class="td">
@@ -1838,6 +2024,12 @@
    </b>
    =
    <var>m1</var>
+   or
+   <b>
+    <var>m2</var>
+   </b>
+   = 3.49
+   <i>s</i>
    or
    <b>
     <var>m2</var>
@@ -1904,6 +2096,14 @@
     <var>m2</var>
    </b>
    )  =
+   <var>f</var>
+   ( 3.49
+   <i>s</i>
+   ;
+   <b>
+    <var>m2</var>
+   </b>
+   )  =
    <span class="matrix">
     <span class="tr">
      <span class="td">
@@ -1947,6 +2147,12 @@
    </b>
    =
    <var>m1</var>
+   xor
+   <b>
+    <var>m2</var>
+   </b>
+   = 3.49
+   <i>s</i>
    xor
    <b>
     <var>m2</var>
@@ -2008,6 +2214,14 @@
    <var>f</var>
    (
    <var>m1</var>
+   ;
+   <b>
+    <var>m2</var>
+   </b>
+   )  =
+   <var>f</var>
+   ( 3.49
+   <i>s</i>
    ;
    <b>
     <var>m2</var>

--- a/Tests/HP/Vectors/Operators/Scalar-operator-vector/hp-small-vector-with-units.html.stub
+++ b/Tests/HP/Vectors/Operators/Scalar-operator-vector/hp-small-vector-with-units.html.stub
@@ -49,6 +49,13 @@
     <span class="vec">⃗</span>
     b
    </var>
+   = -5
+   <i>dm</i>
+   +
+   <var>
+    <span class="vec">⃗</span>
+    b
+   </var>
    =
    <b class="b0">[</b>
    4.5 11.8 -44.5 12.5 20.9
@@ -78,6 +85,15 @@
    <var>f</var>
    (
    <var>a</var>
+   ;
+   <var>
+    <span class="vec">⃗</span>
+    b
+   </var>
+   )  =
+   <var>f</var>
+   ( -5
+   <i>dm</i>
    ;
    <var>
     <span class="vec">⃗</span>
@@ -1043,6 +1059,17 @@
     </var>
    </span>
    =
+   <span class="dvc">
+    -10
+    <i>s</i>
+    <span class="dvl">
+    </span>
+    <var>
+     <span class="vec">⃗</span>
+     b
+    </var>
+   </span>
+   =
    <b class="b0">[</b>
    -100 50 -33.33 25 -20
    <b class="b0">]</b>
@@ -1076,6 +1103,15 @@
    <var>f</var>
    (
    <var>a</var>
+   ;
+   <var>
+    <span class="vec">⃗</span>
+    b
+   </var>
+   )  =
+   <var>f</var>
+   ( -10
+   <i>s</i>
    ;
    <var>
     <span class="vec">⃗</span>
@@ -2152,6 +2188,13 @@
     <span class="vec">⃗</span>
     b
    </var>
+   = 2.7
+   <i>t</i>
+   mod
+   <var>
+    <span class="vec">⃗</span>
+    b
+   </var>
    =
    <b class="b0">[</b>
    2.7
@@ -2184,6 +2227,15 @@
    <var>f</var>
    (
    <var>a</var>
+   ;
+   <var>
+    <span class="vec">⃗</span>
+    b
+   </var>
+   )  =
+   <var>f</var>
+   ( 2.7
+   <i>t</i>
    ;
    <var>
     <span class="vec">⃗</span>
@@ -2334,6 +2386,13 @@
     <span class="vec">⃗</span>
     b
    </var>
+   = 0.5
+   <i>t</i>
+   mod
+   <var>
+    <span class="vec">⃗</span>
+    b
+   </var>
    =
    <b class="b0">[</b>
    0.5 0.5
@@ -2351,6 +2410,15 @@
    <var>f</var>
    (
    <var>a</var>
+   ;
+   <var>
+    <span class="vec">⃗</span>
+    b
+   </var>
+   )  =
+   <var>f</var>
+   ( 0.5
+   <i>t</i>
    ;
    <var>
     <span class="vec">⃗</span>
@@ -2585,6 +2653,13 @@
     <span class="vec">⃗</span>
     b
    </var>
+   = 8.2
+   <i>V</i>
+   ≡
+   <var>
+    <span class="vec">⃗</span>
+    b
+   </var>
    =
    <b class="b0">[</b>
    1 0 0 0 0 1 0 0
@@ -2613,6 +2688,15 @@
    <var>f</var>
    (
    <var>a</var>
+   ;
+   <var>
+    <span class="vec">⃗</span>
+    b
+   </var>
+   )  =
+   <var>f</var>
+   ( 8.2
+   <i>V</i>
    ;
    <var>
     <span class="vec">⃗</span>
@@ -2705,6 +2789,15 @@
     b
    </var>
    )  =
+   <var>f</var>
+   ( 0
+   <i>V</i>
+   ;
+   <var>
+    <span class="vec">⃗</span>
+    b
+   </var>
+   )  =
    <b class="b0">[</b>
    1 1 1 1 1 1
    <b class="b0">]</b>
@@ -2777,6 +2870,15 @@
    <var>f</var>
    (
    <var>a</var>
+   ;
+   <var>
+    <span class="vec">⃗</span>
+    b
+   </var>
+   )  =
+   <var>f</var>
+   ( 0
+   <i>V</i>
    ;
    <var>
     <span class="vec">⃗</span>
@@ -2988,6 +3090,15 @@
     b
    </var>
    )  =
+   <var>f</var>
+   ( 0
+   <i>Ω</i>
+   ;
+   <var>
+    <span class="vec">⃗</span>
+    b
+   </var>
+   )  =
    <b class="b0">[</b>
    0 0 0 0 0 0
    <b class="b0">]</b>
@@ -3035,6 +3146,13 @@
    </var>
    =
    <var>a</var>
+   ≠
+   <var>
+    <span class="vec">⃗</span>
+    b
+   </var>
+   = 7.3
+   <i>Ω</i>
    ≠
    <var>
     <span class="vec">⃗</span>
@@ -3964,6 +4082,13 @@
     <span class="vec">⃗</span>
     b
    </var>
+   = 9.1
+   <i>W</i>
+   ≤
+   <var>
+    <span class="vec">⃗</span>
+    b
+   </var>
    =
    <b class="b0">[</b>
    0 0 0 0 0 0 0 1
@@ -3980,6 +4105,15 @@
    <var>f</var>
    (
    <var>a</var>
+   ;
+   <var>
+    <span class="vec">⃗</span>
+    b
+   </var>
+   )  =
+   <var>f</var>
+   ( 9.1
+   <i>W</i>
    ;
    <var>
     <span class="vec">⃗</span>
@@ -5300,6 +5434,15 @@
    </var>
    · 2 ≤ 0
    <i>S</i>
+   = 2.7
+   <i>S</i>
+   +
+   <var>
+    <span class="vec">⃗</span>
+    y
+   </var>
+   · 2 ≤ 0
+   <i>S</i>
    =
    <b class="b0">[</b>
    0 1 0 0 1 0 0 1 0
@@ -5329,6 +5472,15 @@
    <var>f</var>
    (
    <var>x</var>
+   ;
+   <var>
+    <span class="vec">⃗</span>
+    y
+   </var>
+   )  =
+   <var>f</var>
+   ( 2.7
+   <i>S</i>
    ;
    <var>
     <span class="vec">⃗</span>
@@ -5421,6 +5573,15 @@
     y
    </var>
    )  =
+   <var>f</var>
+   ( 2.7
+   <i>S</i>
+   ;
+   <var>
+    <span class="vec">⃗</span>
+    y
+   </var>
+   )  =
    <b class="b0">[</b>
    2.21 -1.92
    <span class="err">+∞</span>
@@ -5438,6 +5599,12 @@
    <var>c</var>
    = 4 ·
    <var>x</var>
+   + 5
+   <i>S</i>
+   ≡ 0
+   <i>S</i>
+   = 4 · 2.7
+   <i>S</i>
    + 5
    <i>S</i>
    ≡ 0
@@ -5469,6 +5636,15 @@
     <span class="vec">⃗</span>
     y
    </var>
+   )  =
+   <var>f</var>
+   ( 2.7
+   <i>S</i>
+   ;
+   <var>
+    <span class="vec">⃗</span>
+    y
+   </var>
    )  = 15.8
    <i>S</i>
   </span>
@@ -5483,6 +5659,17 @@
    </var>
    =  (
    <var>x</var>
+   &gt; 0
+   <i>S</i>
+   )  ·
+   <i>S</i>
+   −
+   <var>
+    <span class="vec">⃗</span>
+    y
+   </var>
+   =  ( 2.7
+   <i>S</i>
    &gt; 0
    <i>S</i>
    )  ·
@@ -5526,6 +5713,15 @@
    <var>f</var>
    (
    <var>x</var>
+   ;
+   <var>
+    <span class="vec">⃗</span>
+    y
+   </var>
+   )  =
+   <var>f</var>
+   ( 2.7
+   <i>S</i>
    ;
    <var>
     <span class="vec">⃗</span>

--- a/Tests/HP/Vectors/Operators/Vector-operator-scalar/hp-large-vector-with-units.html.stub
+++ b/Tests/HP/Vectors/Operators/Vector-operator-scalar/hp-large-vector-with-units.html.stub
@@ -683,6 +683,13 @@
    \
    <var>b</var>
    =
+   <var>
+    <span class="vec">⃗</span>
+    x
+   </var>
+   \3.7
+   <i>m</i>
+   =
    <b class="b0">[</b>
    0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
    <span title="129 elements skipped.">...</span>
@@ -717,6 +724,15 @@
    </var>
    ;
    <var>b</var>
+   )  =
+   <var>f</var>
+   (
+   <var>
+    <span class="vec">⃗</span>
+    x
+   </var>
+   ; 3.7
+   <i>m</i>
    )  =
    <b class="b0">[</b>
    0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0

--- a/Tests/HP/Vectors/Operators/Vector-operator-scalar/hp-small-vector-with-units.html.stub
+++ b/Tests/HP/Vectors/Operators/Vector-operator-scalar/hp-small-vector-with-units.html.stub
@@ -91,6 +91,15 @@
    ;
    <var>b</var>
    )  =
+   <var>f</var>
+   (
+   <var>
+    <span class="vec">⃗</span>
+    a
+   </var>
+   ; -5
+   <i>dm</i>
+   )  =
    <b class="b0">[</b>
    4.5 11.8 -44.5 12.5 20.9
    <b class="b0">]</b>
@@ -978,6 +987,17 @@
     <var>b</var>
    </span>
    =
+   <span class="dvc">
+    <var>
+     <span class="vec">⃗</span>
+     a
+    </var>
+    <span class="dvl">
+    </span>
+    -10
+    <i>s</i>
+   </span>
+   =
    <b class="b0">[</b>
    -0.01 0.02 -0.03 0.04 -0.05
    <b class="b0">]</b>
@@ -1016,6 +1036,15 @@
    </var>
    ;
    <var>b</var>
+   )  =
+   <var>f</var>
+   (
+   <var>
+    <span class="vec">⃗</span>
+    a
+   </var>
+   ; -10
+   <i>s</i>
    )  =
    <b class="b0">[</b>
    -0.01 0.02 -0.03 0.04 -0.05
@@ -2539,6 +2568,13 @@
    ≡
    <var>b</var>
    =
+   <var>
+    <span class="vec">⃗</span>
+    a
+   </var>
+   ≡ 8.2
+   <i>V</i>
+   =
    <b class="b0">[</b>
    1 0 0 0 0 1 0 0
    <b class="b0">]</b>
@@ -2571,6 +2607,15 @@
    </var>
    ;
    <var>b</var>
+   )  =
+   <var>f</var>
+   (
+   <var>
+    <span class="vec">⃗</span>
+    a
+   </var>
+   ; 8.2
+   <i>V</i>
    )  =
    <b class="b0">[</b>
    1 0 0 0 0 1 0 0
@@ -4254,6 +4299,13 @@
    ≥
    <var>b1</var>
    =
+   <var>
+    <span class="vec">⃗</span>
+    a
+   </var>
+   ≥ 25.8
+   <i>C</i>
+   =
    <b class="b0">[</b>
    1 1 0
    <b class="b0">]</b>
@@ -4274,6 +4326,15 @@
    </var>
    ;
    <var>b1</var>
+   )  =
+   <var>f</var>
+   (
+   <var>
+    <span class="vec">⃗</span>
+    a
+   </var>
+   ; 25.8
+   <i>C</i>
    )  =
    <b class="b0">[</b>
    1 1 0
@@ -5517,6 +5578,15 @@
    · 2 ≤ 0
    <i>S</i>
    =
+   <var>
+    <span class="vec">⃗</span>
+    x
+   </var>
+   + 2.7
+   <i>S</i>
+   · 2 ≤ 0
+   <i>S</i>
+   =
    <b class="b0">[</b>
    0 0 0 0 1 0 0 0 0
    <b class="b0">]</b>
@@ -5551,6 +5621,15 @@
    ;
    <var>y</var>
    )  =
+   <var>f</var>
+   (
+   <var>
+    <span class="vec">⃗</span>
+    x
+   </var>
+   ; 2.7
+   <i>S</i>
+   )  =
    <b class="b0">[</b>
    11.4 2.9 5.4 9.7 -2.7 14 5.4 0.2 7.3
    <b class="b0">]</b>
@@ -5578,6 +5657,25 @@
     <span class="dvl">
     </span>
     <var>y</var>
+   </span>
+   + 1
+   <i>S</i>
+   ≥ 0
+   <i>S</i>
+   =
+   <span class="dvc">
+    <var>
+     <span class="vec">⃗</span>
+     x
+    </var>
+    <sup>
+     <small class="nth">⊙</small>
+     2
+    </sup>
+    <span class="dvl">
+    </span>
+    2.7
+    <i>S</i>
    </span>
    + 1
    <i>S</i>
@@ -5622,6 +5720,15 @@
    </var>
    ;
    <var>y</var>
+   )  =
+   <var>f</var>
+   (
+   <var>
+    <span class="vec">⃗</span>
+    x
+   </var>
+   ; 2.7
+   <i>S</i>
    )  =
    <b class="b0">[</b>
    14.33 3.31 1 7.85 25.3 28.39 1 11.01 2.34
@@ -5680,6 +5787,15 @@
    ;
    <var>y</var>
    )  =
+   <var>f</var>
+   (
+   <var>
+    <span class="vec">⃗</span>
+    x
+   </var>
+   ; 2.7
+   <i>S</i>
+   )  =
    <b class="b0">[</b>
    29 -5 5 22.2 -27.4 39.4 5 -15.8 12.6
    <b class="b0">]</b>
@@ -5705,6 +5821,17 @@
    <i>S</i>
    −
    <var>y</var>
+   =  (
+   <var>
+    <span class="vec">⃗</span>
+    x
+   </var>
+   &gt; 0
+   <i>S</i>
+   )  ·
+   <i>S</i>
+   − 2.7
+   <i>S</i>
    =
    <b class="b0">[</b>
    -1.7 -2.7 -2.7 -1.7 -2.7 -1.7 -2.7 -2.7 -1.7
@@ -5744,6 +5871,15 @@
    </var>
    ;
    <var>y</var>
+   )  =
+   <var>f</var>
+   (
+   <var>
+    <span class="vec">⃗</span>
+    x
+   </var>
+   ; 2.7
+   <i>S</i>
    )  =
    <b class="b0">[</b>
    0.3 -3.95 -2.7 -0.55 -6.75 1.6 -2.7 -5.3 -1.75

--- a/Tests/Matrices/Operators/matrix-operator-scalar/full-rectangular-with-units.html.stub
+++ b/Tests/Matrices/Operators/matrix-operator-scalar/full-rectangular-with-units.html.stub
@@ -105,6 +105,12 @@
    +
    <var>m2</var>
    =
+   <b>
+    <var>m1</var>
+   </b>
+   + 2.71
+   <i>s</i>
+   =
    <span class="matrix">
     <span class="tr">
      <span class="td">
@@ -202,6 +208,14 @@
    ;
    <var>m2</var>
    )  =
+   <var>f</var>
+   (
+   <b>
+    <var>m1</var>
+   </b>
+   ; 2.71
+   <i>s</i>
+   )  =
    <span class="matrix">
     <span class="tr">
      <span class="td">
@@ -287,6 +301,12 @@
    </b>
    −
    <var>m2</var>
+   =
+   <b>
+    <var>m1</var>
+   </b>
+   − 2.71
+   <i>s</i>
    =
    <span class="matrix">
     <span class="tr">
@@ -385,6 +405,14 @@
    ;
    <var>m2</var>
    )  =
+   <var>f</var>
+   (
+   <b>
+    <var>m1</var>
+   </b>
+   ; 2.71
+   <i>s</i>
+   )  =
    <span class="matrix">
     <span class="tr">
      <span class="td">
@@ -476,6 +504,12 @@
    </b>
    ·
    <var>m2</var>
+   =
+   <b>
+    <var>m1</var>
+   </b>
+   · 2.71
+   <i>s</i>
    =
    <span class="matrix">
     <span class="tr">
@@ -585,6 +619,14 @@
    </b>
    ;
    <var>m2</var>
+   )  =
+   <var>f</var>
+   (
+   <b>
+    <var>m1</var>
+   </b>
+   ; 2.71
+   <i>s</i>
    )  =
    <span class="matrix">
     <span class="tr">
@@ -685,6 +727,16 @@
     <var>m2</var>
    </span>
    =
+   <span class="dvc">
+    <b>
+     <var>m1</var>
+    </b>
+    <span class="dvl">
+    </span>
+    2.71
+    <i>s</i>
+   </span>
+   =
    <span class="matrix">
     <span class="tr">
      <span class="td">
@@ -748,6 +800,14 @@
    </b>
    ;
    <var>m2</var>
+   )  =
+   <var>f</var>
+   (
+   <b>
+    <var>m1</var>
+   </b>
+   ; 2.71
+   <i>s</i>
    )  =
    <span class="matrix">
     <span class="tr">
@@ -1078,6 +1138,12 @@
    \
    <var>m2</var>
    =
+   <b>
+    <var>m1</var>
+   </b>
+   \2.71
+   <i>s</i>
+   =
    <span class="matrix">
     <span class="tr">
      <span class="td">
@@ -1139,6 +1205,14 @@
    ;
    <var>m2</var>
    )  =
+   <var>f</var>
+   (
+   <b>
+    <var>m1</var>
+   </b>
+   ; 2.71
+   <i>s</i>
+   )  =
    <span class="matrix">
     <span class="tr">
      <span class="td">
@@ -1186,6 +1260,13 @@
    </b>
    <em>/</em>
    <var>m2</var>
+   =
+   <b>
+    <var>m1</var>
+   </b>
+   <em>/</em>
+   2.71
+   <i>s</i>
    =
    <span class="matrix">
     <span class="tr">
@@ -1247,6 +1328,14 @@
    </b>
    ;
    <var>m2</var>
+   )  =
+   <var>f</var>
+   (
+   <b>
+    <var>m1</var>
+   </b>
+   ; 2.71
+   <i>s</i>
    )  =
    <span class="matrix">
     <span class="tr">
@@ -1507,6 +1596,12 @@
    ≡
    <var>m2</var>
    =
+   <b>
+    <var>m1</var>
+   </b>
+   ≡ 2.71
+   <i>s</i>
+   =
    <span class="matrix">
     <span class="tr">
      <span class="td">
@@ -1568,6 +1663,14 @@
    ;
    <var>m2</var>
    )  =
+   <var>f</var>
+   (
+   <b>
+    <var>m1</var>
+   </b>
+   ; 2.71
+   <i>s</i>
+   )  =
    <span class="matrix">
     <span class="tr">
      <span class="td">
@@ -1615,6 +1718,12 @@
    </b>
    ≠
    <var>m2</var>
+   =
+   <b>
+    <var>m1</var>
+   </b>
+   ≠ 2.71
+   <i>s</i>
    =
    <span class="matrix">
     <span class="tr">
@@ -1676,6 +1785,14 @@
    </b>
    ;
    <var>m2</var>
+   )  =
+   <var>f</var>
+   (
+   <b>
+    <var>m1</var>
+   </b>
+   ; 2.71
+   <i>s</i>
    )  =
    <span class="matrix">
     <span class="tr">
@@ -1725,6 +1842,12 @@
    &lt;
    <var>m2</var>
    =
+   <b>
+    <var>m1</var>
+   </b>
+   &lt; 2.71
+   <i>s</i>
+   =
    <span class="matrix">
     <span class="tr">
      <span class="td">
@@ -1786,6 +1909,14 @@
    ;
    <var>m2</var>
    )  =
+   <var>f</var>
+   (
+   <b>
+    <var>m1</var>
+   </b>
+   ; 2.71
+   <i>s</i>
+   )  =
    <span class="matrix">
     <span class="tr">
      <span class="td">
@@ -1833,6 +1964,12 @@
    </b>
    &gt;
    <var>m2</var>
+   =
+   <b>
+    <var>m1</var>
+   </b>
+   &gt; 2.71
+   <i>s</i>
    =
    <span class="matrix">
     <span class="tr">
@@ -1894,6 +2031,14 @@
    </b>
    ;
    <var>m2</var>
+   )  =
+   <var>f</var>
+   (
+   <b>
+    <var>m1</var>
+   </b>
+   ; 2.71
+   <i>s</i>
    )  =
    <span class="matrix">
     <span class="tr">
@@ -1943,6 +2088,12 @@
    ≥
    <var>m2</var>
    =
+   <b>
+    <var>m1</var>
+   </b>
+   ≥ 2.71
+   <i>s</i>
+   =
    <span class="matrix">
     <span class="tr">
      <span class="td">
@@ -2004,6 +2155,14 @@
    ;
    <var>m2</var>
    )  =
+   <var>f</var>
+   (
+   <b>
+    <var>m1</var>
+   </b>
+   ; 2.71
+   <i>s</i>
+   )  =
    <span class="matrix">
     <span class="tr">
      <span class="td">
@@ -2051,6 +2210,12 @@
    </b>
    ≤
    <var>m2</var>
+   =
+   <b>
+    <var>m1</var>
+   </b>
+   ≤ 2.71
+   <i>s</i>
    =
    <span class="matrix">
     <span class="tr">
@@ -2112,6 +2277,14 @@
    </b>
    ;
    <var>m2</var>
+   )  =
+   <var>f</var>
+   (
+   <b>
+    <var>m1</var>
+   </b>
+   ; 2.71
+   <i>s</i>
    )  =
    <span class="matrix">
     <span class="tr">
@@ -2164,6 +2337,12 @@
    and
    <var>m2</var>
    =
+   <b>
+    <var>m1</var>
+   </b>
+   and 2.71
+   <i>s</i>
+   =
    <span class="matrix">
     <span class="tr">
      <span class="td">
@@ -2225,6 +2404,14 @@
    ;
    <var>m2</var>
    )  =
+   <var>f</var>
+   (
+   <b>
+    <var>m1</var>
+   </b>
+   ; 2.71
+   <i>s</i>
+   )  =
    <span class="matrix">
     <span class="tr">
      <span class="td">
@@ -2272,6 +2459,12 @@
    </b>
    or
    <var>m2</var>
+   =
+   <b>
+    <var>m1</var>
+   </b>
+   or 2.71
+   <i>s</i>
    =
    <span class="matrix">
     <span class="tr">
@@ -2334,6 +2527,14 @@
    ;
    <var>m2</var>
    )  =
+   <var>f</var>
+   (
+   <b>
+    <var>m1</var>
+   </b>
+   ; 2.71
+   <i>s</i>
+   )  =
    <span class="matrix">
     <span class="tr">
      <span class="td">
@@ -2381,6 +2582,12 @@
    </b>
    xor
    <var>m2</var>
+   =
+   <b>
+    <var>m1</var>
+   </b>
+   xor 2.71
+   <i>s</i>
    =
    <span class="matrix">
     <span class="tr">
@@ -2442,6 +2649,14 @@
    </b>
    ;
    <var>m2</var>
+   )  =
+   <var>f</var>
+   (
+   <b>
+    <var>m1</var>
+   </b>
+   ; 2.71
+   <i>s</i>
    )  =
    <span class="matrix">
     <span class="tr">

--- a/Tests/Matrices/Operators/scalar-operator-matrix/full-rectangular-with-units.html.stub
+++ b/Tests/Matrices/Operators/scalar-operator-matrix/full-rectangular-with-units.html.stub
@@ -104,6 +104,12 @@
    <b>
     <var>m2</var>
    </b>
+   = 3.49
+   <i>s</i>
+   +
+   <b>
+    <var>m2</var>
+   </b>
    =
    <span class="matrix">
     <span class="tr">
@@ -202,6 +208,14 @@
     <var>m2</var>
    </b>
    )  =
+   <var>f</var>
+   ( 3.49
+   <i>s</i>
+   ;
+   <b>
+    <var>m2</var>
+   </b>
+   )  =
    <span class="matrix">
     <span class="tr">
      <span class="td">
@@ -283,6 +297,12 @@
    </b>
    =
    <var>m1</var>
+   −
+   <b>
+    <var>m2</var>
+   </b>
+   = 3.49
+   <i>s</i>
    −
    <b>
     <var>m2</var>
@@ -385,6 +405,14 @@
     <var>m2</var>
    </b>
    )  =
+   <var>f</var>
+   ( 3.49
+   <i>s</i>
+   ;
+   <b>
+    <var>m2</var>
+   </b>
+   )  =
    <span class="matrix">
     <span class="tr">
      <span class="td">
@@ -472,6 +500,12 @@
    </b>
    =
    <var>m1</var>
+   ·
+   <b>
+    <var>m2</var>
+   </b>
+   = 3.49
+   <i>s</i>
    ·
    <b>
     <var>m2</var>
@@ -581,6 +615,14 @@
    <var>f</var>
    (
    <var>m1</var>
+   ;
+   <b>
+    <var>m2</var>
+   </b>
+   )  =
+   <var>f</var>
+   ( 3.49
+   <i>s</i>
    ;
    <b>
     <var>m2</var>
@@ -685,6 +727,16 @@
     </b>
    </span>
    =
+   <span class="dvc">
+    3.49
+    <i>s</i>
+    <span class="dvl">
+    </span>
+    <b>
+     <var>m2</var>
+    </b>
+   </span>
+   =
    <span class="matrix">
     <span class="tr">
      <span class="td">
@@ -746,6 +798,14 @@
    <var>f</var>
    (
    <var>m1</var>
+   ;
+   <b>
+    <var>m2</var>
+   </b>
+   )  =
+   <var>f</var>
+   ( 3.49
+   <i>s</i>
    ;
    <b>
     <var>m2</var>
@@ -906,6 +966,12 @@
    <b>
     <var>m2</var>
    </b>
+   = 3.49
+   <i>s</i>
+   \
+   <b>
+    <var>m2</var>
+   </b>
    =
    <span class="matrix">
     <span class="tr">
@@ -970,6 +1036,14 @@
     <var>m2</var>
    </b>
    )  =
+   <var>f</var>
+   ( 3.49
+   <i>s</i>
+   ;
+   <b>
+    <var>m2</var>
+   </b>
+   )  =
    <span class="matrix">
     <span class="tr">
      <span class="td">
@@ -1015,6 +1089,12 @@
    </b>
    =
    <var>m1</var>
+   <em>/</em>
+   <b>
+    <var>m2</var>
+   </b>
+   = 3.49
+   <i>s</i>
    <em>/</em>
    <b>
     <var>m2</var>
@@ -1078,6 +1158,14 @@
    <var>f</var>
    (
    <var>m1</var>
+   ;
+   <b>
+    <var>m2</var>
+   </b>
+   )  =
+   <var>f</var>
+   ( 3.49
+   <i>s</i>
    ;
    <b>
     <var>m2</var>
@@ -1343,6 +1431,12 @@
    <b>
     <var>m2</var>
    </b>
+   = 3.49
+   <i>s</i>
+   ≡
+   <b>
+    <var>m2</var>
+   </b>
    =
    <span class="matrix">
     <span class="tr">
@@ -1405,6 +1499,14 @@
     <var>m2</var>
    </b>
    )  =
+   <var>f</var>
+   ( 3.49
+   <i>s</i>
+   ;
+   <b>
+    <var>m2</var>
+   </b>
+   )  =
    <span class="matrix">
     <span class="tr">
      <span class="td">
@@ -1448,6 +1550,12 @@
    </b>
    =
    <var>m1</var>
+   ≠
+   <b>
+    <var>m2</var>
+   </b>
+   = 3.49
+   <i>s</i>
    ≠
    <b>
     <var>m2</var>
@@ -1514,6 +1622,14 @@
     <var>m2</var>
    </b>
    )  =
+   <var>f</var>
+   ( 3.49
+   <i>s</i>
+   ;
+   <b>
+    <var>m2</var>
+   </b>
+   )  =
    <span class="matrix">
     <span class="tr">
      <span class="td">
@@ -1557,6 +1673,12 @@
    </b>
    =
    <var>m1</var>
+   &lt;
+   <b>
+    <var>m2</var>
+   </b>
+   = 3.49
+   <i>s</i>
    &lt;
    <b>
     <var>m2</var>
@@ -1623,6 +1745,14 @@
     <var>m2</var>
    </b>
    )  =
+   <var>f</var>
+   ( 3.49
+   <i>s</i>
+   ;
+   <b>
+    <var>m2</var>
+   </b>
+   )  =
    <span class="matrix">
     <span class="tr">
      <span class="td">
@@ -1666,6 +1796,12 @@
    </b>
    =
    <var>m1</var>
+   &gt;
+   <b>
+    <var>m2</var>
+   </b>
+   = 3.49
+   <i>s</i>
    &gt;
    <b>
     <var>m2</var>
@@ -1732,6 +1868,14 @@
     <var>m2</var>
    </b>
    )  =
+   <var>f</var>
+   ( 3.49
+   <i>s</i>
+   ;
+   <b>
+    <var>m2</var>
+   </b>
+   )  =
    <span class="matrix">
     <span class="tr">
      <span class="td">
@@ -1775,6 +1919,12 @@
    </b>
    =
    <var>m1</var>
+   ≥
+   <b>
+    <var>m2</var>
+   </b>
+   = 3.49
+   <i>s</i>
    ≥
    <b>
     <var>m2</var>
@@ -1841,6 +1991,14 @@
     <var>m2</var>
    </b>
    )  =
+   <var>f</var>
+   ( 3.49
+   <i>s</i>
+   ;
+   <b>
+    <var>m2</var>
+   </b>
+   )  =
    <span class="matrix">
     <span class="tr">
      <span class="td">
@@ -1884,6 +2042,12 @@
    </b>
    =
    <var>m1</var>
+   ≤
+   <b>
+    <var>m2</var>
+   </b>
+   = 3.49
+   <i>s</i>
    ≤
    <b>
     <var>m2</var>
@@ -1945,6 +2109,14 @@
    <var>f</var>
    (
    <var>m1</var>
+   ;
+   <b>
+    <var>m2</var>
+   </b>
+   )  =
+   <var>f</var>
+   ( 3.49
+   <i>s</i>
    ;
    <b>
     <var>m2</var>
@@ -2000,6 +2172,12 @@
    <b>
     <var>m2</var>
    </b>
+   = 3.49
+   <i>s</i>
+   and
+   <b>
+    <var>m2</var>
+   </b>
    =
    <span class="matrix">
     <span class="tr">
@@ -2062,6 +2240,14 @@
     <var>m2</var>
    </b>
    )  =
+   <var>f</var>
+   ( 3.49
+   <i>s</i>
+   ;
+   <b>
+    <var>m2</var>
+   </b>
+   )  =
    <span class="matrix">
     <span class="tr">
      <span class="td">
@@ -2105,6 +2291,12 @@
    </b>
    =
    <var>m1</var>
+   or
+   <b>
+    <var>m2</var>
+   </b>
+   = 3.49
+   <i>s</i>
    or
    <b>
     <var>m2</var>
@@ -2171,6 +2363,14 @@
     <var>m2</var>
    </b>
    )  =
+   <var>f</var>
+   ( 3.49
+   <i>s</i>
+   ;
+   <b>
+    <var>m2</var>
+   </b>
+   )  =
    <span class="matrix">
     <span class="tr">
      <span class="td">
@@ -2214,6 +2414,12 @@
    </b>
    =
    <var>m1</var>
+   xor
+   <b>
+    <var>m2</var>
+   </b>
+   = 3.49
+   <i>s</i>
    xor
    <b>
     <var>m2</var>
@@ -2275,6 +2481,14 @@
    <var>f</var>
    (
    <var>m1</var>
+   ;
+   <b>
+    <var>m2</var>
+   </b>
+   )  =
+   <var>f</var>
+   ( 3.49
+   <i>s</i>
    ;
    <b>
     <var>m2</var>

--- a/Tests/Vectors/Operators/Scalar-operator-vector/small-vector-with-units.html.stub
+++ b/Tests/Vectors/Operators/Scalar-operator-vector/small-vector-with-units.html.stub
@@ -55,6 +55,13 @@
     <span class="vec">⃗</span>
     b
    </var>
+   = -5
+   <i>dm</i>
+   +
+   <var>
+    <span class="vec">⃗</span>
+    b
+   </var>
    =
    <b class="b0">[</b>
    4.5
@@ -92,6 +99,15 @@
    <var>f</var>
    (
    <var>a</var>
+   ;
+   <var>
+    <span class="vec">⃗</span>
+    b
+   </var>
+   )  =
+   <var>f</var>
+   ( -5
+   <i>dm</i>
    ;
    <var>
     <span class="vec">⃗</span>
@@ -1211,6 +1227,17 @@
     </var>
    </span>
    =
+   <span class="dvc">
+    -10
+    <i>s</i>
+    <span class="dvl">
+    </span>
+    <var>
+     <span class="vec">⃗</span>
+     b
+    </var>
+   </span>
+   =
    <b class="b0">[</b>
    -100
    <i>kg</i>
@@ -1265,6 +1292,15 @@
    <var>f</var>
    (
    <var>a</var>
+   ;
+   <var>
+    <span class="vec">⃗</span>
+    b
+   </var>
+   )  =
+   <var>f</var>
+   ( -10
+   <i>s</i>
    ;
    <var>
     <span class="vec">⃗</span>
@@ -2625,6 +2661,13 @@
     <span class="vec">⃗</span>
     b
    </var>
+   = 2.7
+   <i>t</i>
+   mod
+   <var>
+    <span class="vec">⃗</span>
+    b
+   </var>
    =
    <b class="b0">[</b>
    2.7
@@ -2668,6 +2711,15 @@
    <var>f</var>
    (
    <var>a</var>
+   ;
+   <var>
+    <span class="vec">⃗</span>
+    b
+   </var>
+   )  =
+   <var>f</var>
+   ( 2.7
+   <i>t</i>
    ;
    <var>
     <span class="vec">⃗</span>
@@ -2835,6 +2887,13 @@
     <span class="vec">⃗</span>
     b
    </var>
+   = 0.5
+   <i>t</i>
+   mod
+   <var>
+    <span class="vec">⃗</span>
+    b
+   </var>
    =
    <b class="b0">[</b>
    0.5
@@ -2854,6 +2913,15 @@
    <var>f</var>
    (
    <var>a</var>
+   ;
+   <var>
+    <span class="vec">⃗</span>
+    b
+   </var>
+   )  =
+   <var>f</var>
+   ( 0.5
+   <i>t</i>
    ;
    <var>
     <span class="vec">⃗</span>
@@ -3096,6 +3164,13 @@
     <span class="vec">⃗</span>
     b
    </var>
+   = 8.2
+   <i>V</i>
+   ≡
+   <var>
+    <span class="vec">⃗</span>
+    b
+   </var>
    =
    <b class="b0">[</b>
    1 0 0 0 0 1 0 0
@@ -3124,6 +3199,15 @@
    <var>f</var>
    (
    <var>a</var>
+   ;
+   <var>
+    <span class="vec">⃗</span>
+    b
+   </var>
+   )  =
+   <var>f</var>
+   ( 8.2
+   <i>V</i>
    ;
    <var>
     <span class="vec">⃗</span>
@@ -3218,6 +3302,15 @@
    <var>f</var>
    (
    <var>a</var>
+   ;
+   <var>
+    <span class="vec">⃗</span>
+    b
+   </var>
+   )  =
+   <var>f</var>
+   ( 0
+   <i>V</i>
    ;
    <var>
     <span class="vec">⃗</span>
@@ -3296,6 +3389,15 @@
    <var>f</var>
    (
    <var>a</var>
+   ;
+   <var>
+    <span class="vec">⃗</span>
+    b
+   </var>
+   )  =
+   <var>f</var>
+   ( 0
+   <i>V</i>
    ;
    <var>
     <span class="vec">⃗</span>
@@ -3529,6 +3631,15 @@
     b
    </var>
    )  =
+   <var>f</var>
+   ( 0
+   <i>Ω</i>
+   ;
+   <var>
+    <span class="vec">⃗</span>
+    b
+   </var>
+   )  =
    <b class="b0">[</b>
    0 0 0 0 0 0
    <b class="b0">]</b>
@@ -3574,6 +3685,13 @@
    </var>
    =
    <var>a</var>
+   ≠
+   <var>
+    <span class="vec">⃗</span>
+    b
+   </var>
+   = 7.3
+   <i>Ω</i>
    ≠
    <var>
     <span class="vec">⃗</span>
@@ -4575,6 +4693,13 @@
     <span class="vec">⃗</span>
     b
    </var>
+   = 9.1
+   <i>W</i>
+   ≤
+   <var>
+    <span class="vec">⃗</span>
+    b
+   </var>
    =
    <b class="b0">[</b>
    0 0 0 0 0 0 0 1
@@ -4591,6 +4716,15 @@
    <var>f</var>
    (
    <var>a</var>
+   ;
+   <var>
+    <span class="vec">⃗</span>
+    b
+   </var>
+   )  =
+   <var>f</var>
+   ( 9.1
+   <i>W</i>
    ;
    <var>
     <span class="vec">⃗</span>
@@ -6017,6 +6151,15 @@
    </var>
    · 2 ≤ 0
    <i>S</i>
+   = 2.7
+   <i>S</i>
+   +
+   <var>
+    <span class="vec">⃗</span>
+    y
+   </var>
+   · 2 ≤ 0
+   <i>S</i>
    =
    <b class="b0">[</b>
    0 1 0 0 1 0 0 1 0
@@ -6046,6 +6189,15 @@
    <var>f</var>
    (
    <var>x</var>
+   ;
+   <var>
+    <span class="vec">⃗</span>
+    y
+   </var>
+   )  =
+   <var>f</var>
+   ( 2.7
+   <i>S</i>
    ;
    <var>
     <span class="vec">⃗</span>
@@ -6154,6 +6306,15 @@
     y
    </var>
    )  =
+   <var>f</var>
+   ( 2.7
+   <i>S</i>
+   ;
+   <var>
+    <span class="vec">⃗</span>
+    y
+   </var>
+   )  =
    <b class="b0">[</b>
    2.21
    <i>S</i>
@@ -6187,6 +6348,12 @@
    <i>S</i>
    ≡ 0
    <i>S</i>
+   = 4 · 2.7
+   <i>S</i>
+   + 5
+   <i>S</i>
+   ≡ 0
+   <i>S</i>
    = 0
   </span>
  </p>
@@ -6214,6 +6381,15 @@
     <span class="vec">⃗</span>
     y
    </var>
+   )  =
+   <var>f</var>
+   ( 2.7
+   <i>S</i>
+   ;
+   <var>
+    <span class="vec">⃗</span>
+    y
+   </var>
    )  = 15.8
    <i>S</i>
   </span>
@@ -6228,6 +6404,17 @@
    </var>
    =  (
    <var>x</var>
+   &gt; 0
+   <i>S</i>
+   )  ·
+   <i>S</i>
+   −
+   <var>
+    <span class="vec">⃗</span>
+    y
+   </var>
+   =  ( 2.7
+   <i>S</i>
    &gt; 0
    <i>S</i>
    )  ·
@@ -6287,6 +6474,15 @@
    <var>f</var>
    (
    <var>x</var>
+   ;
+   <var>
+    <span class="vec">⃗</span>
+    y
+   </var>
+   )  =
+   <var>f</var>
+   ( 2.7
+   <i>S</i>
    ;
    <var>
     <span class="vec">⃗</span>

--- a/Tests/Vectors/Operators/Vector-operator-scalar/large-vector-with-units.html.stub
+++ b/Tests/Vectors/Operators/Vector-operator-scalar/large-vector-with-units.html.stub
@@ -1468,6 +1468,13 @@
    \
    <var>b</var>
    =
+   <var>
+    <span class="vec">⃗</span>
+    x
+   </var>
+   \3.7
+   <i>m</i>
+   =
    <b class="b0">[</b>
    0 0 0 0 0 0 0 0 0 0
    <i>m</i>
@@ -1536,6 +1543,15 @@
    </var>
    ;
    <var>b</var>
+   )  =
+   <var>f</var>
+   (
+   <var>
+    <span class="vec">⃗</span>
+    x
+   </var>
+   ; 3.7
+   <i>m</i>
    )  =
    <b class="b0">[</b>
    0 0 0 0 0 0 0 0 0 0

--- a/Tests/Vectors/Operators/Vector-operator-scalar/small-vector-with-units.html.stub
+++ b/Tests/Vectors/Operators/Vector-operator-scalar/small-vector-with-units.html.stub
@@ -105,6 +105,15 @@
    ;
    <var>b</var>
    )  =
+   <var>f</var>
+   (
+   <var>
+    <span class="vec">⃗</span>
+    a
+   </var>
+   ; -5
+   <i>dm</i>
+   )  =
    <b class="b0">[</b>
    4.5
    <i>m</i>
@@ -1146,6 +1155,17 @@
     <var>b</var>
    </span>
    =
+   <span class="dvc">
+    <var>
+     <span class="vec">⃗</span>
+     a
+    </var>
+    <span class="dvl">
+    </span>
+    -10
+    <i>s</i>
+   </span>
+   =
    <b class="b0">[</b>
    -0.01
    <i>kg</i>
@@ -1200,6 +1220,15 @@
    </var>
    ;
    <var>b</var>
+   )  =
+   <var>f</var>
+   (
+   <var>
+    <span class="vec">⃗</span>
+    a
+   </var>
+   ; -10
+   <i>s</i>
    )  =
    <b class="b0">[</b>
    -0.01
@@ -3095,6 +3124,13 @@
    ≡
    <var>b</var>
    =
+   <var>
+    <span class="vec">⃗</span>
+    a
+   </var>
+   ≡ 8.2
+   <i>V</i>
+   =
    <b class="b0">[</b>
    1 0 0 0 0 1 0 0
    <b class="b0">]</b>
@@ -3127,6 +3163,15 @@
    </var>
    ;
    <var>b</var>
+   )  =
+   <var>f</var>
+   (
+   <var>
+    <span class="vec">⃗</span>
+    a
+   </var>
+   ; 8.2
+   <i>V</i>
    )  =
    <b class="b0">[</b>
    1 0 0 0 0 1 0 0
@@ -4936,6 +4981,13 @@
    ≥
    <var>b1</var>
    =
+   <var>
+    <span class="vec">⃗</span>
+    a
+   </var>
+   ≥ 25.8
+   <i>C</i>
+   =
    <b class="b0">[</b>
    1 1 0
    <b class="b0">]</b>
@@ -4956,6 +5008,15 @@
    </var>
    ;
    <var>b1</var>
+   )  =
+   <var>f</var>
+   (
+   <var>
+    <span class="vec">⃗</span>
+    a
+   </var>
+   ; 25.8
+   <i>C</i>
    )  =
    <b class="b0">[</b>
    1 1 0
@@ -6337,6 +6398,15 @@
    · 2 ≤ 0
    <i>S</i>
    =
+   <var>
+    <span class="vec">⃗</span>
+    x
+   </var>
+   + 2.7
+   <i>S</i>
+   · 2 ≤ 0
+   <i>S</i>
+   =
    <b class="b0">[</b>
    0 0 0 0 1 0 0 0 0
    <b class="b0">]</b>
@@ -6370,6 +6440,15 @@
    </var>
    ;
    <var>y</var>
+   )  =
+   <var>f</var>
+   (
+   <var>
+    <span class="vec">⃗</span>
+    x
+   </var>
+   ; 2.7
+   <i>S</i>
    )  =
    <b class="b0">[</b>
    11.4
@@ -6420,6 +6499,25 @@
    ≥ 0
    <i>S</i>
    =
+   <span class="dvc">
+    <var>
+     <span class="vec">⃗</span>
+     x
+    </var>
+    <sup>
+     <small class="nth">⊙</small>
+     2
+    </sup>
+    <span class="dvl">
+    </span>
+    2.7
+    <i>S</i>
+   </span>
+   + 1
+   <i>S</i>
+   ≥ 0
+   <i>S</i>
+   =
    <b class="b0">[</b>
    1 1 1 1 1 1 1 1 1
    <b class="b0">]</b>
@@ -6458,6 +6556,15 @@
    </var>
    ;
    <var>y</var>
+   )  =
+   <var>f</var>
+   (
+   <var>
+    <span class="vec">⃗</span>
+    x
+   </var>
+   ; 2.7
+   <i>S</i>
    )  =
    <b class="b0">[</b>
    14.33
@@ -6532,6 +6639,15 @@
    ;
    <var>y</var>
    )  =
+   <var>f</var>
+   (
+   <var>
+    <span class="vec">⃗</span>
+    x
+   </var>
+   ; 2.7
+   <i>S</i>
+   )  =
    <b class="b0">[</b>
    29
    <i>S</i>
@@ -6575,6 +6691,17 @@
    <i>S</i>
    −
    <var>y</var>
+   =  (
+   <var>
+    <span class="vec">⃗</span>
+    x
+   </var>
+   &gt; 0
+   <i>S</i>
+   )  ·
+   <i>S</i>
+   − 2.7
+   <i>S</i>
    =
    <b class="b0">[</b>
    -1.7
@@ -6630,6 +6757,15 @@
    </var>
    ;
    <var>y</var>
+   )  =
+   <var>f</var>
+   (
+   <var>
+    <span class="vec">⃗</span>
+    x
+   </var>
+   ; 2.7
+   <i>S</i>
    )  =
    <b class="b0">[</b>
    0.3


### PR DESCRIPTION
Fix #90 

Since this fix rendering issues, compare-renderings checks will fail... (I wasn't very familiar to these checks. Then, I was unsure I should run `python .github/scripts/compare_renderings.py --write` to update the stubs.)