### PR TITLE
Allow combining diacritical marks inside identifiers

### DIFF
--- a/Calcpad.Core/Parsers/MathParser/MathParser.Input.cs
+++ b/Calcpad.Core/Parsers/MathParser/MathParser.Input.cs
@@ -19,7 +19,6 @@ namespace Calcpad.Core
             private readonly Dictionary<string, Variable> _variables;
             private readonly Stack<Dictionary<string, Variable>> _localVariables = new();
             private readonly Dictionary<string, Unit> _units;
-            private static readonly char[] UnitChars = Validator.UnitChars.ToCharArray();
             static Input()
             {
                 // This array is needed to quickly check the token type of a character during parsing
@@ -134,7 +133,7 @@ namespace Calcpad.Core
                     {
                         if (pt == TokenTypes.Unit || pt == TokenTypes.Variable)
                         {
-                            tt = tokenLiteral.StartsWithAny(UnitChars) ?
+                            tt = tokenLiteral.StartsWithAny(Validator.UnitChars) ?
                                 TokenTypes.Unit :
                                 TokenTypes.Variable;
 
@@ -264,7 +263,7 @@ namespace Calcpad.Core
                                         if (!tokenLiteral.IsEmpty)
                                             t = MakeUnitToken(s, true);
                                     }
-                                    else if (UnitChars.Contains(s[0]))
+                                    else if (Validator.UnitChars.Contains(s[0]))
                                         t = MakeUnitToken(s, true);
                                     else
                                         t = new VariableToken(s, null);

--- a/Calcpad.Core/TextSpan.cs
+++ b/Calcpad.Core/TextSpan.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Linq;
+using System.Buffers;
 
 namespace Calcpad.Core
 {
@@ -36,7 +36,7 @@ namespace Calcpad.Core
 
         public readonly bool StartsWith(char c) => _contents[_start] == c;
 
-        public readonly bool StartsWithAny(char[] chars) => chars.Contains(_contents[_start]);
+        public readonly bool StartsWithAny(SearchValues<char> chars) => chars.Contains(_contents[_start]);
 
         public readonly bool Equals(ReadOnlySpan<char> s) => _contents[_start.._end].SequenceEqual(s);
     }

--- a/Calcpad.Core/Validator.cs
+++ b/Calcpad.Core/Validator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Buffers;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
@@ -7,23 +8,54 @@ namespace Calcpad.Core
 {
     public static class Validator
     {
-        private const string CurrencyChars = "€£₤¥¢₽₹₩₪"; // For custom currency units
-        private const string UnitSymbolChars = "°′″%‰‱";
-        // Combining marks (́ acute, ̄ macron, ̇ dot above, ̈ diaeresis)
-        // attach to a preceding base letter, so they're allowed inside an identifier but never as a starter.
-        private const string VarSymbolChars = ",_‾‴⁗́̄̇̈";
-        private const string VarNonLetterChars = "℧∡";
-        private const string VarLetterChars = "ϑϕøØ";
-        private const string SuperscriptChars = "⁰¹²³⁴⁵⁶⁷⁸⁹⁺⁻⁼⁽⁾";
-        private const string SubscriptChars = "₀₁₂₃₄₅₆₇₈₉₊₋₌₍₎";
-        internal const string UnitChars = UnitSymbolChars + CurrencyChars;
-        private const string VarStartingChars = UnitChars + VarNonLetterChars;
-        private const string VarChars =
-            VarStartingChars +
-            VarSymbolChars +
-            SuperscriptChars +
-            SubscriptChars +
-            VarLetterChars;
+        // For custom currency units.
+        private static readonly char[] CurrencyChars =
+        [
+            '€', '£', '₤', '¥', '¢', '₽', '₹', '₩', '₪',
+        ];
+
+        private static readonly char[] UnitSymbolChars =
+        [
+            '°', '′', '″', '%', '‰', '‱',
+        ];
+
+        // Combining marks attach to a preceding base letter, so they're allowed
+        // inside an identifier but never as a starter.
+        private static readonly char[] VarSymbolChars =
+        [
+            ',', '_', '‾', '‴', '⁗',
+            '́', // combining acute
+            '̄', // combining macron
+            '̇', // combining dot above
+            '̈', // combining diaeresis
+        ];
+
+        private static readonly char[] VarNonLetterChars = ['℧', '∡'];
+        private static readonly char[] VarLetterChars = ['ϑ', 'ϕ', 'ø', 'Ø'];
+
+        private static readonly char[] SuperscriptChars =
+        [
+            '⁰', '¹', '²', '³', '⁴', '⁵', '⁶', '⁷', '⁸', '⁹',
+            '⁺', '⁻', '⁼', '⁽', '⁾',
+        ];
+
+        private static readonly char[] SubscriptChars =
+        [
+            '₀', '₁', '₂', '₃', '₄', '₅', '₆', '₇', '₈', '₉',
+            '₊', '₋', '₌', '₍', '₎',
+        ];
+
+        internal static readonly SearchValues<char> UnitChars =
+            SearchValues.Create([.. UnitSymbolChars, .. CurrencyChars]);
+
+        private static readonly SearchValues<char> VarStartingChars =
+            SearchValues.Create([.. UnitSymbolChars, .. CurrencyChars, .. VarNonLetterChars]);
+
+        private static readonly SearchValues<char> VarChars = SearchValues.Create(
+        [
+            .. UnitSymbolChars, .. CurrencyChars, .. VarNonLetterChars,
+            .. VarSymbolChars, .. SuperscriptChars, .. SubscriptChars, .. VarLetterChars,
+        ]);
 
         private static readonly Regex MyFormatRegex = new(@"^[FCEGND]\d{0,2}$|^[0#]+(,[0#]+)?(\.[0#]+)?([eE][+-]?0+)?$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 

--- a/Calcpad.Core/Validator.cs
+++ b/Calcpad.Core/Validator.cs
@@ -9,7 +9,9 @@ namespace Calcpad.Core
     {
         private const string CurrencyChars = "€£₤¥¢₽₹₩₪"; // For custom currency units
         private const string UnitSymbolChars = "°′″%‰‱";
-        private const string VarSymbolChars = ",_‾‴⁗";
+        // Combining marks (́ acute, ̄ macron, ̇ dot above, ̈ diaeresis)
+        // attach to a preceding base letter, so they're allowed inside an identifier but never as a starter.
+        private const string VarSymbolChars = ",_‾‴⁗́̄̇̈";
         private const string VarNonLetterChars = "℧∡";
         private const string VarLetterChars = "ϑϕøØ";
         private const string SuperscriptChars = "⁰¹²³⁴⁵⁶⁷⁸⁹⁺⁻⁼⁽⁾";


### PR DESCRIPTION
Add the combining acute, macron, dot-above and diaeresis marks to VarSymbolChars so they attach to a preceding base letter within an identifier, while remaining disallowed as an identifier starter.