### PR TITLE
Feature/vscode preview

### DIFF
--- a/.github/workflows/build-vscode.yml
+++ b/.github/workflows/build-vscode.yml
@@ -1,0 +1,81 @@
+name: Build VS Code extension
+
+# Builds a per-platform VSIX of the CalcpadCE preview extension. The CLI is
+# cross-published from a single Linux runner (dotnet can target every RID), and
+# @vscode/vsce packages a platform-specific VSIX per target. On a tag (or manual
+# dispatch with publish=true) and when a VSCE_PAT secret is present, the VSIX is
+# also published to the Marketplace.
+
+on:
+  push:
+    tags:
+      - 'vscode-v*'
+    paths:
+      - 'Calcpad.VSCode/**'
+      - 'Calcpad.Cli/**'
+      - 'Calcpad.Core/**'
+      - 'Calcpad.OpenXml/**'
+      - '.github/workflows/build-vscode.yml'
+  pull_request:
+    paths:
+      - 'Calcpad.VSCode/**'
+      - 'Calcpad.Cli/**'
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: 'Publish to the VS Code Marketplace'
+        type: boolean
+        default: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: Calcpad.VSCode
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: win32-x64
+            rid: win-x64
+          - target: linux-x64
+            rid: linux-x64
+          - target: darwin-x64
+            rid: osx-x64
+          - target: darwin-arm64
+            rid: osx-arm64
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Publish CLI (${{ matrix.rid }})
+        run: node scripts/publish-cli.mjs ${{ matrix.rid }}
+
+      - name: Build extension
+        run: npm run build
+
+      - name: Package VSIX (${{ matrix.target }})
+        run: npx @vscode/vsce package --target ${{ matrix.target }} -o calcpad-preview-${{ matrix.target }}.vsix
+
+      - name: Upload VSIX artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: calcpad-preview-${{ matrix.target }}
+          path: Calcpad.VSCode/calcpad-preview-${{ matrix.target }}.vsix
+
+      - name: Publish to Marketplace
+        if: ${{ (startsWith(github.ref, 'refs/tags/vscode-v') || inputs.publish) && env.VSCE_PAT != '' }}
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: npx @vscode/vsce publish --target ${{ matrix.target }} --packagePath calcpad-preview-${{ matrix.target }}.vsix

--- a/Calcpad.Cli/CalcpadReader.cs
+++ b/Calcpad.Cli/CalcpadReader.cs
@@ -12,9 +12,13 @@ namespace Calcpad.Cli
     internal static class CalcpadReader
     {
         private static readonly StringBuilder _stringBuilder = new();
-        internal static string Read(string fileName)
+        internal static string Read(string fileName) => ProcessLines(ReadLines(fileName));
+
+        //Same preprocessing as Read, but from an in-memory source string (used by the preview server).
+        internal static string ReadText(string text) => ProcessLines(text.EnumerateLines());
+
+        private static string ProcessLines(SpanLineEnumerator inputLines)
         {
-            var inputLines = ReadLines(fileName);
             var outputLines = new List<string>();
             var hasForm = false;
             foreach (var line in inputLines)

--- a/Calcpad.Cli/PreviewServer.cs
+++ b/Calcpad.Cli/PreviewServer.cs
@@ -49,8 +49,16 @@ namespace Calcpad.Cli
                 {
                     var request = JsonSerializer.Deserialize<PreviewRequest>(line, JsonOptions);
                     id = request?.Id ?? 0;
-                    var html = Render(request, settings);
-                    response = new PreviewResponse { Id = id, Ok = true, Html = html };
+                    if (request?.Export is not null)
+                    {
+                        var outPath = Export(request, settings);
+                        response = new PreviewResponse { Id = id, Ok = true, OutPath = outPath };
+                    }
+                    else
+                    {
+                        var html = Render(request, settings);
+                        response = new PreviewResponse { Id = id, Ok = true, Html = html };
+                    }
                 }
                 catch (Exception ex)
                 {
@@ -80,6 +88,55 @@ namespace Calcpad.Cli
             if (req is null)
                 return Body(string.Empty);
 
+            var unwrappedCode = Prepare(req, settings, out var macroErrorHtml);
+            if (macroErrorHtml is not null)
+                return Body(macroErrorHtml);
+
+            var parser = new ExpressionParser { Settings = settings };
+            parser.Parse(unwrappedCode, true, false);
+            return Body(parser.HtmlResult);
+        }
+
+        // Renders the worksheet (with the current input values) to a file via the same
+        // Converter the one-shot CLI uses, so the export matches the calculated output.
+        private static string Export(PreviewRequest req, Settings settings)
+        {
+            var format = (req.Export.Format ?? "html").Trim().ToLowerInvariant();
+            var outPath = req.Export.OutPath;
+            if (string.IsNullOrWhiteSpace(outPath))
+                throw new ArgumentException("Missing export output path.");
+
+            var unwrappedCode = Prepare(req, settings, out var macroErrorHtml);
+            if (macroErrorHtml is not null)
+                throw new InvalidOperationException("Cannot export: the worksheet has macro or #include errors.");
+
+            var getXml = format is "docx";
+            var parser = new ExpressionParser { Settings = settings };
+            parser.Parse(unwrappedCode, true, getXml);
+
+            var converter = new Converter(isSilent: true, isBodyOnly: false);
+            switch (format)
+            {
+                case "html":
+                case "htm":
+                    converter.ToHtml(parser.HtmlResult, outPath);
+                    break;
+                case "docx":
+                    converter.ToOpenXml(parser.HtmlResult, outPath, parser.OpenXmlExpressions);
+                    break;
+                default:
+                    throw new ArgumentException($"Unsupported export format: {format}");
+            }
+            return outPath;
+        }
+
+        // Shared preparation: resolve paths, set units, read & macro-expand the source,
+        // and inject interactive input values. Returns the unwrapped code, or null with
+        // macroErrorHtml set when macro/include expansion failed.
+        private static string Prepare(PreviewRequest req, Settings settings, out string macroErrorHtml)
+        {
+            macroErrorHtml = null;
+
             // Resolve relative #include / image paths against the document folder when known.
             // Resolve to an absolute path BEFORE changing the working directory, otherwise a
             // relative SourcePath would be resolved against the previous request's folder.
@@ -102,14 +159,15 @@ namespace Calcpad.Cli
             var macroParser = new MacroParser { Include = CalcpadReader.Include };
             var hasMacroErrors = macroParser.Parse(code, out var unwrappedCode, null, 0, true);
             if (hasMacroErrors)
-                return Body(CalcpadReader.CodeToHtml(unwrappedCode));
+            {
+                macroErrorHtml = CalcpadReader.CodeToHtml(unwrappedCode);
+                return null;
+            }
 
             if (req.InputValues is { Count: > 0 })
                 unwrappedCode = ApplyInputValues(unwrappedCode, req.InputValues);
 
-            var parser = new ExpressionParser { Settings = settings };
-            parser.Parse(unwrappedCode, true, false);
-            return Body(parser.HtmlResult);
+            return unwrappedCode;
         }
 
         // Injects the interactive input-field values back into the source as {value} tokens,
@@ -155,6 +213,7 @@ namespace Calcpad.Cli
             public string SourceText { get; set; }
             public string Units { get; set; }
             public List<InputValue> InputValues { get; set; }
+            public ExportRequest Export { get; set; }
         }
 
         private sealed class InputValue
@@ -163,11 +222,18 @@ namespace Calcpad.Cli
             public string Value { get; set; }
         }
 
+        private sealed class ExportRequest
+        {
+            public string Format { get; set; }
+            public string OutPath { get; set; }
+        }
+
         private sealed class PreviewResponse
         {
             public long Id { get; set; }
             public bool Ok { get; set; }
             public string Html { get; set; }
+            public string OutPath { get; set; }
             public string Error { get; set; }
         }
     }

--- a/Calcpad.Cli/PreviewServer.cs
+++ b/Calcpad.Cli/PreviewServer.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using Calcpad.Core;
+
+namespace Calcpad.Cli
+{
+    // Long-running headless render server for the VS Code preview extension.
+    // Protocol: newline-delimited JSON (NDJSON) — one PreviewRequest per stdin line,
+    // one PreviewResponse per stdout line. Keeps a warm process so live preview is fast.
+    internal static class PreviewServer
+    {
+        private static readonly JsonSerializerOptions JsonOptions = new()
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            PropertyNameCaseInsensitive = true,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        };
+
+        internal static void Run()
+        {
+            // The render pipeline and any reused helper may write to the console; redirect
+            // Console.Out to nowhere so it can never pollute the NDJSON protocol stream.
+            Console.SetOut(TextWriter.Null);
+
+            // Always produce '.' as the decimal separator, regardless of machine locale.
+            CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
+            Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+
+            using var stdout = new StreamWriter(Console.OpenStandardOutput(), new UTF8Encoding(false)) { AutoFlush = true };
+            using var stdin = new StreamReader(Console.OpenStandardInput(), Encoding.UTF8);
+
+            var settings = LoadSettings();
+
+            string line;
+            while ((line = stdin.ReadLine()) is not null)
+            {
+                if (line.Length == 0)
+                    continue;
+
+                PreviewResponse response;
+                long id = 0;
+                try
+                {
+                    var request = JsonSerializer.Deserialize<PreviewRequest>(line, JsonOptions);
+                    id = request?.Id ?? 0;
+                    var html = Render(request, settings);
+                    response = new PreviewResponse { Id = id, Ok = true, Html = html };
+                }
+                catch (Exception ex)
+                {
+                    response = new PreviewResponse { Id = id, Ok = false, Error = ex.Message };
+                }
+                stdout.WriteLine(JsonSerializer.Serialize(response, JsonOptions));
+            }
+        }
+
+        private static Settings LoadSettings()
+        {
+            try
+            {
+                return Program.GetSettings();
+            }
+            catch
+            {
+                // GetSettings may try to prompt on a corrupt settings file; never block here.
+                var s = new Settings();
+                s.Math.Decimals = 6;
+                return s;
+            }
+        }
+
+        private static string Render(PreviewRequest req, Settings settings)
+        {
+            if (req is null)
+                return Body(string.Empty);
+
+            // Resolve relative #include / image paths against the document folder when known.
+            // Resolve to an absolute path BEFORE changing the working directory, otherwise a
+            // relative SourcePath would be resolved against the previous request's folder.
+            string fullPath = null;
+            if (!string.IsNullOrEmpty(req.SourcePath))
+            {
+                fullPath = Path.GetFullPath(req.SourcePath);
+                var dir = Path.GetDirectoryName(fullPath);
+                if (!string.IsNullOrWhiteSpace(dir) && Directory.Exists(dir))
+                    Directory.SetCurrentDirectory(dir);
+            }
+
+            // Reset units each render so settings don't leak across documents (warm process).
+            settings.Units = string.IsNullOrEmpty(req.Units) ? "m" : req.Units;
+
+            var code = req.SourceText is not null
+                ? CalcpadReader.ReadText(req.SourceText)
+                : CalcpadReader.Read(fullPath);
+
+            var macroParser = new MacroParser { Include = CalcpadReader.Include };
+            var hasMacroErrors = macroParser.Parse(code, out var unwrappedCode, null, 0, true);
+            if (hasMacroErrors)
+                return Body(CalcpadReader.CodeToHtml(unwrappedCode));
+
+            if (req.InputValues is { Count: > 0 })
+                unwrappedCode = ApplyInputValues(unwrappedCode, req.InputValues);
+
+            var parser = new ExpressionParser { Settings = settings };
+            parser.Parse(unwrappedCode, true, false);
+            return Body(parser.HtmlResult);
+        }
+
+        // Injects the interactive input-field values back into the source as {value} tokens,
+        // mirroring Calcpad.Wpf MainWindow.SetInputFields, then lets the parser recalc.
+        private static string ApplyInputValues(string source, List<InputValue> inputs)
+        {
+            var byLine = new Dictionary<int, Queue<string>>();
+            foreach (var iv in inputs)
+            {
+                if (iv is null || iv.Line <= 0)
+                    continue;
+
+                if (!byLine.TryGetValue(iv.Line, out var queue))
+                {
+                    queue = new Queue<string>();
+                    byLine[iv.Line] = queue;
+                }
+                queue.Enqueue((iv.Value ?? string.Empty).Trim());
+            }
+            if (byLine.Count == 0)
+                return source;
+
+            var lines = source.Replace("\r\n", "\n").Split('\n');
+            var sb = new StringBuilder();
+            for (var i = 0; i < lines.Length; ++i)
+            {
+                if (byLine.TryGetValue(i + 1, out var queue) && queue.Count != 0)
+                {
+                    sb.Clear();
+                    if (MacroParser.SetLineInputFields(lines[i].TrimEnd(), sb, queue, true))
+                        lines[i] = sb.ToString();
+                }
+            }
+            return string.Join('\n', lines);
+        }
+
+        private static string Body(string html) => $"<div class=\"calcpad-output\">{html}</div>";
+
+        private sealed class PreviewRequest
+        {
+            public long Id { get; set; }
+            public string SourcePath { get; set; }
+            public string SourceText { get; set; }
+            public string Units { get; set; }
+            public List<InputValue> InputValues { get; set; }
+        }
+
+        private sealed class InputValue
+        {
+            public int Line { get; set; }
+            public string Value { get; set; }
+        }
+
+        private sealed class PreviewResponse
+        {
+            public long Id { get; set; }
+            public bool Ok { get; set; }
+            public string Html { get; set; }
+            public string Error { get; set; }
+        }
+    }
+}

--- a/Calcpad.Cli/Program.cs
+++ b/Calcpad.Cli/Program.cs
@@ -70,6 +70,12 @@ namespace Calcpad.Cli
 
         static void Main()
         {
+            var cliArgs = Environment.GetCommandLineArgs();
+            if (cliArgs.Length > 1 && cliArgs[1] == "--serve")
+            {
+                PreviewServer.Run();
+                return;
+            }
             Thread.CurrentThread.CurrentUICulture = new CultureInfo(_currentCultureName);
             try
             {
@@ -216,7 +222,7 @@ namespace Calcpad.Cli
                 $".{ext}" :
                 $".{_currentCultureName}.{ext}";
 
-        static Settings GetSettings()
+        internal static Settings GetSettings()
         {
             Settings settings = new();
             settings.Math.Decimals = 6;

--- a/Calcpad.VSCode/.gitignore
+++ b/Calcpad.VSCode/.gitignore
@@ -1,0 +1,13 @@
+node_modules/
+dist/
+bin/
+*.vsix
+
+# The repo-root .gitignore ignores these globally; they are required for the extension.
+!package.json
+!package-lock.json
+# Generated webview assets
+media/main.js
+media/main.js.map
+media/calcpad.css
+media/jquery-3.6.3.min.js

--- a/Calcpad.VSCode/.vscode/launch.json
+++ b/Calcpad.VSCode/.vscode/launch.json
@@ -1,0 +1,13 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run Calcpad Preview Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
+      "outFiles": ["${workspaceFolder}/dist/**/*.js"],
+      "preLaunchTask": "npm: build"
+    }
+  ]
+}

--- a/Calcpad.VSCode/.vscode/tasks.json
+++ b/Calcpad.VSCode/.vscode/tasks.json
@@ -1,0 +1,12 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "npm",
+      "script": "build",
+      "problemMatcher": ["$tsc", "$esbuild"],
+      "label": "npm: build",
+      "detail": "Copy assets and bundle the extension + webview."
+    }
+  ]
+}

--- a/Calcpad.VSCode/.vscodeignore
+++ b/Calcpad.VSCode/.vscodeignore
@@ -1,0 +1,20 @@
+# Sources & build tooling — only ship the bundled output
+src/**
+media/main.ts
+scripts/**
+esbuild.mjs
+tsconfig.json
+.vscode/**
+**/*.map
+**/*.ts
+node_modules/**
+.gitignore
+
+# CLI extras we don't need in the preview bundle
+bin/**/doc/HELP*
+bin/**/doc/help*
+bin/**/doc/readme*
+bin/**/doc/LICENSE*
+bin/**/wkhtmltopdf*
+bin/**/Examples/**
+bin/**/*.pdb

--- a/Calcpad.VSCode/README.md
+++ b/Calcpad.VSCode/README.md
@@ -1,0 +1,48 @@
+# CalcpadCE Preview (VS Code)
+
+Live, interactive preview for CalcpadCE `.cpd` worksheets — similar to the built-in
+Markdown preview. The preview re-renders as you type and supports the interactive
+input fields (`?` prompts) and unit selectors with full recalculation.
+
+It renders through the same engine as the desktop app, by talking to a bundled
+`Calcpad.Cli` running in a long-lived `--serve` (NDJSON over stdio) mode.
+
+## Usage
+
+- Open a `.cpd` file.
+- Run **Calcpad: Open Preview to the Side** (`Ctrl+K V`) or **Calcpad: Open Preview** (`Ctrl+Shift+V`),
+  or click the preview icon in the editor title bar.
+- Edit the worksheet — the preview updates after a short debounce.
+- Change an input field or unit selector in the preview — the worksheet recalculates.
+
+## Settings
+
+| Setting | Default | Description |
+| --- | --- | --- |
+| `calcpad.preview.debounceMs` | `300` | Delay before re-rendering after an edit. |
+| `calcpad.preview.updateOnSaveOnly` | `false` | Only refresh on save. |
+| `calcpad.cli.path` | `""` | Override the CLI used for rendering (native exe or `Cli.dll`). |
+
+## Development
+
+```pwsh
+cd Calcpad.VSCode
+npm install
+dotnet build ..\Calcpad.Cli   # provides the dev-fallback Cli.dll
+npm run build
+# Press F5 to launch the Extension Development Host
+```
+
+`npm run build` extracts the worksheet CSS from `Calcpad.Cli/doc/template.html`,
+copies jQuery into `media/`, and bundles the extension and webview client with esbuild.
+
+In the Extension Development Host the extension auto-discovers the repo's built
+`Calcpad.Cli/bin/<Config>/net10.0/Cli.dll`. For a packaged build, run
+`npm run publish-cli` to publish a self-contained CLI into `bin/<rid>/`, then
+`vsce package --target <platform>`.
+
+## Limitations (MVP)
+
+- Worksheet fonts fall back to system fonts (no embedded `@font-face`).
+- Embedded `<script>` worksheets (e.g. Plotly 3D examples) don't run under the webview CSP.
+- `?` input fields inside macros/included modules may not map back to editable inputs.

--- a/Calcpad.VSCode/README.md
+++ b/Calcpad.VSCode/README.md
@@ -13,7 +13,19 @@ It renders through the same engine as the desktop app, by talking to a bundled
 - Run **Calcpad: Open Preview to the Side** (`Ctrl+K V`) or **Calcpad: Open Preview** (`Ctrl+Shift+V`),
   or click the preview icon in the editor title bar.
 - Edit the worksheet — the preview updates after a short debounce.
+- Toggle **Interactive** / **Final** in the preview toolbar: Interactive shows editable input
+  fields that recalculate live; Final shows the read-only calculated output.
 - Change an input field or unit selector in the preview — the worksheet recalculates.
+
+## Export
+
+Export the calculated worksheet (using the values currently shown in the preview):
+
+- Toolbar buttons **Export HTML** / **Export DOCX** in the preview.
+- Commands **Calcpad: Export to HTML** / **Calcpad: Export to Word (DOCX)** (command palette
+  or right-click a `.cpd` in the Explorer).
+
+PDF export is not yet available (it requires bundling `wkhtmltopdf`).
 
 ## Settings
 
@@ -46,3 +58,4 @@ In the Extension Development Host the extension auto-discovers the repo's built
 - Worksheet fonts fall back to system fonts (no embedded `@font-face`).
 - Embedded `<script>` worksheets (e.g. Plotly 3D examples) don't run under the webview CSP.
 - `?` input fields inside macros/included modules may not map back to editable inputs.
+- PDF export is not bundled yet (needs `wkhtmltopdf`).

--- a/Calcpad.VSCode/esbuild.mjs
+++ b/Calcpad.VSCode/esbuild.mjs
@@ -1,0 +1,37 @@
+import * as esbuild from 'esbuild';
+
+const watch = process.argv.includes('--watch');
+
+/** @type {import('esbuild').BuildOptions} */
+const extensionConfig = {
+  entryPoints: ['src/extension.ts'],
+  bundle: true,
+  outfile: 'dist/extension.js',
+  external: ['vscode'],
+  format: 'cjs',
+  platform: 'node',
+  target: 'node18',
+  sourcemap: true,
+  logLevel: 'info'
+};
+
+/** @type {import('esbuild').BuildOptions} */
+const webviewConfig = {
+  entryPoints: ['media/main.ts'],
+  bundle: true,
+  outfile: 'media/main.js',
+  format: 'iife',
+  platform: 'browser',
+  target: 'es2020',
+  sourcemap: true,
+  logLevel: 'info'
+};
+
+if (watch) {
+  const ctxExt = await esbuild.context(extensionConfig);
+  const ctxWeb = await esbuild.context(webviewConfig);
+  await Promise.all([ctxExt.watch(), ctxWeb.watch()]);
+  console.log('esbuild watching...');
+} else {
+  await Promise.all([esbuild.build(extensionConfig), esbuild.build(webviewConfig)]);
+}

--- a/Calcpad.VSCode/language-configuration.json
+++ b/Calcpad.VSCode/language-configuration.json
@@ -1,0 +1,24 @@
+{
+  "comments": {
+    "lineComment": "'"
+  },
+  "brackets": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"]
+  ],
+  "autoClosingPairs": [
+    { "open": "{", "close": "}" },
+    { "open": "[", "close": "]" },
+    { "open": "(", "close": ")" },
+    { "open": "\"", "close": "\"" },
+    { "open": "'", "close": "'" }
+  ],
+  "surroundingPairs": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"],
+    ["\"", "\""],
+    ["'", "'"]
+  ]
+}

--- a/Calcpad.VSCode/media/main.ts
+++ b/Calcpad.VSCode/media/main.ts
@@ -1,0 +1,221 @@
+// Webview client for the Calcpad preview. jQuery is loaded as a global <script>
+// before this bundle, so we reference it as `$`. Communicates with the extension
+// host via the VS Code webview messaging API.
+declare const $: any;
+declare function acquireVsCodeApi(): {
+  postMessage(msg: unknown): void;
+  getState(): any;
+  setState(state: any): void;
+};
+
+type Mode = 'interactive' | 'final';
+
+const vscode = acquireVsCodeApi();
+const root = document.getElementById('calcpad-root')!;
+
+let mode: Mode = (vscode.getState()?.mode as Mode) || 'interactive';
+let lastHtml = '<div class="calcpad-status">Rendering…</div>';
+let imgBase = '';
+
+function isNumeric(s: string): boolean {
+  return /^-?\d+(?:\.\d+)?$/.test(s);
+}
+
+function getTargetId(el: any): string | undefined {
+  const name = $(el).attr('name');
+  if (name && name.length > 0) {
+    return name;
+  }
+  return $(el).data('target');
+}
+
+function getValue(id: string, source: any): string {
+  let value = '';
+  let target = $('#' + id + ' input');
+  if (target.get(0) == null) {
+    target = $('#' + id + ' .eq u');
+    target.each(function (this: any) {
+      value += $(this).text() + ';';
+    });
+    $(source).prop('disabled', true);
+  } else {
+    target.each(function (this: any) {
+      value += $(this).val() + ';';
+    });
+  }
+  if (value.length > 1) {
+    value = value.slice(0, -1);
+  }
+  return value;
+}
+
+// In calculated output the parser renders filled input fields as read-only
+// <u class="input-N">value</u>. For interactive mode we turn them back into
+// editable <input> elements so the user can change them and trigger a recalc.
+function makeInputsEditable(): void {
+  $('#calcpad-root u[class*="input-"]').each(function (this: HTMLElement) {
+    const m = this.className.match(/input-\d+/);
+    if (!m) {
+      return;
+    }
+    const value = $(this).text();
+    const size = Math.max(2, String(value).length);
+    const input = $('<input type="text" name="Var">')
+      .addClass(m[0])
+      .attr('size', size)
+      .val(value);
+    $(this).replaceWith(input);
+  });
+}
+
+function collectInputs(): { line: number; value: string }[] {
+  return $("input[type='text'][name='Var']")
+    .map(function (this: any) {
+      const m = this.className.match(/input-(\d+)/);
+      return { line: m ? parseInt(m[1], 10) : NaN, value: $(this).val() };
+    })
+    .get()
+    .filter((iv: any) => !isNaN(iv.line));
+}
+
+function currentUnits(): string | undefined {
+  const u = $('#Units');
+  return u.length ? u.val() : undefined;
+}
+
+function sendRecalc(type: 'inputChange' | 'unitChange'): void {
+  vscode.postMessage({ type, inputValues: collectInputs(), units: currentUnits() });
+}
+
+function rewriteImages(): void {
+  if (!imgBase) {
+    return;
+  }
+  $('#calcpad-root img').each(function (this: HTMLImageElement) {
+    const raw = this.getAttribute('src');
+    if (!raw) {
+      return;
+    }
+    const src = raw.trim();
+    if (/^(https?:|data:|vscode-webview:|vscode-resource:|blob:)/.test(src)) {
+      return;
+    }
+    try {
+      this.setAttribute('src', new URL(src, imgBase).toString());
+    } catch {
+      /* ignore malformed src */
+    }
+  });
+}
+
+// Replicates the worksheet template's $(document).ready() wiring (minus the
+// WPF-only chrome.webview hooks) and adds the recalc round-trip hooks.
+function initContent(): void {
+  $('.dvcs:has(.block) > :first-child').html('&hairsp;');
+
+  $('#Units')
+    .off('change.cp')
+    .on('change.cp', function (this: any) {
+      $('.Units').text($(this).val());
+      sendRecalc('unitChange');
+    });
+
+  $('.fold > :first-child')
+    .off('click.cp')
+    .on('click.cp', function (this: any) {
+      const parent = $(this).parent();
+      if (parent.hasClass('fold')) {
+        parent.removeClass('fold').addClass('unfold');
+      } else {
+        parent.removeClass('unfold').addClass('fold');
+      }
+    });
+
+  $('select').each(function (this: any) {
+    if ($(this).prop('id') !== 'Units') {
+      const id = getTargetId(this);
+      if (id) {
+        $(this).val(getValue(id, this));
+      }
+    }
+  });
+
+  $('select')
+    .off('change.cpsel')
+    .on('change.cpsel', function (this: any) {
+      if ($(this).prop('id') === 'Units') {
+        return;
+      }
+      const id = getTargetId(this);
+      if (id) {
+        const target = $('#' + id + ' input');
+        const values = String($(this).val()).split(';');
+        target.each(function (this: any, index: number) {
+          $(this).val(values[index]);
+        });
+        sendRecalc('inputChange');
+      }
+    });
+
+  $('.money').each(function (this: any) {
+    $(this).text(Number($(this).text()).toFixed(2));
+  });
+
+  $("input[name='Var']")
+    .off('change.cpinput')
+    .on('change.cpinput', function (this: any) {
+      const e = $(this);
+      const s = e.val();
+      if (isNumeric(s)) {
+        e.css('color', '').removeAttr('title');
+      } else {
+        e.css('color', 'red').attr('title', 'Invalid number');
+      }
+      sendRecalc('inputChange');
+    });
+
+  rewriteImages();
+}
+
+function applyRender(): void {
+  root.innerHTML = lastHtml;
+  if (mode === 'interactive') {
+    makeInputsEditable();
+  }
+  initContent();
+}
+
+function setMode(next: Mode): void {
+  mode = next;
+  vscode.setState({ mode });
+  $('#cp-mode-interactive').toggleClass('cp-active', mode === 'interactive');
+  $('#cp-mode-final').toggleClass('cp-active', mode === 'final');
+  applyRender();
+}
+
+window.addEventListener('message', (event) => {
+  const data = event.data;
+  if (!data || typeof data.type !== 'string') {
+    return;
+  }
+  if (data.type === 'update') {
+    lastHtml = data.html;
+    if (typeof data.imgBase === 'string') {
+      imgBase = data.imgBase;
+    }
+    applyRender();
+  } else if (data.type === 'error') {
+    root.innerHTML = '<div class="calcpad-error"></div>';
+    const div = root.querySelector('.calcpad-error');
+    if (div) {
+      div.textContent = data.message;
+    }
+  }
+});
+
+// Wire the mode toolbar (exists in the persistent shell, outside #calcpad-root).
+$(function () {
+  $('#cp-mode-interactive').on('click', () => setMode('interactive'));
+  $('#cp-mode-final').on('click', () => setMode('final'));
+  setMode(mode);
+});

--- a/Calcpad.VSCode/media/main.ts
+++ b/Calcpad.VSCode/media/main.ts
@@ -213,9 +213,15 @@ window.addEventListener('message', (event) => {
   }
 });
 
-// Wire the mode toolbar (exists in the persistent shell, outside #calcpad-root).
+function sendExport(format: 'html' | 'docx'): void {
+  vscode.postMessage({ type: 'export', format, inputValues: collectInputs(), units: currentUnits() });
+}
+
+// Wire the toolbar (exists in the persistent shell, outside #calcpad-root).
 $(function () {
   $('#cp-mode-interactive').on('click', () => setMode('interactive'));
   $('#cp-mode-final').on('click', () => setMode('final'));
+  $('#cp-export-html').on('click', () => sendExport('html'));
+  $('#cp-export-docx').on('click', () => sendExport('docx'));
   setMode(mode);
 });

--- a/Calcpad.VSCode/package-lock.json
+++ b/Calcpad.VSCode/package-lock.json
@@ -1,0 +1,2901 @@
+{
+  "name": "calcpad-preview",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "calcpad-preview",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "@types/vscode": "^1.84.0",
+        "@vscode/vsce": "^2.24.0",
+        "esbuild": "^0.20.0",
+        "typescript": "^5.4.0"
+      },
+      "engines": {
+        "vscode": "^1.84.0"
+      }
+    },
+    "node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-auth": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.10.1.tgz",
+      "integrity": "sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-util": "^1.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-client": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.10.1.tgz",
+      "integrity": "sha512-Nh5PhEOeY6PrnxNPsEHRr9eimxLwgLlpmguQaHKBinFYA/RU9+kOYVOQqOrTsCL+KSxrLLl1gD8Dk5BFW/7l/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.22.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-rest-pipeline": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.23.0.tgz",
+      "integrity": "sha512-Evs1INHo+jUjwHi1T6SG6Ua/LHOQBCLuKEEE6efIpt4ZOoNonaT1kP32GoOcdNDbfqsD2445CPri3MubBy5DEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "@typespec/ts-http-runtime": "^0.3.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-tracing": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.3.1.tgz",
+      "integrity": "sha512-9MWKevR7Hz8kNzzPLfX4EAtGM2b8mr50HPDBvio96bURP/9C+HjdH3sBlLSNNrvRAr5/k/svoH457gB5IKpmwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-util": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.13.1.tgz",
+      "integrity": "sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/identity": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.13.1.tgz",
+      "integrity": "sha512-5C/2WD5Vb1lHnZS16dNQRPMjN6oV/Upba+C9nBIs15PmOi6A3ZGs4Lr2u60zw4S04gi+u3cEXiqTVP7M4Pz3kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-client": "^1.9.2",
+        "@azure/core-rest-pipeline": "^1.17.0",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/logger": "^1.0.0",
+        "@azure/msal-browser": "^5.5.0",
+        "@azure/msal-node": "^5.1.0",
+        "open": "^10.1.0",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/logger": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.3.0.tgz",
+      "integrity": "sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/msal-browser": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.11.0.tgz",
+      "integrity": "sha512-zkGNYS3TwY8lUpPIafAmsFCYZbgFixY9y/LZB9GUg0IILoHTqpN26j5OrkL1AQThh/YdZsawe4iWXfp85lFVxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "16.6.2"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-common": {
+      "version": "16.6.2",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.6.2.tgz",
+      "integrity": "sha512-hQjjsekAjB00cM1EmatWJlzhEoK2Qhz7Rj5gvM6tYf8iL7RM3tkxlpU9fG0+ofkulzg9AEEA6dIEnSmDr5ZqUA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-node": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.2.2.tgz",
+      "integrity": "sha512-toS+2AePxqyzb0YOKttDOOiSl3jrkK9aiqIvpurpis0O34QcIS5gToqrgT39p04Dpxw3YoUU0lxJKTpSFFfA6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "16.6.2",
+        "jsonwebtoken": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.2.tgz",
+      "integrity": "sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.2.tgz",
+      "integrity": "sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.2.tgz",
+      "integrity": "sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.2.tgz",
+      "integrity": "sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.2.tgz",
+      "integrity": "sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.2.tgz",
+      "integrity": "sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.2.tgz",
+      "integrity": "sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.2.tgz",
+      "integrity": "sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.2.tgz",
+      "integrity": "sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.2.tgz",
+      "integrity": "sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.2.tgz",
+      "integrity": "sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.2.tgz",
+      "integrity": "sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.2.tgz",
+      "integrity": "sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.2.tgz",
+      "integrity": "sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.2.tgz",
+      "integrity": "sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.2.tgz",
+      "integrity": "sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.2.tgz",
+      "integrity": "sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.2.tgz",
+      "integrity": "sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.2.tgz",
+      "integrity": "sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.2.tgz",
+      "integrity": "sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.2.tgz",
+      "integrity": "sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.2.tgz",
+      "integrity": "sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.2.tgz",
+      "integrity": "sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.120.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.120.0.tgz",
+      "integrity": "sha512-feaT4Rst+FkTch5zz/ZbNCxoIvo55YU80Be2kiL7OJcod4+CUYf2lUBPdIJzozNnSEMq1VRTGrWEcCGFB3fBmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typespec/ts-http-runtime": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.5.tgz",
+      "integrity": "sha512-yURCknZhvywvQItHMMmFSo+fq5arCUIyz/CVk7jD89MSai7dkaX8ufjCWp3NttLojoTVbcE72ri+be/TnEbMHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@vscode/vsce": {
+      "version": "2.32.0",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-2.32.0.tgz",
+      "integrity": "sha512-3EFJfsgrSftIqt3EtdRcAygy/OJ3hstyI1cDmIgkU9CFZW5C+3djr6mfosndCUqcVYuyjmxOK1xmFp/Bq7+NIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/identity": "^4.1.0",
+        "@vscode/vsce-sign": "^2.0.0",
+        "azure-devops-node-api": "^12.5.0",
+        "chalk": "^2.4.2",
+        "cheerio": "^1.0.0-rc.9",
+        "cockatiel": "^3.1.2",
+        "commander": "^6.2.1",
+        "form-data": "^4.0.0",
+        "glob": "^7.0.6",
+        "hosted-git-info": "^4.0.2",
+        "jsonc-parser": "^3.2.0",
+        "leven": "^3.1.0",
+        "markdown-it": "^12.3.2",
+        "mime": "^1.3.4",
+        "minimatch": "^3.0.3",
+        "parse-semver": "^1.1.1",
+        "read": "^1.0.7",
+        "semver": "^7.5.2",
+        "tmp": "^0.2.1",
+        "typed-rest-client": "^1.8.4",
+        "url-join": "^4.0.1",
+        "xml2js": "^0.5.0",
+        "yauzl": "^2.3.1",
+        "yazl": "^2.2.2"
+      },
+      "bin": {
+        "vsce": "vsce"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "optionalDependencies": {
+        "keytar": "^7.7.0"
+      }
+    },
+    "node_modules/@vscode/vsce-sign": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign/-/vsce-sign-2.0.9.tgz",
+      "integrity": "sha512-8IvaRvtFyzUnGGl3f5+1Cnor3LqaUWvhaUjAYO8Y39OUYlOf3cRd+dowuQYLpZcP3uwSG+mURwjEBOSq4SOJ0g==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optionalDependencies": {
+        "@vscode/vsce-sign-alpine-arm64": "2.0.6",
+        "@vscode/vsce-sign-alpine-x64": "2.0.6",
+        "@vscode/vsce-sign-darwin-arm64": "2.0.6",
+        "@vscode/vsce-sign-darwin-x64": "2.0.6",
+        "@vscode/vsce-sign-linux-arm": "2.0.6",
+        "@vscode/vsce-sign-linux-arm64": "2.0.6",
+        "@vscode/vsce-sign-linux-x64": "2.0.6",
+        "@vscode/vsce-sign-win32-arm64": "2.0.6",
+        "@vscode/vsce-sign-win32-x64": "2.0.6"
+      }
+    },
+    "node_modules/@vscode/vsce-sign-alpine-arm64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-alpine-arm64/-/vsce-sign-alpine-arm64-2.0.6.tgz",
+      "integrity": "sha512-wKkJBsvKF+f0GfsUuGT0tSW0kZL87QggEiqNqK6/8hvqsXvpx8OsTEc3mnE1kejkh5r+qUyQ7PtF8jZYN0mo8Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "alpine"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-alpine-x64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-alpine-x64/-/vsce-sign-alpine-x64-2.0.6.tgz",
+      "integrity": "sha512-YoAGlmdK39vKi9jA18i4ufBbd95OqGJxRvF3n6ZbCyziwy3O+JgOpIUPxv5tjeO6gQfx29qBivQ8ZZTUF2Ba0w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "alpine"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-darwin-arm64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-darwin-arm64/-/vsce-sign-darwin-arm64-2.0.6.tgz",
+      "integrity": "sha512-5HMHaJRIQuozm/XQIiJiA0W9uhdblwwl2ZNDSSAeXGO9YhB9MH5C4KIHOmvyjUnKy4UCuiP43VKpIxW1VWP4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-darwin-x64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-darwin-x64/-/vsce-sign-darwin-x64-2.0.6.tgz",
+      "integrity": "sha512-25GsUbTAiNfHSuRItoQafXOIpxlYj+IXb4/qarrXu7kmbH94jlm5sdWSCKrrREs8+GsXF1b+l3OB7VJy5jsykw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-linux-arm": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-arm/-/vsce-sign-linux-arm-2.0.6.tgz",
+      "integrity": "sha512-UndEc2Xlq4HsuMPnwu7420uqceXjs4yb5W8E2/UkaHBB9OWCwMd3/bRe/1eLe3D8kPpxzcaeTyXiK3RdzS/1CA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-linux-arm64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-arm64/-/vsce-sign-linux-arm64-2.0.6.tgz",
+      "integrity": "sha512-cfb1qK7lygtMa4NUl2582nP7aliLYuDEVpAbXJMkDq1qE+olIw/es+C8j1LJwvcRq1I2yWGtSn3EkDp9Dq5FdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-linux-x64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-x64/-/vsce-sign-linux-x64-2.0.6.tgz",
+      "integrity": "sha512-/olerl1A4sOqdP+hjvJ1sbQjKN07Y3DVnxO4gnbn/ahtQvFrdhUi0G1VsZXDNjfqmXw57DmPi5ASnj/8PGZhAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-win32-arm64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-win32-arm64/-/vsce-sign-win32-arm64-2.0.6.tgz",
+      "integrity": "sha512-ivM/MiGIY0PJNZBoGtlRBM/xDpwbdlCWomUWuLmIxbi1Cxe/1nooYrEQoaHD8ojVRgzdQEUzMsRbyF5cJJgYOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-win32-x64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-win32-x64/-/vsce-sign-win32-x64-2.0.6.tgz",
+      "integrity": "sha512-mgth9Kvze+u8CruYMmhHw6Zgy3GRX2S+Ed5oSokDEK5vPEwGGKnmuXua9tmFhomeAnhgJnL4DCna3TiNuGrBTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/azure-devops-node-api": {
+      "version": "12.5.0",
+      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-12.5.0.tgz",
+      "integrity": "sha512-R5eFskGvOm3U/GzeAuxRkUsAl0hrAwGgWn6zAd2KrZmrEhWZVqLew4OOupbQlXUuojUzpGtq62SmdhJ06N88og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tunnel": "0.0.6",
+        "typed-rest-client": "^1.8.4"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/cockatiel": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/cockatiel/-/cockatiel-3.2.1.tgz",
+      "integrity": "sha512-gfrHV6ZPkquExvMh9IOkKsBzNDk6sDuZ6DdBGUBkvFnTCqCxzpuq48RySgP0AnaqQkw2zynOFj9yly6T1Q2G5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.2.tgz",
+      "integrity": "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.20.2",
+        "@esbuild/android-arm": "0.20.2",
+        "@esbuild/android-arm64": "0.20.2",
+        "@esbuild/android-x64": "0.20.2",
+        "@esbuild/darwin-arm64": "0.20.2",
+        "@esbuild/darwin-x64": "0.20.2",
+        "@esbuild/freebsd-arm64": "0.20.2",
+        "@esbuild/freebsd-x64": "0.20.2",
+        "@esbuild/linux-arm": "0.20.2",
+        "@esbuild/linux-arm64": "0.20.2",
+        "@esbuild/linux-ia32": "0.20.2",
+        "@esbuild/linux-loong64": "0.20.2",
+        "@esbuild/linux-mips64el": "0.20.2",
+        "@esbuild/linux-ppc64": "0.20.2",
+        "@esbuild/linux-riscv64": "0.20.2",
+        "@esbuild/linux-s390x": "0.20.2",
+        "@esbuild/linux-x64": "0.20.2",
+        "@esbuild/netbsd-x64": "0.20.2",
+        "@esbuild/openbsd-x64": "0.20.2",
+        "@esbuild/sunos-x64": "0.20.2",
+        "@esbuild/win32-arm64": "0.20.2",
+        "@esbuild/win32-ia32": "0.20.2",
+        "@esbuild/win32-x64": "0.20.2"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "dev": true,
+      "license": "(MIT OR WTFPL)",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/keytar": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/keytar/-/keytar-7.9.0.tgz",
+      "integrity": "sha512-VPD8mtVtm5JNtA2AErl6Chp06JBfy7diFQ7TQQhdpWOl6MrCRB+eRbvAZUsbGQS9kiMq0coJsy0W0vHpDCkWsQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^4.3.0",
+        "prebuild-install": "^7.0.1"
+      }
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/linkify-it": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
+      "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^1.0.1"
+      }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/markdown-it": {
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
+      "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "~2.1.0",
+        "linkify-it": "^3.0.1",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.js"
+      }
+    },
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/node-abi": {
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+      "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-semver": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/parse-semver/-/parse-semver-1.1.1.tgz",
+      "integrity": "sha512-Eg1OuNntBMH0ojvEKSrvDSnwLmvVuUOSdylH/pSCPNMIspLlweJyIWXCE+k/5hm3cj/EBUYwmWkjhBALNP4LXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^5.1.0"
+      }
+    },
+    "node_modules/parse-semver/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "optional": true,
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/read": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+      "integrity": "sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "mute-stream": "~0.0.4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/typed-rest-client": {
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.11.tgz",
+      "integrity": "sha512-5UvfMpd1oelmUPRbbaVnq+rHP7ng2cE4qoQkQeAqxRL6PklkxsM0g32/HL0yfvruK6ojQ5x8EE+HF4YV6DtuCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "qs": "^6.9.1",
+        "tunnel": "0.0.6",
+        "underscore": "^1.12.1"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/underscore": {
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.0.tgz",
+      "integrity": "sha512-+t2Z/GwkZQDtu00813aP66ygViGtPHKhhoFZpQKpKrE+9jIgES+Zw+mFNaDWOVRKiuJjuqKHzD3B1sfGg8+ZOQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/yazl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
+      "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3"
+      }
+    }
+  }
+}

--- a/Calcpad.VSCode/package.json
+++ b/Calcpad.VSCode/package.json
@@ -41,6 +41,16 @@
         "title": "Calcpad: Open Preview to the Side",
         "category": "Calcpad",
         "icon": "$(open-preview)"
+      },
+      {
+        "command": "calcpad.exportHtml",
+        "title": "Calcpad: Export to HTML",
+        "category": "Calcpad"
+      },
+      {
+        "command": "calcpad.exportDocx",
+        "title": "Calcpad: Export to Word (DOCX)",
+        "category": "Calcpad"
       }
     ],
     "keybindings": [
@@ -73,6 +83,14 @@
         {
           "command": "calcpad.showPreviewToSide",
           "when": "editorLangId == calcpad"
+        },
+        {
+          "command": "calcpad.exportHtml",
+          "when": "editorLangId == calcpad"
+        },
+        {
+          "command": "calcpad.exportDocx",
+          "when": "editorLangId == calcpad"
         }
       ],
       "explorer/context": [
@@ -80,6 +98,16 @@
           "command": "calcpad.showPreview",
           "when": "resourceExtname == .cpd || resourceExtname == .cpdz",
           "group": "navigation"
+        },
+        {
+          "command": "calcpad.exportHtml",
+          "when": "resourceExtname == .cpd || resourceExtname == .cpdz",
+          "group": "calcpad@1"
+        },
+        {
+          "command": "calcpad.exportDocx",
+          "when": "resourceExtname == .cpd || resourceExtname == .cpdz",
+          "group": "calcpad@2"
         }
       ]
     },

--- a/Calcpad.VSCode/package.json
+++ b/Calcpad.VSCode/package.json
@@ -5,6 +5,12 @@
   "version": "0.1.0",
   "publisher": "calcpad",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/imartincei/CalcpadCE.git",
+    "directory": "Calcpad.VSCode"
+  },
+  "homepage": "https://github.com/imartincei/CalcpadCE",
   "engines": {
     "vscode": "^1.84.0"
   },
@@ -27,6 +33,13 @@
           ".cpdz"
         ],
         "configuration": "./language-configuration.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "calcpad",
+        "scopeName": "source.calcpad",
+        "path": "./syntaxes/calcpad.tmLanguage.json"
       }
     ],
     "commands": [
@@ -138,6 +151,7 @@
     "build": "npm run copy-assets && npm run compile",
     "watch": "node esbuild.mjs --watch",
     "publish-cli": "node scripts/publish-cli.mjs",
+    "package": "vsce package",
     "vscode:prepublish": "npm run build"
   },
   "devDependencies": {

--- a/Calcpad.VSCode/package.json
+++ b/Calcpad.VSCode/package.json
@@ -1,0 +1,122 @@
+{
+  "name": "calcpad-preview",
+  "displayName": "CalcpadCE Preview",
+  "description": "Live, interactive preview for CalcpadCE .cpd worksheets — like the built-in Markdown preview.",
+  "version": "0.1.0",
+  "publisher": "calcpad",
+  "license": "MIT",
+  "engines": {
+    "vscode": "^1.84.0"
+  },
+  "categories": [
+    "Visualization",
+    "Programming Languages"
+  ],
+  "main": "./dist/extension.js",
+  "activationEvents": [],
+  "contributes": {
+    "languages": [
+      {
+        "id": "calcpad",
+        "aliases": [
+          "Calcpad",
+          "calcpad"
+        ],
+        "extensions": [
+          ".cpd",
+          ".cpdz"
+        ],
+        "configuration": "./language-configuration.json"
+      }
+    ],
+    "commands": [
+      {
+        "command": "calcpad.showPreview",
+        "title": "Calcpad: Open Preview",
+        "category": "Calcpad",
+        "icon": "$(open-preview)"
+      },
+      {
+        "command": "calcpad.showPreviewToSide",
+        "title": "Calcpad: Open Preview to the Side",
+        "category": "Calcpad",
+        "icon": "$(open-preview)"
+      }
+    ],
+    "keybindings": [
+      {
+        "command": "calcpad.showPreview",
+        "key": "ctrl+shift+v",
+        "mac": "cmd+shift+v",
+        "when": "editorLangId == calcpad"
+      },
+      {
+        "command": "calcpad.showPreviewToSide",
+        "key": "ctrl+k v",
+        "mac": "cmd+k v",
+        "when": "editorLangId == calcpad"
+      }
+    ],
+    "menus": {
+      "editor/title": [
+        {
+          "command": "calcpad.showPreviewToSide",
+          "when": "editorLangId == calcpad",
+          "group": "navigation"
+        }
+      ],
+      "commandPalette": [
+        {
+          "command": "calcpad.showPreview",
+          "when": "editorLangId == calcpad"
+        },
+        {
+          "command": "calcpad.showPreviewToSide",
+          "when": "editorLangId == calcpad"
+        }
+      ],
+      "explorer/context": [
+        {
+          "command": "calcpad.showPreview",
+          "when": "resourceExtname == .cpd || resourceExtname == .cpdz",
+          "group": "navigation"
+        }
+      ]
+    },
+    "configuration": {
+      "title": "CalcpadCE Preview",
+      "properties": {
+        "calcpad.preview.debounceMs": {
+          "type": "number",
+          "default": 300,
+          "description": "Delay in milliseconds before re-rendering the preview after an edit."
+        },
+        "calcpad.preview.updateOnSaveOnly": {
+          "type": "boolean",
+          "default": false,
+          "description": "Only refresh the preview when the document is saved (not on every edit)."
+        },
+        "calcpad.cli.path": {
+          "type": "string",
+          "default": "",
+          "description": "Override path to the Calcpad CLI used for rendering. May point to the native executable or to Cli.dll (run via dotnet). Leave empty to use the bundled binary."
+        }
+      }
+    }
+  },
+  "scripts": {
+    "copy-assets": "node scripts/copy-assets.mjs",
+    "compile": "node esbuild.mjs",
+    "build": "npm run copy-assets && npm run compile",
+    "watch": "node esbuild.mjs --watch",
+    "publish-cli": "node scripts/publish-cli.mjs",
+    "vscode:prepublish": "npm run build"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@types/vscode": "^1.84.0",
+    "@vscode/vsce": "^2.24.0",
+    "esbuild": "^0.20.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/Calcpad.VSCode/scripts/copy-assets.mjs
+++ b/Calcpad.VSCode/scripts/copy-assets.mjs
@@ -1,0 +1,30 @@
+// Extracts the worksheet CSS from the CLI template and copies jQuery into media/,
+// so the webview can render Calcpad output with the same styling as the desktop app.
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const extRoot = path.resolve(here, '..');
+const cliDoc = path.resolve(extRoot, '..', 'Calcpad.Cli', 'doc');
+const mediaDir = path.join(extRoot, 'media');
+
+fs.mkdirSync(mediaDir, { recursive: true });
+
+// 1. Extract the <style> block from template.html into media/calcpad.css
+const templatePath = path.join(cliDoc, 'template.html');
+const template = fs.readFileSync(templatePath, 'utf8');
+const start = template.indexOf('<style>');
+const end = template.indexOf('</style>');
+if (start < 0 || end < 0) {
+  throw new Error(`Could not find <style> block in ${templatePath}`);
+}
+const css = template.slice(start + '<style>'.length, end).trim();
+const header = '/* Generated from Calcpad.Cli/doc/template.html — do not edit by hand. */\n';
+fs.writeFileSync(path.join(mediaDir, 'calcpad.css'), header + css + '\n', 'utf8');
+console.log('Wrote media/calcpad.css');
+
+// 2. Copy jQuery
+const jquery = 'jquery-3.6.3.min.js';
+fs.copyFileSync(path.join(cliDoc, jquery), path.join(mediaDir, jquery));
+console.log(`Copied media/${jquery}`);

--- a/Calcpad.VSCode/scripts/publish-cli.mjs
+++ b/Calcpad.VSCode/scripts/publish-cli.mjs
@@ -1,0 +1,46 @@
+// Publishes a self-contained Calcpad.Cli build into bin/<rid>/ for bundling in the VSIX.
+// Usage:  node scripts/publish-cli.mjs [rid]
+// Default rid is the current host platform.
+import { spawnSync } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const extRoot = path.resolve(here, '..');
+const csproj = path.resolve(extRoot, '..', 'Calcpad.Cli', 'Calcpad.Cli.csproj');
+
+function hostRid() {
+  switch (process.platform) {
+    case 'win32':
+      return 'win-x64';
+    case 'linux':
+      return 'linux-x64';
+    case 'darwin':
+      return process.arch === 'arm64' ? 'osx-arm64' : 'osx-x64';
+    default:
+      throw new Error(`Unsupported platform: ${process.platform}`);
+  }
+}
+
+const rid = process.argv[2] || hostRid();
+const outDir = path.join(extRoot, 'bin', rid);
+
+const args = [
+  'publish',
+  csproj,
+  '-c',
+  'Release',
+  '-r',
+  rid,
+  '--self-contained',
+  '-o',
+  outDir,
+  '-p:PublishSingleFile=false'
+];
+
+console.log(`dotnet ${args.join(' ')}`);
+const result = spawnSync('dotnet', args, { stdio: 'inherit' });
+if (result.status !== 0) {
+  process.exit(result.status ?? 1);
+}
+console.log(`Published Calcpad CLI to ${outDir}`);

--- a/Calcpad.VSCode/src/CalcpadPreviewManager.ts
+++ b/Calcpad.VSCode/src/CalcpadPreviewManager.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
-import { CalcpadRenderer } from './CalcpadRenderer';
-import { CalcpadPreviewPanel } from './CalcpadPreviewPanel';
+import * as path from 'path';
+import { CalcpadRenderer, ExportFormat } from './CalcpadRenderer';
+import { CalcpadPreviewPanel, ExportState } from './CalcpadPreviewPanel';
 
 function isCalcpad(doc: vscode.TextDocument): boolean {
   return doc.languageId === 'calcpad' || /\.cpdz?$/i.test(doc.uri.fsPath);
@@ -88,9 +89,64 @@ export class CalcpadPreviewManager implements vscode.Disposable {
       },
       () => {
         /* activated hook (unused) */
-      }
+      },
+      (exportUri, format, state) => void this.doExport(exportUri, format, state)
     );
     void this.renderNow();
+  }
+
+  // Export command entry point: uses the preview's current state when it targets
+  // the same document, so the exported file matches what is shown.
+  async exportCommand(uri: vscode.Uri | undefined, format: ExportFormat): Promise<void> {
+    const target = uri ?? vscode.window.activeTextEditor?.document.uri;
+    if (!target) {
+      void vscode.window.showWarningMessage('Open a .cpd file to export.');
+      return;
+    }
+    const state: ExportState =
+      this.preview && this.preview.sourceUri.toString() === target.toString()
+        ? this.preview.exportState
+        : { inputValues: [], units: undefined };
+    await this.doExport(target, format, state);
+  }
+
+  private async doExport(uri: vscode.Uri, format: ExportFormat, state: ExportState): Promise<void> {
+    const ext = format === 'docx' ? 'docx' : 'html';
+    const defaultUri = vscode.Uri.file(uri.fsPath.replace(/\.[^.\\/]+$/, '') + '.' + ext);
+    const filters: Record<string, string[]> =
+      format === 'docx' ? { 'Word document': ['docx'] } : { HTML: ['html', 'htm'] };
+    const target = await vscode.window.showSaveDialog({ defaultUri, filters });
+    if (!target) {
+      return;
+    }
+
+    const doc = vscode.workspace.textDocuments.find((d) => d.uri.toString() === uri.toString());
+    const sourceText = doc ? doc.getText() : (await vscode.workspace.openTextDocument(uri)).getText();
+
+    try {
+      await this.renderer.export({
+        sourcePath: uri.fsPath,
+        sourceText,
+        units: state.units,
+        inputValues: state.inputValues,
+        export: { format, outPath: target.fsPath }
+      });
+      const open = 'Open';
+      const reveal = 'Reveal in Explorer';
+      const choice = await vscode.window.showInformationMessage(
+        `Calcpad: exported to ${path.basename(target.fsPath)}`,
+        open,
+        reveal
+      );
+      if (choice === open) {
+        void vscode.env.openExternal(target);
+      } else if (choice === reveal) {
+        void vscode.commands.executeCommand('revealFileInOS', target);
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      void vscode.window.showErrorMessage(`Calcpad export failed: ${message}`);
+    }
   }
 
   private async renderNow(): Promise<void> {

--- a/Calcpad.VSCode/src/CalcpadPreviewManager.ts
+++ b/Calcpad.VSCode/src/CalcpadPreviewManager.ts
@@ -1,0 +1,115 @@
+import * as vscode from 'vscode';
+import { CalcpadRenderer } from './CalcpadRenderer';
+import { CalcpadPreviewPanel } from './CalcpadPreviewPanel';
+
+function isCalcpad(doc: vscode.TextDocument): boolean {
+  return doc.languageId === 'calcpad' || /\.cpdz?$/i.test(doc.uri.fsPath);
+}
+
+// Owns the shared renderer and a single dynamic preview panel that follows the
+// active .cpd editor (like the built-in Markdown preview).
+export class CalcpadPreviewManager implements vscode.Disposable {
+  private readonly renderer: CalcpadRenderer;
+  private preview: CalcpadPreviewPanel | undefined;
+  private previewColumn: vscode.ViewColumn = vscode.ViewColumn.Beside;
+  private debounceTimer: NodeJS.Timeout | undefined;
+
+  constructor(private readonly context: vscode.ExtensionContext) {
+    this.renderer = new CalcpadRenderer(context);
+  }
+
+  openPreview(uri: vscode.Uri, options: { side: boolean }): void {
+    this.previewColumn = options.side ? vscode.ViewColumn.Beside : vscode.ViewColumn.Active;
+    this.show(uri, true);
+  }
+
+  // Follow the active editor: retarget the existing preview to the newly focused .cpd.
+  onActiveEditorChanged(editor: vscode.TextEditor | undefined): void {
+    if (!this.preview || !editor || !isCalcpad(editor.document)) {
+      return;
+    }
+    if (editor.document.uri.toString() !== this.preview.sourceUri.toString()) {
+      this.show(editor.document.uri, false);
+    }
+  }
+
+  onSourceChanged(doc: vscode.TextDocument, immediate = false): void {
+    if (!this.preview || doc.uri.toString() !== this.preview.sourceUri.toString()) {
+      return;
+    }
+    const config = vscode.workspace.getConfiguration('calcpad');
+    if (config.get<boolean>('preview.updateOnSaveOnly') && !immediate) {
+      return;
+    }
+    if (immediate) {
+      void this.renderNow();
+      return;
+    }
+    const delay = config.get<number>('preview.debounceMs') ?? 300;
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+    }
+    this.debounceTimer = setTimeout(() => {
+      this.debounceTimer = undefined;
+      void this.renderNow();
+    }, delay);
+  }
+
+  // Show `uri` in the preview, creating/retargeting/recreating the panel as needed.
+  private show(uri: vscode.Uri, reveal: boolean): void {
+    if (this.preview) {
+      if (this.preview.sourceUri.toString() === uri.toString()) {
+        if (reveal) {
+          this.preview.reveal(this.previewColumn);
+        }
+        void this.renderNow();
+        return;
+      }
+      if (this.preview.coversUri(uri)) {
+        this.preview.retarget(uri);
+        if (reveal) {
+          this.preview.reveal(this.previewColumn);
+        }
+        void this.renderNow();
+        return;
+      }
+      // Roots don't cover the new document — recreate the panel.
+      this.preview.dispose();
+      this.preview = undefined;
+    }
+
+    this.preview = new CalcpadPreviewPanel(
+      this.context,
+      this.renderer,
+      uri,
+      this.previewColumn,
+      () => {
+        this.preview = undefined;
+      },
+      () => {
+        /* activated hook (unused) */
+      }
+    );
+    void this.renderNow();
+  }
+
+  private async renderNow(): Promise<void> {
+    const panel = this.preview;
+    if (!panel) {
+      return;
+    }
+    const uri = panel.sourceUri;
+    const doc = vscode.workspace.textDocuments.find((d) => d.uri.toString() === uri.toString());
+    const text = doc ? doc.getText() : (await vscode.workspace.openTextDocument(uri)).getText();
+    await panel.update(text);
+  }
+
+  dispose(): void {
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+    }
+    this.preview?.dispose();
+    this.preview = undefined;
+    this.renderer.dispose();
+  }
+}

--- a/Calcpad.VSCode/src/CalcpadPreviewPanel.ts
+++ b/Calcpad.VSCode/src/CalcpadPreviewPanel.ts
@@ -1,0 +1,220 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+import { CalcpadRenderer, InputValue } from './CalcpadRenderer';
+
+function getNonce(): string {
+  let text = '';
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  for (let i = 0; i < 32; i++) {
+    text += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  return text;
+}
+
+// Collects directories that the webview is allowed to load images from: the
+// extension media folder, all workspace folders, and the document folder plus a
+// few ancestors (worksheets reference images via paths like ../../Images/...).
+function computeRoots(extensionUri: vscode.Uri, sourceUri: vscode.Uri): vscode.Uri[] {
+  const roots: vscode.Uri[] = [vscode.Uri.joinPath(extensionUri, 'media')];
+  for (const folder of vscode.workspace.workspaceFolders ?? []) {
+    roots.push(folder.uri);
+  }
+  let dir = path.dirname(sourceUri.fsPath);
+  for (let i = 0; i < 6; i++) {
+    roots.push(vscode.Uri.file(dir));
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+      break;
+    }
+    dir = parent;
+  }
+  return roots;
+}
+
+// One dynamic preview panel that can be retargeted to follow the active .cpd editor.
+export class CalcpadPreviewPanel {
+  public readonly panel: vscode.WebviewPanel;
+  private readonly disposables: vscode.Disposable[] = [];
+  private readonly rootPaths: string[];
+  private units: string | undefined;
+  private inputValues: InputValue[] = [];
+  private renderToken = 0;
+  public sourceUri: vscode.Uri;
+
+  constructor(
+    private readonly context: vscode.ExtensionContext,
+    private readonly renderer: CalcpadRenderer,
+    sourceUri: vscode.Uri,
+    viewColumn: vscode.ViewColumn,
+    private readonly onDispose: (panel: CalcpadPreviewPanel) => void,
+    private readonly onActivated: (panel: CalcpadPreviewPanel) => void
+  ) {
+    this.sourceUri = sourceUri;
+    const roots = computeRoots(context.extensionUri, sourceUri);
+    this.rootPaths = roots.map((r) => r.fsPath);
+
+    this.panel = vscode.window.createWebviewPanel(
+      'calcpadPreview',
+      this.title(),
+      { viewColumn, preserveFocus: true },
+      { enableScripts: true, retainContextWhenHidden: true, localResourceRoots: roots }
+    );
+
+    this.panel.webview.html = this.buildShell();
+    this.panel.webview.onDidReceiveMessage((msg) => this.onMessage(msg), null, this.disposables);
+    this.panel.onDidChangeViewState(
+      (e) => {
+        if (e.webviewPanel.active) {
+          this.onActivated(this);
+        }
+      },
+      null,
+      this.disposables
+    );
+    this.panel.onDidDispose(() => this.dispose(), null, this.disposables);
+  }
+
+  private title(): string {
+    return `Preview ${path.basename(this.sourceUri.fsPath)}`;
+  }
+
+  // True if this panel's localResourceRoots already cover the given document
+  // (so it can be retargeted without recreating the webview).
+  coversUri(uri: vscode.Uri): boolean {
+    const dir = path.dirname(uri.fsPath);
+    return this.rootPaths.some((root) => {
+      const rel = path.relative(root, dir);
+      return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
+    });
+  }
+
+  reveal(viewColumn?: vscode.ViewColumn): void {
+    this.panel.reveal(viewColumn, true);
+  }
+
+  // Point this preview at a different document (clears the interactive state).
+  retarget(uri: vscode.Uri): void {
+    this.sourceUri = uri;
+    this.units = undefined;
+    this.inputValues = [];
+    this.panel.title = this.title();
+  }
+
+  async update(sourceText: string): Promise<void> {
+    const token = ++this.renderToken;
+    try {
+      const html = await this.renderer.render({
+        sourcePath: this.sourceUri.fsPath,
+        sourceText,
+        units: this.units,
+        inputValues: this.inputValues
+      });
+      if (token !== this.renderToken) {
+        return;
+      }
+      this.panel.webview.postMessage({ type: 'update', html, imgBase: this.imgBase() });
+    } catch (err) {
+      if (token !== this.renderToken) {
+        return;
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      this.panel.webview.postMessage({ type: 'error', message });
+    }
+  }
+
+  private imgBase(): string {
+    const docDir = vscode.Uri.file(path.dirname(this.sourceUri.fsPath));
+    return this.panel.webview.asWebviewUri(docDir).toString() + '/';
+  }
+
+  private async onMessage(msg: any): Promise<void> {
+    if (!msg || typeof msg.type !== 'string') {
+      return;
+    }
+    if (msg.type === 'inputChange' || msg.type === 'unitChange') {
+      this.inputValues = Array.isArray(msg.inputValues) ? msg.inputValues : [];
+      this.units = typeof msg.units === 'string' && msg.units.length > 0 ? msg.units : this.units;
+      const doc = await this.findOpenDocument();
+      await this.update(doc?.getText() ?? '');
+    }
+  }
+
+  private async findOpenDocument(): Promise<vscode.TextDocument | undefined> {
+    const open = vscode.workspace.textDocuments.find((d) => d.uri.toString() === this.sourceUri.toString());
+    if (open) {
+      return open;
+    }
+    try {
+      return await vscode.workspace.openTextDocument(this.sourceUri);
+    } catch {
+      return undefined;
+    }
+  }
+
+  private buildShell(): string {
+    const webview = this.panel.webview;
+    const nonce = getNonce();
+    const cssUri = webview.asWebviewUri(vscode.Uri.joinPath(this.context.extensionUri, 'media', 'calcpad.css'));
+    const jqueryUri = webview.asWebviewUri(
+      vscode.Uri.joinPath(this.context.extensionUri, 'media', 'jquery-3.6.3.min.js')
+    );
+    const mainUri = webview.asWebviewUri(vscode.Uri.joinPath(this.context.extensionUri, 'media', 'main.js'));
+
+    const csp = [
+      `default-src 'none'`,
+      `img-src ${webview.cspSource} https: data:`,
+      `font-src ${webview.cspSource}`,
+      `style-src ${webview.cspSource} 'unsafe-inline'`,
+      `script-src 'nonce-${nonce}' ${webview.cspSource}`
+    ].join('; ');
+
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy" content="${csp}">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="${cssUri}">
+  <title>Calcpad Preview</title>
+  <style>
+    #cp-toolbar {
+      position: sticky; top: 0; z-index: 10;
+      display: flex; gap: 4px; padding: 4px 6px; margin: 0 0 6px 0;
+      background: var(--vscode-editor-background);
+      border-bottom: 1px solid var(--vscode-panel-border);
+    }
+    #cp-toolbar button {
+      font: inherit; font-size: 12px; cursor: pointer;
+      padding: 2px 10px; border: 1px solid var(--vscode-button-border, transparent);
+      border-radius: 3px;
+      color: var(--vscode-button-secondaryForeground);
+      background: var(--vscode-button-secondaryBackground);
+    }
+    #cp-toolbar button.cp-active {
+      color: var(--vscode-button-foreground);
+      background: var(--vscode-button-background);
+    }
+    .calcpad-status { color: var(--vscode-descriptionForeground); padding: 1em; font-style: italic; }
+    .calcpad-error { color: var(--vscode-errorForeground); padding: 1em; white-space: pre-wrap; }
+  </style>
+</head>
+<body>
+  <div id="cp-toolbar">
+    <button id="cp-mode-interactive" title="Editable input fields, live recalculation">Interactive</button>
+    <button id="cp-mode-final" title="Read-only calculated output">Final</button>
+  </div>
+  <div id="calcpad-root"><div class="calcpad-status">Rendering…</div></div>
+  <script nonce="${nonce}" src="${jqueryUri}"></script>
+  <script nonce="${nonce}" src="${mainUri}"></script>
+</body>
+</html>`;
+  }
+
+  dispose(): void {
+    this.onDispose(this);
+    this.panel.dispose();
+    while (this.disposables.length) {
+      this.disposables.pop()?.dispose();
+    }
+  }
+}

--- a/Calcpad.VSCode/src/CalcpadPreviewPanel.ts
+++ b/Calcpad.VSCode/src/CalcpadPreviewPanel.ts
@@ -1,6 +1,11 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { CalcpadRenderer, InputValue } from './CalcpadRenderer';
+import { CalcpadRenderer, ExportFormat, InputValue } from './CalcpadRenderer';
+
+export interface ExportState {
+  inputValues: InputValue[];
+  units: string | undefined;
+}
 
 function getNonce(): string {
   let text = '';
@@ -47,7 +52,8 @@ export class CalcpadPreviewPanel {
     sourceUri: vscode.Uri,
     viewColumn: vscode.ViewColumn,
     private readonly onDispose: (panel: CalcpadPreviewPanel) => void,
-    private readonly onActivated: (panel: CalcpadPreviewPanel) => void
+    private readonly onActivated: (panel: CalcpadPreviewPanel) => void,
+    private readonly onExport: (uri: vscode.Uri, format: ExportFormat, state: ExportState) => void
   ) {
     this.sourceUri = sourceUri;
     const roots = computeRoots(context.extensionUri, sourceUri);
@@ -100,6 +106,11 @@ export class CalcpadPreviewPanel {
     this.panel.title = this.title();
   }
 
+  // Current interactive state, so a command-triggered export matches what's shown.
+  get exportState(): ExportState {
+    return { inputValues: this.inputValues, units: this.units };
+  }
+
   async update(sourceText: string): Promise<void> {
     const token = ++this.renderToken;
     try {
@@ -136,6 +147,10 @@ export class CalcpadPreviewPanel {
       this.units = typeof msg.units === 'string' && msg.units.length > 0 ? msg.units : this.units;
       const doc = await this.findOpenDocument();
       await this.update(doc?.getText() ?? '');
+    } else if (msg.type === 'export' && (msg.format === 'html' || msg.format === 'docx')) {
+      const inputValues = Array.isArray(msg.inputValues) ? msg.inputValues : this.inputValues;
+      const units = typeof msg.units === 'string' && msg.units.length > 0 ? msg.units : this.units;
+      this.onExport(this.sourceUri, msg.format, { inputValues, units });
     }
   }
 
@@ -194,6 +209,7 @@ export class CalcpadPreviewPanel {
       color: var(--vscode-button-foreground);
       background: var(--vscode-button-background);
     }
+    #cp-toolbar .cp-spacer { flex: 1; }
     .calcpad-status { color: var(--vscode-descriptionForeground); padding: 1em; font-style: italic; }
     .calcpad-error { color: var(--vscode-errorForeground); padding: 1em; white-space: pre-wrap; }
   </style>
@@ -202,6 +218,9 @@ export class CalcpadPreviewPanel {
   <div id="cp-toolbar">
     <button id="cp-mode-interactive" title="Editable input fields, live recalculation">Interactive</button>
     <button id="cp-mode-final" title="Read-only calculated output">Final</button>
+    <span class="cp-spacer"></span>
+    <button id="cp-export-html" title="Export the calculated worksheet to HTML">Export HTML</button>
+    <button id="cp-export-docx" title="Export the calculated worksheet to Word (DOCX)">Export DOCX</button>
   </div>
   <div id="calcpad-root"><div class="calcpad-status">Rendering…</div></div>
   <script nonce="${nonce}" src="${jqueryUri}"></script>

--- a/Calcpad.VSCode/src/CalcpadRenderer.ts
+++ b/Calcpad.VSCode/src/CalcpadRenderer.ts
@@ -1,0 +1,132 @@
+import * as vscode from 'vscode';
+import { ChildProcessWithoutNullStreams, spawn } from 'child_process';
+import * as readline from 'readline';
+import { resolveCli } from './binary';
+
+export interface InputValue {
+  line: number;
+  value: string;
+}
+
+export interface RenderRequest {
+  sourcePath?: string;
+  sourceText?: string;
+  units?: string;
+  inputValues?: InputValue[];
+}
+
+interface ServerResponse {
+  id: number;
+  ok: boolean;
+  html?: string;
+  error?: string;
+}
+
+// Manages a single long-running `Cli --serve` child process and matches
+// NDJSON responses back to their requests by id.
+export class CalcpadRenderer implements vscode.Disposable {
+  private proc: ChildProcessWithoutNullStreams | undefined;
+  private rl: readline.Interface | undefined;
+  private nextId = 1;
+  private readonly pending = new Map<number, { resolve: (html: string) => void; reject: (err: Error) => void }>();
+  private readonly output: vscode.OutputChannel;
+  private disposed = false;
+
+  constructor(private readonly context: vscode.ExtensionContext) {
+    this.output = vscode.window.createOutputChannel('Calcpad Preview');
+  }
+
+  async render(request: RenderRequest): Promise<string> {
+    const proc = this.ensureProcess();
+    const id = this.nextId++;
+    const payload = JSON.stringify({ id, ...request });
+    return new Promise<string>((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      proc.stdin.write(payload + '\n', (err) => {
+        if (err) {
+          this.pending.delete(id);
+          reject(err);
+        }
+      });
+    });
+  }
+
+  private ensureProcess(): ChildProcessWithoutNullStreams {
+    if (this.proc && !this.proc.killed) {
+      return this.proc;
+    }
+
+    const { command, args } = resolveCli(this.context);
+    const proc = spawn(command, args, { stdio: ['pipe', 'pipe', 'pipe'] });
+    this.proc = proc;
+
+    this.rl = readline.createInterface({ input: proc.stdout });
+    this.rl.on('line', (line) => this.onLine(line));
+
+    proc.stderr.on('data', (chunk) => this.output.append(chunk.toString()));
+
+    proc.on('exit', (code, signal) => {
+      this.output.appendLine(`[calcpad] CLI process exited (code=${code}, signal=${signal}).`);
+      this.failAllPending(new Error('Calcpad render process exited.'));
+      this.proc = undefined;
+      this.rl?.close();
+      this.rl = undefined;
+    });
+
+    proc.on('error', (err) => {
+      this.output.appendLine(`[calcpad] Failed to start CLI: ${err.message}`);
+      this.failAllPending(err);
+      this.proc = undefined;
+    });
+
+    return proc;
+  }
+
+  private onLine(line: string): void {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      return;
+    }
+    let response: ServerResponse;
+    try {
+      response = JSON.parse(trimmed);
+    } catch {
+      this.output.appendLine(`[calcpad] Ignoring non-JSON output: ${trimmed.slice(0, 200)}`);
+      return;
+    }
+    const entry = this.pending.get(response.id);
+    if (!entry) {
+      return;
+    }
+    this.pending.delete(response.id);
+    if (response.ok && response.html !== undefined) {
+      entry.resolve(response.html);
+    } else {
+      entry.reject(new Error(response.error ?? 'Unknown render error.'));
+    }
+  }
+
+  private failAllPending(err: Error): void {
+    for (const { reject } of this.pending.values()) {
+      reject(err);
+    }
+    this.pending.clear();
+  }
+
+  dispose(): void {
+    if (this.disposed) {
+      return;
+    }
+    this.disposed = true;
+    this.failAllPending(new Error('Extension deactivated.'));
+    this.rl?.close();
+    try {
+      this.proc?.stdin.end();
+    } catch {
+      /* ignore */
+    }
+    this.proc?.kill();
+    this.proc = undefined;
+    this.output.dispose();
+  }
+}

--- a/Calcpad.VSCode/src/CalcpadRenderer.ts
+++ b/Calcpad.VSCode/src/CalcpadRenderer.ts
@@ -15,10 +15,17 @@ export interface RenderRequest {
   inputValues?: InputValue[];
 }
 
+export type ExportFormat = 'html' | 'docx';
+
+export interface ExportRequest extends RenderRequest {
+  export: { format: ExportFormat; outPath: string };
+}
+
 interface ServerResponse {
   id: number;
   ok: boolean;
   html?: string;
+  outPath?: string;
   error?: string;
 }
 
@@ -28,7 +35,7 @@ export class CalcpadRenderer implements vscode.Disposable {
   private proc: ChildProcessWithoutNullStreams | undefined;
   private rl: readline.Interface | undefined;
   private nextId = 1;
-  private readonly pending = new Map<number, { resolve: (html: string) => void; reject: (err: Error) => void }>();
+  private readonly pending = new Map<number, { resolve: (r: ServerResponse) => void; reject: (err: Error) => void }>();
   private readonly output: vscode.OutputChannel;
   private disposed = false;
 
@@ -37,10 +44,26 @@ export class CalcpadRenderer implements vscode.Disposable {
   }
 
   async render(request: RenderRequest): Promise<string> {
+    const response = await this.send(request);
+    if (!response.ok) {
+      throw new Error(response.error ?? 'Unknown render error.');
+    }
+    return response.html ?? '';
+  }
+
+  async export(request: ExportRequest): Promise<string> {
+    const response = await this.send(request);
+    if (!response.ok) {
+      throw new Error(response.error ?? 'Unknown export error.');
+    }
+    return response.outPath ?? request.export.outPath;
+  }
+
+  private send(request: RenderRequest | ExportRequest): Promise<ServerResponse> {
     const proc = this.ensureProcess();
     const id = this.nextId++;
     const payload = JSON.stringify({ id, ...request });
-    return new Promise<string>((resolve, reject) => {
+    return new Promise<ServerResponse>((resolve, reject) => {
       this.pending.set(id, { resolve, reject });
       proc.stdin.write(payload + '\n', (err) => {
         if (err) {
@@ -99,11 +122,7 @@ export class CalcpadRenderer implements vscode.Disposable {
       return;
     }
     this.pending.delete(response.id);
-    if (response.ok && response.html !== undefined) {
-      entry.resolve(response.html);
-    } else {
-      entry.reject(new Error(response.error ?? 'Unknown render error.'));
-    }
+    entry.resolve(response);
   }
 
   private failAllPending(err: Error): void {

--- a/Calcpad.VSCode/src/binary.ts
+++ b/Calcpad.VSCode/src/binary.ts
@@ -1,0 +1,84 @@
+import * as path from 'path';
+import * as fs from 'fs';
+import * as vscode from 'vscode';
+
+export interface CliCommand {
+  command: string;
+  args: string[];
+}
+
+function ridFor(): string {
+  switch (process.platform) {
+    case 'win32':
+      return 'win-x64';
+    case 'linux':
+      return 'linux-x64';
+    case 'darwin':
+      return process.arch === 'arm64' ? 'osx-arm64' : 'osx-x64';
+    default:
+      throw new Error(`Unsupported platform: ${process.platform}`);
+  }
+}
+
+// Builds the command used to launch the Calcpad CLI in --serve mode.
+// Honors the `calcpad.cli.path` override (which may be a native exe or a Cli.dll
+// run through `dotnet`); otherwise falls back to the bundled per-RID binary.
+export function resolveCli(context: vscode.ExtensionContext): CliCommand {
+  const override = vscode.workspace.getConfiguration('calcpad').get<string>('cli.path')?.trim();
+  if (override) {
+    return toCommand(override);
+  }
+
+  const exe = process.platform === 'win32' ? 'Cli.exe' : 'Cli';
+  const bundled = path.join(context.extensionPath, 'bin', ridFor(), exe);
+  if (fs.existsSync(bundled)) {
+    ensureExecutable(bundled);
+    return { command: bundled, args: ['--serve'] };
+  }
+
+  // Dev fallback (F5 from the monorepo): use the already-built Cli.dll next door
+  // so the extension works without a full self-contained publish.
+  const devDll = findDevCliDll(context.extensionPath);
+  if (devDll) {
+    return { command: 'dotnet', args: [devDll, '--serve'] };
+  }
+
+  throw new Error(
+    `Calcpad CLI not found at ${bundled}. Build it with "npm run publish-cli", ` +
+      `run "dotnet build Calcpad.Cli", or set "calcpad.cli.path".`
+  );
+}
+
+function findDevCliDll(extensionPath: string): string | undefined {
+  const base = path.resolve(extensionPath, '..', 'Calcpad.Cli', 'bin');
+  for (const config of ['Debug', 'Release']) {
+    const dll = path.join(base, config, 'net10.0', 'Cli.dll');
+    if (fs.existsSync(dll)) {
+      return dll;
+    }
+  }
+  return undefined;
+}
+
+function toCommand(p: string): CliCommand {
+  if (p.toLowerCase().endsWith('.dll')) {
+    return { command: 'dotnet', args: [p, '--serve'] };
+  }
+  ensureExecutable(p);
+  return { command: p, args: ['--serve'] };
+}
+
+function ensureExecutable(p: string): void {
+  if (process.platform === 'win32') {
+    return;
+  }
+  try {
+    fs.accessSync(p, fs.constants.X_OK);
+  } catch {
+    try {
+      fs.chmodSync(p, 0o755);
+    } catch {
+      /* best effort */
+    }
+  }
+}

--- a/Calcpad.VSCode/src/extension.ts
+++ b/Calcpad.VSCode/src/extension.ts
@@ -26,6 +26,12 @@ export function activate(context: vscode.ExtensionContext): void {
         manager!.openPreview(uri, { side: true });
       }
     }),
+    vscode.commands.registerCommand('calcpad.exportHtml', (arg?: vscode.Uri) => {
+      void manager!.exportCommand(resolveUri(arg), 'html');
+    }),
+    vscode.commands.registerCommand('calcpad.exportDocx', (arg?: vscode.Uri) => {
+      void manager!.exportCommand(resolveUri(arg), 'docx');
+    }),
     vscode.workspace.onDidChangeTextDocument((e) => {
       if (e.document.languageId === 'calcpad' || e.document.uri.fsPath.endsWith('.cpd')) {
         manager!.onSourceChanged(e.document);

--- a/Calcpad.VSCode/src/extension.ts
+++ b/Calcpad.VSCode/src/extension.ts
@@ -1,0 +1,48 @@
+import * as vscode from 'vscode';
+import { CalcpadPreviewManager } from './CalcpadPreviewManager';
+
+let manager: CalcpadPreviewManager | undefined;
+
+export function activate(context: vscode.ExtensionContext): void {
+  manager = new CalcpadPreviewManager(context);
+
+  const resolveUri = (arg?: vscode.Uri): vscode.Uri | undefined => {
+    if (arg instanceof vscode.Uri) {
+      return arg;
+    }
+    return vscode.window.activeTextEditor?.document.uri;
+  };
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('calcpad.showPreview', (arg?: vscode.Uri) => {
+      const uri = resolveUri(arg);
+      if (uri) {
+        manager!.openPreview(uri, { side: false });
+      }
+    }),
+    vscode.commands.registerCommand('calcpad.showPreviewToSide', (arg?: vscode.Uri) => {
+      const uri = resolveUri(arg);
+      if (uri) {
+        manager!.openPreview(uri, { side: true });
+      }
+    }),
+    vscode.workspace.onDidChangeTextDocument((e) => {
+      if (e.document.languageId === 'calcpad' || e.document.uri.fsPath.endsWith('.cpd')) {
+        manager!.onSourceChanged(e.document);
+      }
+    }),
+    vscode.workspace.onDidSaveTextDocument((doc) => {
+      if (doc.languageId === 'calcpad' || doc.uri.fsPath.endsWith('.cpd')) {
+        manager!.onSourceChanged(doc, true);
+      }
+    }),
+    vscode.window.onDidChangeActiveTextEditor((editor) => {
+      manager!.onActiveEditorChanged(editor);
+    })
+  );
+}
+
+export function deactivate(): void {
+  manager?.dispose();
+  manager = undefined;
+}

--- a/Calcpad.VSCode/syntaxes/calcpad.tmLanguage.json
+++ b/Calcpad.VSCode/syntaxes/calcpad.tmLanguage.json
@@ -1,0 +1,121 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "Calcpad",
+  "scopeName": "source.calcpad",
+  "patterns": [
+    { "include": "#text" },
+    { "include": "#directives" },
+    { "include": "#methods" },
+    { "include": "#functions" },
+    { "include": "#constants" },
+    { "include": "#numbers" },
+    { "include": "#operators" },
+    { "include": "#punctuation" },
+    { "include": "#macro" },
+    { "include": "#identifiers" }
+  ],
+  "repository": {
+    "text": {
+      "patterns": [
+        {
+          "name": "string.quoted.single.calcpad",
+          "begin": "'",
+          "end": "'|(?=$)",
+          "beginCaptures": { "0": { "name": "punctuation.definition.string.begin.calcpad" } },
+          "endCaptures": { "0": { "name": "punctuation.definition.string.end.calcpad" } },
+          "patterns": [{ "include": "#html" }]
+        },
+        {
+          "name": "string.quoted.double.calcpad",
+          "begin": "\"",
+          "end": "\"|(?=$)",
+          "beginCaptures": { "0": { "name": "punctuation.definition.string.begin.calcpad" } },
+          "endCaptures": { "0": { "name": "punctuation.definition.string.end.calcpad" } },
+          "patterns": [{ "include": "#html" }]
+        }
+      ]
+    },
+    "html": {
+      "patterns": [
+        { "name": "comment.block.html.calcpad", "begin": "<!--", "end": "-->" },
+        {
+          "name": "meta.tag.calcpad",
+          "match": "(</?)([a-zA-Z][a-zA-Z0-9]*)\\b[^>]*?(/?>)",
+          "captures": {
+            "1": { "name": "punctuation.definition.tag.calcpad" },
+            "2": { "name": "entity.name.tag.calcpad" },
+            "3": { "name": "punctuation.definition.tag.calcpad" }
+          }
+        }
+      ]
+    },
+    "directives": {
+      "patterns": [
+        {
+          "match": "(?i)(#)(else\\s+if|end\\s+if|end\\s+def|md\\s+on|md\\s+off|if|else|rad|deg|gra|val|equ|noc|round|format|show|hide|nosub|novar|varsub|const|split|wrap|pre|post|repeat|for|while|loop|break|continue|include|local|global|def|pause|input|md|read|write|append|phasor|complex)\\b",
+          "captures": {
+            "1": { "name": "punctuation.definition.keyword.calcpad" },
+            "2": { "name": "keyword.control.calcpad" }
+          }
+        }
+      ]
+    },
+    "methods": {
+      "patterns": [
+        {
+          "match": "(?i)(\\$)(root|find|inf|sup|area|integral|slope|derivative|sum|product|repeat|map|plot|block|inline|while)\\b",
+          "captures": {
+            "1": { "name": "punctuation.definition.method.calcpad" },
+            "2": { "name": "support.function.method.calcpad" }
+          }
+        }
+      ]
+    },
+    "functions": {
+      "patterns": [
+        {
+          "name": "support.function.calcpad",
+          "match": "\\b(sign|abs|mod|gcd|lcm|sin|cos|tan|csc|sec|cot|sinh|cosh|tanh|csch|sech|coth|asin|acos|atan|acsc|asec|acot|asinh|acosh|atanh|acsch|asech|acoth|ln|log|log_2|exp|sqr|sqrt|cbrt|round|floor|ceiling|trunc|re|im|phase|conj|random|root|atan2|min|max|sum|sumsq|srss|average|product|mean|switch|take|line|spline|not|and|or|xor|timer|vector|vector_hp|len|size|fill|range|range_hp|join|resize|first|last|slice|sort|rsort|order|revorder|reverse|extract|search|count|find|find_eq|find_ne|find_lt|find_gt|find_le|find_ge|lookup|Lookup_eq|Lookup_ne|Lookup_lt|Lookup_gt|Lookup_le|Lookup_ge|unit|dot|cross|matrix|matrix_hp|identity|identity_hp|diagonal|diagonal_hp|column|column_hp|utriang|utriang_hp|ltriang|ltriang_hp|symmetric|symmetric_hp|vec2diag|diag2vec|vec2col|vec2row|join_cols|join_rows|augment|stack|mfill|fill_row|fill_col|mresize|copy|add|n_rows|n_cols|row|col|extract_rows|extract_cols|submatrix|mnorm|mnorm_2|mnorm_e|mnorm_1|mnorm_i|cond|cond_1|cond_2|cond_e|cond_i|det|rank|transp|trace|inverse|adj|cofactor|eigenvals|eigenvecs|eigen|lu|qr|svd|cholesky|lsolve|clsolve|slsolve|msolve|cmsolve|smsolve|matmul|hprod|fprod|kprod|sort_cols|rsort_cols|sort_rows|rsort_rows|order_cols|revorder_cols|order_rows|revorder_rows|mcount|mfind|mfind_eq|mfind_ne|mfind_lt|mfind_le|mfind_gt|mfind_ge|msearch|hlookup|hlookup_eq|hlookup_ne|hlookup_lt|hlookup_le|hlookup_gt|hlookup_ge|vlookup|vlookup_eq|vlookup_ne|vlookup_lt|vlookup_le|vlookup_gt|vlookup_ge|getunits|setunits|clrunits|fft|ift)\\b"
+        }
+      ]
+    },
+    "constants": {
+      "patterns": [
+        { "name": "constant.language.calcpad", "match": "(?<![\\w.])(pi|π|πi|ei)(?![\\w])" }
+      ]
+    },
+    "numbers": {
+      "patterns": [
+        { "name": "constant.numeric.calcpad", "match": "\\b[0-9]*\\.?[0-9]+([eE][-+]?[0-9]+)?" }
+      ]
+    },
+    "operators": {
+      "patterns": [
+        { "name": "keyword.operator.arithmetic.calcpad", "match": "[\\^/÷\\\\%*·\\-+∠]" },
+        { "name": "keyword.operator.comparison.calcpad", "match": "[≡≠<>≤≥]|==|!=|<=|>=" },
+        { "name": "keyword.operator.logical.calcpad", "match": "[∧∨⊕]" },
+        { "name": "keyword.operator.assignment.calcpad", "match": "[=←]" }
+      ]
+    },
+    "punctuation": {
+      "patterns": [
+        { "name": "punctuation.separator.calcpad", "match": "[;&@:|,]" },
+        { "name": "punctuation.section.brackets.calcpad", "match": "[\\[\\]{}()]" },
+        { "name": "keyword.other.input.calcpad", "match": "\\?" }
+      ]
+    },
+    "macro": {
+      "patterns": [
+        { "name": "entity.name.function.macro.calcpad", "match": "\\b[a-zA-Z]+[a-zA-Z0-9_]*\\$" }
+      ]
+    },
+    "identifiers": {
+      "patterns": [
+        {
+          "name": "variable.other.calcpad",
+          "match": "[a-zA-Zα-ωΑ-Ω°øØ∡]+[a-zA-Zα-ωΑ-Ω°øØ∡0-9_,′″‴⁗⁰¹²³⁴⁵⁶⁷⁸⁹ⁿ⁺⁻]*"
+        }
+      ]
+    }
+  }
+}

--- a/Calcpad.VSCode/tsconfig.json
+++ b/Calcpad.VSCode/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES2021",
+    "lib": ["ES2021", "DOM"],
+    "outDir": "dist",
+    "rootDir": ".",
+    "sourceMap": true,
+    "strict": true,
+    "noImplicitAny": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "moduleResolution": "node"
+  },
+  "include": ["src", "media"],
+  "exclude": ["node_modules", "dist", "bin"]
+}

--- a/Calcpad.Wpf/LibraryManager.cs
+++ b/Calcpad.Wpf/LibraryManager.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+
+namespace Calcpad.Wpf
+{
+    internal abstract class LibraryNode : INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler PropertyChanged;
+        public string Name { get; protected set; }
+        public string FullPath { get; protected set; }
+        public ObservableCollection<LibraryNode> Children { get; } = new();
+
+        private bool _isExpanded;
+        public bool IsExpanded
+        {
+            get => _isExpanded;
+            set
+            {
+                if (_isExpanded == value) return;
+                _isExpanded = value;
+                OnExpanded();
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsExpanded)));
+            }
+        }
+
+        protected virtual void OnExpanded() { }
+    }
+
+    internal sealed class LibraryFolderNode : LibraryNode
+    {
+        public bool Exists { get; private set; }
+
+        public LibraryFolderNode(string path)
+        {
+            FullPath = path;
+            Refresh();
+        }
+
+        public void Refresh()
+        {
+            Children.Clear();
+            Exists = Directory.Exists(FullPath);
+            Name = Exists ? new DirectoryInfo(FullPath).Name : Path.GetFileName(FullPath);
+            if (!Exists) return;
+
+            IEnumerable<string> files;
+            try { files = Directory.EnumerateFiles(FullPath, "*.cpd", SearchOption.AllDirectories); }
+            catch { return; }
+
+            foreach (var file in files.OrderBy(f => f, StringComparer.OrdinalIgnoreCase))
+                Children.Add(new LibraryFileNode(file));
+        }
+    }
+
+    internal sealed class LibraryFileNode : LibraryNode
+    {
+        private bool _scanned;
+
+        public LibraryFileNode(string path)
+        {
+            FullPath = path;
+            Name = Path.GetFileName(path);
+            // Add a placeholder so the TreeView shows an expansion arrow.
+            Children.Add(new LibraryPlaceholderNode());
+        }
+
+        protected override void OnExpanded()
+        {
+            if (_scanned || !IsExpanded) return;
+            _scanned = true;
+            Children.Clear();
+            foreach (var fn in LibraryScanner.ScanFile(FullPath))
+                Children.Add(new LibraryFunctionNode(FullPath, fn));
+            if (Children.Count == 0)
+                Children.Add(new LibraryPlaceholderNode(MainWindowResources.Library_NoFunctionsFound));
+        }
+
+        public void Rescan()
+        {
+            _scanned = false;
+            Children.Clear();
+            Children.Add(new LibraryPlaceholderNode());
+            if (IsExpanded) OnExpanded();
+        }
+    }
+
+    internal sealed class LibraryFunctionNode : LibraryNode
+    {
+        public LibraryFunction Function { get; }
+        public string FilePath { get; }
+
+        public LibraryFunctionNode(string filePath, LibraryFunction fn)
+        {
+            FilePath = filePath;
+            Function = fn;
+            Name = string.IsNullOrEmpty(fn.Signature) ? fn.Name : $"{fn.Name}({fn.Signature})";
+            FullPath = filePath;
+        }
+    }
+
+    internal sealed class LibraryPlaceholderNode : LibraryNode
+    {
+        public LibraryPlaceholderNode(string label = null)
+        {
+            Name = label ?? "…";
+            FullPath = string.Empty;
+        }
+    }
+
+    internal sealed class LibraryManager
+    {
+        public ObservableCollection<LibraryFolderNode> Folders { get; } = new();
+
+        public void LoadFromSettings(StringCollection persisted)
+        {
+            Folders.Clear();
+            if (persisted is null) return;
+            foreach (var path in persisted)
+                if (!string.IsNullOrWhiteSpace(path))
+                    Folders.Add(new LibraryFolderNode(path));
+        }
+
+        public StringCollection ToSettings()
+        {
+            var sc = new StringCollection();
+            foreach (var f in Folders)
+                sc.Add(f.FullPath);
+            return sc;
+        }
+
+        public bool AddFolder(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path)) return false;
+            var full = Path.GetFullPath(path);
+            if (Folders.Any(f => string.Equals(f.FullPath, full, StringComparison.OrdinalIgnoreCase)))
+                return false;
+            Folders.Add(new LibraryFolderNode(full));
+            return true;
+        }
+
+        public void RemoveFolder(LibraryFolderNode node)
+        {
+            Folders.Remove(node);
+        }
+
+        public void Refresh()
+        {
+            foreach (var f in Folders)
+                f.Refresh();
+        }
+    }
+}

--- a/Calcpad.Wpf/LibraryScanner.cs
+++ b/Calcpad.Wpf/LibraryScanner.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+
+namespace Calcpad.Wpf
+{
+    internal sealed record LibraryFunction(string Name, string Signature, int LineNumber);
+
+    internal static partial class LibraryScanner
+    {
+        // #def name$(args) = ...   or   #def name$  (multi-line block ended by #end def)
+        // Group 1: name (with trailing $ for macros)
+        // Group 2: args (optional)
+        [GeneratedRegex(@"^\s*#def\s+([A-Za-z_][A-Za-z0-9_]*\$?)\s*(?:\(([^)]*)\))?", RegexOptions.CultureInvariant)]
+        private static partial Regex MacroDefRegex();
+
+        // f(x) = expression   (single-line math function definition)
+        // Group 1: name
+        // Group 2: args
+        [GeneratedRegex(@"^\s*([A-Za-z_][A-Za-z_0-9]*)\s*\(([^)]*)\)\s*=", RegexOptions.CultureInvariant)]
+        private static partial Regex MathFuncRegex();
+
+        public static IReadOnlyList<LibraryFunction> ScanFile(string path)
+        {
+            if (string.IsNullOrEmpty(path) || !File.Exists(path))
+                return Array.Empty<LibraryFunction>();
+
+            var results = new List<LibraryFunction>();
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+
+            string[] lines;
+            try { lines = File.ReadAllLines(path); }
+            catch { return Array.Empty<LibraryFunction>(); }
+
+            for (var i = 0; i < lines.Length; i++)
+            {
+                var line = lines[i];
+                if (string.IsNullOrWhiteSpace(line) || line.TrimStart().StartsWith('\''))
+                    continue;
+
+                var m = MacroDefRegex().Match(line);
+                if (m.Success)
+                {
+                    var name = m.Groups[1].Value;
+                    var args = m.Groups[2].Success ? m.Groups[2].Value.Trim() : string.Empty;
+                    var sig = $"{name}({args})";
+                    if (seen.Add(sig))
+                        results.Add(new LibraryFunction(name, args, i + 1));
+                    continue;
+                }
+
+                m = MathFuncRegex().Match(line);
+                if (m.Success)
+                {
+                    var name = m.Groups[1].Value;
+                    var args = m.Groups[2].Value.Trim();
+                    var sig = $"{name}({args})";
+                    if (seen.Add(sig))
+                        results.Add(new LibraryFunction(name, args, i + 1));
+                }
+            }
+
+            return results;
+        }
+    }
+}

--- a/Calcpad.Wpf/MainWindow.xaml
+++ b/Calcpad.Wpf/MainWindow.xaml
@@ -1812,6 +1812,14 @@
                 ToolTip="{x:Static wpf:MainWindowResources.ShowHelp}">
             <Image Source="Resources/help.png" Width="20" Height="20" VerticalAlignment="Center" HorizontalAlignment="Center"/>
         </Button>
+        <Button Grid.Row="0" Click="LibraryButton_Click" x:Name="LibraryButton"
+                HorizontalAlignment="Left" VerticalAlignment="Top"
+                Height="24" Width="24" Margin="325,24,0,0"
+                Focusable="false" IsTabStop="false"
+                Background="{x:Null}" BorderBrush="{x:Null}"
+                ToolTip="{x:Static wpf:MainWindowResources.Library_Tooltip}">
+            <Image Source="Resources/open.png" Width="20" Height="20" VerticalAlignment="Center" HorizontalAlignment="Center"/>
+        </Button>
         <TextBlock Grid.Row="0" TextWrapping="Wrap" FontSize="11.5" Margin="0,6,146,0" Height="16"
             VerticalAlignment="Top"  HorizontalAlignment="Right" Width="110" Foreground="#DA000000"
             Text="{x:Static wpf:MainWindowResources.MaxOutputCount}" />
@@ -2231,7 +2239,79 @@
                            MouseUp="Website_MouseUp"/>
             </StatusBarItem>
         </StatusBar>
-        <Grid x:Name="FramesGrid" Margin="0,1,0,35" Grid.Row="1">
+        <Grid x:Name="MainContentGrid" Grid.Row="1" Margin="0,1,0,35">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition x:Name="LibraryColumn" Width="0"/>
+                <ColumnDefinition x:Name="LibrarySplitterColumn" Width="0"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+            <Border Grid.Column="0" x:Name="LibraryPanel" Visibility="Collapsed"
+                    BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
+                    BorderThickness="0,1,1,1" Background="#FFFAFAFA">
+                <DockPanel LastChildFill="True" Margin="2">
+                    <Border DockPanel.Dock="Top" Padding="2" Background="#FFEFEFEF">
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="{x:Static wpf:MainWindowResources.Library_Title}"
+                                       FontWeight="Bold" VerticalAlignment="Center" Margin="4,0,8,0"/>
+                            <Button x:Name="LibraryAddFolderButton"
+                                    Content="{x:Static wpf:MainWindowResources.Library_AddFolder}"
+                                    ToolTip="{x:Static wpf:MainWindowResources.Library_AddFolder_Tooltip}"
+                                    Click="LibraryAddFolderButton_Click"
+                                    Padding="6,1" Margin="0,0,4,0" FontSize="11"/>
+                            <Button x:Name="LibraryRefreshButton"
+                                    Content="{x:Static wpf:MainWindowResources.Library_Refresh}"
+                                    ToolTip="{x:Static wpf:MainWindowResources.Library_Refresh_Tooltip}"
+                                    Click="LibraryRefreshButton_Click"
+                                    Padding="6,1" FontSize="11"/>
+                        </StackPanel>
+                    </Border>
+                    <TreeView x:Name="LibraryTree"
+                              BorderThickness="0" Background="Transparent"
+                              MouseDoubleClick="LibraryTree_MouseDoubleClick"
+                              FontSize="12">
+                        <TreeView.ItemContainerStyle>
+                            <Style TargetType="TreeViewItem">
+                                <Setter Property="IsExpanded" Value="{Binding IsExpanded, Mode=TwoWay}"/>
+                            </Style>
+                        </TreeView.ItemContainerStyle>
+                        <TreeView.Resources>
+                            <HierarchicalDataTemplate DataType="{x:Type wpf:LibraryFolderNode}" ItemsSource="{Binding Children}">
+                                <StackPanel Orientation="Horizontal">
+                                    <TextBlock Text="📁 " FontFamily="Segoe UI Emoji"/>
+                                    <TextBlock Text="{Binding Name}" FontWeight="SemiBold">
+                                        <TextBlock.ContextMenu>
+                                            <ContextMenu>
+                                                <MenuItem Header="{x:Static wpf:MainWindowResources.Library_RemoveFolder}"
+                                                          Click="LibraryRemoveFolderMenuItem_Click"
+                                                          Tag="{Binding}"/>
+                                            </ContextMenu>
+                                        </TextBlock.ContextMenu>
+                                    </TextBlock>
+                                </StackPanel>
+                            </HierarchicalDataTemplate>
+                            <HierarchicalDataTemplate DataType="{x:Type wpf:LibraryFileNode}" ItemsSource="{Binding Children}">
+                                <StackPanel Orientation="Horizontal">
+                                    <TextBlock Text="📄 " FontFamily="Segoe UI Emoji"/>
+                                    <TextBlock Text="{Binding Name}"/>
+                                </StackPanel>
+                            </HierarchicalDataTemplate>
+                            <HierarchicalDataTemplate DataType="{x:Type wpf:LibraryFunctionNode}">
+                                <StackPanel Orientation="Horizontal">
+                                    <TextBlock Text="ƒ " Foreground="#FF1565C0" FontStyle="Italic"/>
+                                    <TextBlock Text="{Binding Name}"/>
+                                </StackPanel>
+                            </HierarchicalDataTemplate>
+                            <DataTemplate DataType="{x:Type wpf:LibraryPlaceholderNode}">
+                                <TextBlock Text="{Binding Name}" Foreground="Gray" FontStyle="Italic"/>
+                            </DataTemplate>
+                        </TreeView.Resources>
+                    </TreeView>
+                </DockPanel>
+            </Border>
+            <GridSplitter Grid.Column="1" x:Name="LibrarySplitter" Width="4"
+                          HorizontalAlignment="Stretch" Visibility="Collapsed"
+                          Background="#FFE3E3E3"/>
+        <Grid x:Name="FramesGrid" Grid.Column="2">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="120*"/>
                 <ColumnDefinition />
@@ -2799,6 +2879,7 @@
                     TabIndex="22" Click="CodeCheckBox_Click" FontFamily="Segoe UI Semibold" >
                 </CheckBox>
             </Border>
+        </Grid>
         </Grid>
         <TextBlock Grid.Row="0" TextWrapping="Wrap" FontSize="12.5" Margin="0,28,155,0" Height="16"
             VerticalAlignment="Top"  HorizontalAlignment="Right" Width="50"

--- a/Calcpad.Wpf/MainWindow.xaml.cs
+++ b/Calcpad.Wpf/MainWindow.xaml.cs
@@ -2293,18 +2293,13 @@ namespace Calcpad.Wpf
                     return relative;
                 }
             }
-            else if (useRelative && !_relativePathWarningShown)
+            else if (useRelative && !hasCurrentDoc && !_relativePathWarningShown)
             {
                 _relativePathWarningShown = true;
                 MessageBox.Show(MainWindowResources.SaveDocumentFirstForRelativePaths,
                     "CalcpadCE", MessageBoxButton.OK, MessageBoxImage.Information);
             }
-            else if (hasCurrentDoc)
-            {
-                var fileDir = Path.GetDirectoryName(filePath);
-                if (string.Equals(Path.GetDirectoryName(CurrentFileName), fileDir, StringComparison.OrdinalIgnoreCase))
-                    return "./" + Path.GetFileName(filePath);
-            }
+            // Relative paths off (or no saved document): always emit the absolute path.
             return filePath.Replace('\\', '/');
         }
 

--- a/Calcpad.Wpf/MainWindow.xaml.cs
+++ b/Calcpad.Wpf/MainWindow.xaml.cs
@@ -91,6 +91,7 @@ namespace Calcpad.Wpf
         private readonly UndoManager _undoMan;
         private readonly WebView2Wrapper _wv2Warper;
         private readonly InsertManager _insertManager;
+        private readonly LibraryManager _libraryManager = new();
         private readonly AutoCompleteManager _autoCompleteManager;
 
         private readonly string _readmeFileName;
@@ -237,6 +238,8 @@ namespace Calcpad.Wpf
             };
             _insertManager = new(RichTextBox);
             _autoCompleteManager = new(RichTextBox, AutoCompleteListBox, Dispatcher, _insertManager);
+            LibraryTree.ItemsSource = _libraryManager.Folders;
+            _libraryManager.LoadFromSettings(Properties.Settings.Default.LibraryFolders);
             _cfn = string.Empty;
             Title = AppInfo.Title;
             _isTextChangedEnabled = false;
@@ -710,6 +713,7 @@ namespace Calcpad.Wpf
             MaxOutputCountTextBox.Text = settings.MaxOutputCount.ToString();
             EmbedCheckBox.IsChecked = settings.Embed;
             UseRelativePathsCheckBox.IsChecked = settings.UseRelativePaths;
+            SetLibraryPanelVisible(settings.ShowLibraryPanel);
             if (settings.WindowLeft > 0) Left = settings.WindowLeft;
             if (settings.WindowTop > 0) Top = settings.WindowTop;
             if (settings.WindowWidth > 0) Width = settings.WindowWidth;
@@ -795,6 +799,10 @@ namespace Calcpad.Wpf
             settings.MaxOutputCount = int.TryParse(MaxOutputCountTextBox.Text, out int i) ? i : (int)20;
             settings.Embed = EmbedCheckBox.IsChecked ?? false;
             settings.UseRelativePaths = UseRelativePathsCheckBox.IsChecked ?? false;
+            settings.ShowLibraryPanel = LibraryPanel.Visibility == Visibility.Visible;
+            if (LibraryColumn.Width.Value > 0)
+                settings.LibraryPanelWidth = LibraryColumn.Width.Value;
+            settings.LibraryFolders = _libraryManager.ToSettings();
             settings.WindowLeft = Left;
             settings.WindowTop = Top;
             settings.WindowWidth = Width;
@@ -2130,9 +2138,143 @@ namespace Calcpad.Wpf
                 InsertImage(dlg.FileName);
         }
 
+        private void LibraryButton_Click(object sender, RoutedEventArgs e)
+        {
+            SetLibraryPanelVisible(LibraryPanel.Visibility != Visibility.Visible);
+        }
+
+        private void SetLibraryPanelVisible(bool visible)
+        {
+            if (visible)
+            {
+                var w = Properties.Settings.Default.LibraryPanelWidth;
+                if (w < 120) w = 250;
+                LibraryColumn.Width = new GridLength(w);
+                LibrarySplitterColumn.Width = new GridLength(4);
+                LibraryPanel.Visibility = Visibility.Visible;
+                LibrarySplitter.Visibility = Visibility.Visible;
+            }
+            else
+            {
+                if (LibraryColumn.Width.Value > 0)
+                    Properties.Settings.Default.LibraryPanelWidth = LibraryColumn.Width.Value;
+                LibraryColumn.Width = new GridLength(0);
+                LibrarySplitterColumn.Width = new GridLength(0);
+                LibraryPanel.Visibility = Visibility.Collapsed;
+                LibrarySplitter.Visibility = Visibility.Collapsed;
+            }
+        }
+
+        private void LibraryAddFolderButton_Click(object sender, RoutedEventArgs e)
+        {
+            var dlg = new OpenFolderDialog
+            {
+                Title = MainWindowResources.Library_SelectFolderDialog_Title,
+                Multiselect = false
+            };
+            if (dlg.ShowDialog() == true)
+                _libraryManager.AddFolder(dlg.FolderName);
+        }
+
+        private void LibraryRefreshButton_Click(object sender, RoutedEventArgs e)
+        {
+            _libraryManager.Refresh();
+        }
+
+        private void LibraryRemoveFolderMenuItem_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is MenuItem mi && mi.Tag is LibraryFolderNode folder)
+                _libraryManager.RemoveFolder(folder);
+        }
+
+        private void LibraryTree_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            switch (LibraryTree.SelectedItem)
+            {
+                case LibraryFunctionNode fn:
+                    InsertFunctionReference(fn.FilePath, fn.Function);
+                    e.Handled = true;
+                    break;
+                case LibraryFileNode file:
+                    InsertFileInclude(file.FullPath);
+                    e.Handled = true;
+                    break;
+            }
+        }
+
+        private void InsertFileInclude(string filePath)
+        {
+            var path = BuildLinkedPath(filePath);
+            _insertManager.InsertText($"#include {path}\n");
+        }
+
+        private void InsertFunctionReference(string filePath, LibraryFunction fn)
+        {
+            EnsureIncludeAtTop(filePath);
+            // Wrap the args in `{…}` so InsertManager.SelectInsertedText highlights them for quick replacement.
+            var signature = string.IsNullOrEmpty(fn.Signature) ? fn.Name : $"{fn.Name}({{{fn.Signature}}})";
+            _insertManager.InsertText($"' {signature}\n");
+        }
+
+        /// Adds an #include directive for filePath at the top of the document if one isn't already
+        /// present (case-insensitive comparison on canonicalized full paths).
+        private void EnsureIncludeAtTop(string filePath)
+        {
+            var targetFull = Path.GetFullPath(filePath);
+            Paragraph lastIncludeParagraph = null;
+            foreach (var block in _document.Blocks)
+            {
+                if (block is not Paragraph p) continue;
+                var text = new TextRange(p.ContentStart, p.ContentEnd).Text.TrimStart();
+                if (!text.StartsWith("#include", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (lastIncludeParagraph is not null) break;
+                    continue;
+                }
+                lastIncludeParagraph = p;
+                var existing = ExtractIncludePath(text);
+                if (existing is null) continue;
+                try
+                {
+                    var existingFull = Path.IsPathRooted(existing)
+                        ? Path.GetFullPath(existing)
+                        : Path.GetFullPath(existing,
+                            string.IsNullOrEmpty(CurrentFileName) ? Environment.CurrentDirectory : Path.GetDirectoryName(CurrentFileName));
+                    if (string.Equals(existingFull, targetFull, StringComparison.OrdinalIgnoreCase))
+                        return;
+                }
+                catch { /* ignore malformed include paths */ }
+            }
+
+            var path = BuildLinkedPath(filePath);
+            var newPara = new Paragraph();
+            newPara.Inlines.Add(new Run($"#include {path}"));
+            _highlighter.Parse(newPara, IsComplex, GetLineNumber(newPara), true);
+            if (lastIncludeParagraph is not null)
+                _document.Blocks.InsertAfter(lastIncludeParagraph, newPara);
+            else if (_document.Blocks.FirstBlock is not null)
+                _document.Blocks.InsertBefore(_document.Blocks.FirstBlock, newPara);
+            else
+                _document.Blocks.Add(newPara);
+        }
+
+        private static string ExtractIncludePath(string trimmedLine)
+        {
+            // Mirror MacroParser.ParseInclude (Calcpad.Core/Parsers/MacroParser.cs): path runs from
+            // index 8 to the first '#{…}' field marker (if any) or end of line. No quotes supported.
+            var afterKeyword = trimmedLine.AsSpan(8);
+            var sharp = afterKeyword.IndexOf('#');
+            if (sharp >= 0)
+                afterKeyword = afterKeyword[..sharp];
+            return afterKeyword.Trim().ToString();
+        }
+
         private bool _relativePathWarningShown;
 
-        private string BuildImageSrc(string filePath)
+        /// Returns a path string suitable for embedding in the document (image src, #include path, etc.):
+        /// relative to the current document folder when "Use relative paths" is on and the doc is saved,
+        /// otherwise the original absolute path (with forward slashes).
+        private string BuildLinkedPath(string filePath)
         {
             var hasCurrentDoc = !string.IsNullOrEmpty(CurrentFileName);
             var useRelative = UseRelativePathsCheckBox.IsChecked ?? false;
@@ -2170,7 +2312,7 @@ namespace Calcpad.Wpf
         {
             var fileName = Path.GetFileName(filePath);
             var size = GetImageSize(filePath);
-            var src = BuildImageSrc(filePath);
+            var src = BuildLinkedPath(filePath);
             var p = new Paragraph();
             p.Inlines.Add(new Run($"'<img style=\"height:{size.Height}pt; width:{size.Width}pt;\" src=\"{src}\" alt=\"{fileName}\">"));
             _highlighter.Parse(p, IsComplex, GetLineNumber(p), true);

--- a/Calcpad.Wpf/MainWindowResources.Designer.cs
+++ b/Calcpad.Wpf/MainWindowResources.Designer.cs
@@ -1042,6 +1042,50 @@ namespace Calcpad.Wpf {
             }
         }
 
+        public static string Library_Tooltip {
+            get { return ResourceManager.GetString("Library_Tooltip", resourceCulture); }
+        }
+
+        public static string Library_Title {
+            get { return ResourceManager.GetString("Library_Title", resourceCulture); }
+        }
+
+        public static string Library_AddFolder {
+            get { return ResourceManager.GetString("Library_AddFolder", resourceCulture); }
+        }
+
+        public static string Library_AddFolder_Tooltip {
+            get { return ResourceManager.GetString("Library_AddFolder_Tooltip", resourceCulture); }
+        }
+
+        public static string Library_RemoveFolder {
+            get { return ResourceManager.GetString("Library_RemoveFolder", resourceCulture); }
+        }
+
+        public static string Library_Refresh {
+            get { return ResourceManager.GetString("Library_Refresh", resourceCulture); }
+        }
+
+        public static string Library_Refresh_Tooltip {
+            get { return ResourceManager.GetString("Library_Refresh_Tooltip", resourceCulture); }
+        }
+
+        public static string Library_NoFunctionsFound {
+            get { return ResourceManager.GetString("Library_NoFunctionsFound", resourceCulture); }
+        }
+
+        public static string Library_FolderNotFound {
+            get { return ResourceManager.GetString("Library_FolderNotFound", resourceCulture); }
+        }
+
+        public static string Library_SelectFolderDialog_Title {
+            get { return ResourceManager.GetString("Library_SelectFolderDialog_Title", resourceCulture); }
+        }
+
+        public static string Library_Hide {
+            get { return ResourceManager.GetString("Library_Hide", resourceCulture); }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Enables markdown in comments.
         /// </summary>

--- a/Calcpad.Wpf/MainWindowResources.bg.resx
+++ b/Calcpad.Wpf/MainWindowResources.bg.resx
@@ -1145,6 +1145,39 @@
   <data name="SaveDocumentFirstForRelativePaths" xml:space="preserve">
     <value>Запазете документа, за да вмъквате относителни пътища. Вместо това беше използван абсолютен път.</value>
   </data>
+  <data name="Library_Tooltip" xml:space="preserve">
+    <value>Показване/скриване на панела с библиотеката</value>
+  </data>
+  <data name="Library_Title" xml:space="preserve">
+    <value>Библиотека</value>
+  </data>
+  <data name="Library_AddFolder" xml:space="preserve">
+    <value>+ Папка</value>
+  </data>
+  <data name="Library_AddFolder_Tooltip" xml:space="preserve">
+    <value>Добавяне на папка с .cpd файлове към библиотеката</value>
+  </data>
+  <data name="Library_RemoveFolder" xml:space="preserve">
+    <value>Премахни от библиотеката</value>
+  </data>
+  <data name="Library_Refresh" xml:space="preserve">
+    <value>Опресни</value>
+  </data>
+  <data name="Library_Refresh_Tooltip" xml:space="preserve">
+    <value>Повторно сканиране на папките от библиотеката</value>
+  </data>
+  <data name="Library_NoFunctionsFound" xml:space="preserve">
+    <value>(няма функции)</value>
+  </data>
+  <data name="Library_FolderNotFound" xml:space="preserve">
+    <value>Папката не е намерена: {0}</value>
+  </data>
+  <data name="Library_SelectFolderDialog_Title" xml:space="preserve">
+    <value>Изберете папка от библиотеката</value>
+  </data>
+  <data name="Library_Hide" xml:space="preserve">
+    <value>Скрий панела с библиотеката</value>
+  </data>
   <data name="MultilineExpressionBlock" xml:space="preserve">
     <value>Многоредов блок от изрази</value>
   </data>

--- a/Calcpad.Wpf/MainWindowResources.resx
+++ b/Calcpad.Wpf/MainWindowResources.resx
@@ -1146,6 +1146,39 @@ You can find your unsaved data in
   <data name="SaveDocumentFirstForRelativePaths" xml:space="preserve">
     <value>Save the document first to insert relative paths. An absolute path was used instead.</value>
   </data>
+  <data name="Library_Tooltip" xml:space="preserve">
+    <value>Show/hide library panel</value>
+  </data>
+  <data name="Library_Title" xml:space="preserve">
+    <value>Library</value>
+  </data>
+  <data name="Library_AddFolder" xml:space="preserve">
+    <value>+ Folder</value>
+  </data>
+  <data name="Library_AddFolder_Tooltip" xml:space="preserve">
+    <value>Add a folder of .cpd files to the library</value>
+  </data>
+  <data name="Library_RemoveFolder" xml:space="preserve">
+    <value>Remove from library</value>
+  </data>
+  <data name="Library_Refresh" xml:space="preserve">
+    <value>Refresh</value>
+  </data>
+  <data name="Library_Refresh_Tooltip" xml:space="preserve">
+    <value>Rescan library folders</value>
+  </data>
+  <data name="Library_NoFunctionsFound" xml:space="preserve">
+    <value>(no functions)</value>
+  </data>
+  <data name="Library_FolderNotFound" xml:space="preserve">
+    <value>Folder not found: {0}</value>
+  </data>
+  <data name="Library_SelectFolderDialog_Title" xml:space="preserve">
+    <value>Select a library folder</value>
+  </data>
+  <data name="Library_Hide" xml:space="preserve">
+    <value>Hide library panel</value>
+  </data>
   <data name="MultilineExpressionBlock" xml:space="preserve">
     <value>Multiline expression block</value>
   </data>

--- a/Calcpad.Wpf/MainWindowResources.zh.resx
+++ b/Calcpad.Wpf/MainWindowResources.zh.resx
@@ -1145,6 +1145,39 @@
   <data name="SaveDocumentFirstForRelativePaths" xml:space="preserve">
     <value>请先保存文档以便插入相对路径。本次已改用绝对路径。</value>
   </data>
+  <data name="Library_Tooltip" xml:space="preserve">
+    <value>显示/隐藏库面板</value>
+  </data>
+  <data name="Library_Title" xml:space="preserve">
+    <value>库</value>
+  </data>
+  <data name="Library_AddFolder" xml:space="preserve">
+    <value>+ 文件夹</value>
+  </data>
+  <data name="Library_AddFolder_Tooltip" xml:space="preserve">
+    <value>将 .cpd 文件夹添加到库中</value>
+  </data>
+  <data name="Library_RemoveFolder" xml:space="preserve">
+    <value>从库中移除</value>
+  </data>
+  <data name="Library_Refresh" xml:space="preserve">
+    <value>刷新</value>
+  </data>
+  <data name="Library_Refresh_Tooltip" xml:space="preserve">
+    <value>重新扫描库文件夹</value>
+  </data>
+  <data name="Library_NoFunctionsFound" xml:space="preserve">
+    <value>(无函数)</value>
+  </data>
+  <data name="Library_FolderNotFound" xml:space="preserve">
+    <value>未找到文件夹: {0}</value>
+  </data>
+  <data name="Library_SelectFolderDialog_Title" xml:space="preserve">
+    <value>选择库文件夹</value>
+  </data>
+  <data name="Library_Hide" xml:space="preserve">
+    <value>隐藏库面板</value>
+  </data>
   <data name="MultilineExpressionBlock" xml:space="preserve">
     <value>多行表达式块</value>
   </data>

--- a/Calcpad.Wpf/Properties/Settings.Designer.cs
+++ b/Calcpad.Wpf/Properties/Settings.Designer.cs
@@ -321,5 +321,40 @@ namespace Calcpad.Wpf.Properties {
                 this["UseRelativePaths"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        public global::System.Collections.Specialized.StringCollection LibraryFolders {
+            get {
+                return ((global::System.Collections.Specialized.StringCollection)(this["LibraryFolders"]));
+            }
+            set {
+                this["LibraryFolders"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("250")]
+        public double LibraryPanelWidth {
+            get {
+                return ((double)(this["LibraryPanelWidth"]));
+            }
+            set {
+                this["LibraryPanelWidth"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool ShowLibraryPanel {
+            get {
+                return ((bool)(this["ShowLibraryPanel"]));
+            }
+            set {
+                this["ShowLibraryPanel"] = value;
+            }
+        }
     }
 }

--- a/Calcpad.Wpf/Properties/Settings.settings
+++ b/Calcpad.Wpf/Properties/Settings.settings
@@ -77,5 +77,14 @@
     <Setting Name="UseRelativePaths" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="LibraryFolders" Type="System.Collections.Specialized.StringCollection" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
+    <Setting Name="LibraryPanelWidth" Type="System.Double" Scope="User">
+      <Value Profile="(Default)">250</Value>
+    </Setting>
+    <Setting Name="ShowLibraryPanel" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
## Summary

Adds a VS Code extension (`Calcpad.VSCode/`) that renders CalcpadCE `.cpd`  worksheets in a live, interactive side-by-side preview, similar to the built-in Markdown preview. It renders through the **same engine as the desktop app** by launching a bundled `Calcpad.Cli` in a new long-lived `--serve` mode (NDJSON over stdio), so there is no second parser to maintain.

 <img width="1720" height="1392" alt="image" src="https://github.com/user-attachments/assets/60687179-5b4a-47a7-9292-4089adc9233d" />

## Features

- **Live preview**: re-renders as you type (debounced) and on save.
- **Follows the active editor**: a single dynamic preview that retargets to the
  focused `.cpd`, like the Markdown preview.
- **Two modes** (toolbar toggle):
  - **Interactive** — `?` input fields and unit selectors are editable and
    recalculate live.
  - **Final** — read-only calculated output.
- **Export** to **HTML** and **DOCX** (toolbar buttons + commands + Explorer
  context menu), reusing the values currently shown.

## Implementation

- `Calcpad.Cli`: new `--serve` mode (`PreviewServer.cs`) — a warm process that
  reads `{sourceText, inputValues, units, export}` requests and returns rendered
  HTML (body-only) or writes an exported file via the existing `Converter`.
  Reuses `CalcpadReader`, `MacroParser.SetLineInputFields`, and `ExpressionParser`.
  The one-shot CLI path is unchanged.
- `Calcpad.VSCode`: TypeScript extension (esbuild). The webview reuses the
  worksheet CSS extracted from `doc/template.html`; CSP + `asWebviewUri` handle
  scripts, fonts, and relative image paths.

## Testing

- `cd Calcpad.VSCode && npm install && dotnet build ..\Calcpad.Cli && npm run build`, then **F5**.
- Verified: live update, interactive recalc, image rendering, HTML/DOCX export.

## Not included (yet)

- PDF export (needs bundling `wkhtmltopdf`).
- `.cpd` syntax highlighting (TextMate grammar).
- Packaged per-platform VSIX / Marketplace publish.