### PR TITLE
ci: pin beautifulsoup4 version to keep consistent output formatting

### DIFF
--- a/.github/workflows/compare-renderings.yml
+++ b/.github/workflows/compare-renderings.yml
@@ -29,7 +29,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install Python dependencies
-        run: python -m pip install beautifulsoup4
+        run: python -m pip install beautifulsoup4==4.14.3 # pin to specific version to keep consistent output formatting
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5


### PR DESCRIPTION
Otherwise, the formatting can change with new versions and generate false-positives in compare_renderings.py like observed in #124.