### PR TITLE
Detect circular macro references instead of overflowing the stack

### DIFF
--- a/Calcpad.Core/Exceptions.cs
+++ b/Calcpad.Core/Exceptions.cs
@@ -232,6 +232,9 @@ namespace Calcpad.Core
         internal static MathParserException CircularReference(string name) =>
             new(string.Format(Messages.Circular_reference_detected_for_function_0, name));
 
+        internal static MathParserException CircularMacroReference(string name) =>
+            new(string.Format(Messages.Circular_reference_detected_for_macro_0, name));
+
         internal static MathParserException InvalidFunctionDefinition() =>
             new(Messages.Invalid_function_definition_exception);
 

--- a/Calcpad.Core/Messages.Designer.cs
+++ b/Calcpad.Core/Messages.Designer.cs
@@ -259,6 +259,15 @@ namespace Calcpad.Core {
         }
 
         // / <summary>
+        // /   Looks up a localized string similar to Circular reference detected for macro &quot;{0}&quot;..
+        // / </summary>
+        public static string Circular_reference_detected_for_macro_0 {
+            get {
+                return ResourceManager.GetString("Circular_reference_detected_for_macro_0", resourceCulture);
+            }
+        }
+
+        // / <summary>
         // /   Looks up a localized string similar to Condition block not initialized with &quot;#if&quot;..
         // / </summary>
         public static string Condition_block_not_initialized_with_if {

--- a/Calcpad.Core/Messages.resx
+++ b/Calcpad.Core/Messages.resx
@@ -250,6 +250,9 @@
   <data name="Circular_reference_detected_for_function_0" xml:space="preserve">
         <value>Circular reference detected for function "{0}".</value>
     </data>
+  <data name="Circular_reference_detected_for_macro_0" xml:space="preserve">
+        <value>Circular reference detected for macro "{0}".</value>
+    </data>
   <data name="Invalid_function_definition_exception" xml:space="preserve">
         <value>Invalid function definition. It has to match the pattern: "f(x; y; z...) = expression".</value>
     </data>

--- a/Calcpad.Core/Parsers/MacroParser.cs
+++ b/Calcpad.Core/Parsers/MacroParser.cs
@@ -375,7 +375,7 @@ namespace Calcpad.Core
             return fields;
         }
 
-        private static string ApplyMacros(ReadOnlySpan<char> lineContent)
+        private static string ApplyMacros(ReadOnlySpan<char> lineContent, HashSet<string> currentlyExpanding = null)
         {
             var index = lineContent.IndexOf("$");
             if (index < 0)
@@ -387,6 +387,7 @@ namespace Calcpad.Core
             var bracketCount = 0;
             var emptyMacro = new Macro(null, null);
             var macro = emptyMacro;
+            string macroKey = null;
             Queue<string> fields = null;
             if (index >= 0)
             {
@@ -414,7 +415,7 @@ namespace Calcpad.Core
 
                     if (c == ';' && bracketCount == 1 || c == ')' && bracketCount == 0)
                     {
-                        var s = ApplyMacros(textSpan.Cut());
+                        var s = ApplyMacros(textSpan.Cut(), currentlyExpanding);
                         macroArguments.Add(s);
                         textSpan.Reset(i + 1);
                         if ((macroArguments.Count == macro.ParameterCount) != (c == ')'))
@@ -428,9 +429,16 @@ namespace Calcpad.Core
                     textSpan.Expand();
                     var macroName = textSpan.ToString();
                     int j, mlen = macroName.Length - 1;
+                    macroKey = null;
                     for (j = 0; j < mlen; ++j)
-                        if (Macros.TryGetValue(macroName[j..], out macro))
+                    {
+                        var candidate = macroName[j..];
+                        if (Macros.TryGetValue(candidate, out macro))
+                        {
+                            macroKey = candidate;
                             break;
+                        }
+                    }
 
                     if (macro.IsEmpty)
                         throw Exceptions.UndefinedMacro(macroName);
@@ -445,7 +453,7 @@ namespace Calcpad.Core
                 {
                     if (!macro.IsEmpty)
                     {
-                        var s = ApplyMacros(macro.Run(macroArguments));
+                        var s = ExpandMacro(macro, macroArguments, macroKey, ref currentlyExpanding);
                         var sbLength = stringBuilder.Length;
                         SetLineInputFields(s, stringBuilder, fields, false);
                         if (stringBuilder.Length == sbLength)
@@ -479,10 +487,20 @@ namespace Calcpad.Core
             }
             else if (macroArguments.Count == macro.ParameterCount)
             {
-                var s = ApplyMacros(macro.Run(macroArguments));
+                var s = ExpandMacro(macro, macroArguments, macroKey, ref currentlyExpanding);
                 stringBuilder.Append(s);
             }
             return stringBuilder.ToString();
+        }
+
+        private static string ExpandMacro(Macro macro, List<string> macroArguments, string macroKey, ref HashSet<string> currentlyExpanding)
+        {
+            if (currentlyExpanding != null && currentlyExpanding.Contains(macroKey))
+                throw Exceptions.CircularMacroReference(macroKey);
+            currentlyExpanding ??= new HashSet<string>(StringComparer.Ordinal);
+            currentlyExpanding.Add(macroKey);
+            try { return ApplyMacros(macro.Run(macroArguments), currentlyExpanding); }
+            finally { currentlyExpanding.Remove(macroKey); }
         }
 
 

--- a/Calcpad.Tests/RecursiveMacroTests.cs
+++ b/Calcpad.Tests/RecursiveMacroTests.cs
@@ -1,0 +1,52 @@
+namespace Calcpad.Tests;
+
+public class RecursiveMacroTests
+{
+    [Fact]
+    public void DirectSelfReference_ReportsCircularError_DoesNotOverflow()
+    {
+        var macroParser = new MacroParser();
+        var source = "#def selfref$ = selfref$\nselfref$\n";
+
+        var hasErrors = macroParser.Parse(source, out var expanded, null, 0, false);
+
+        Assert.True(hasErrors);
+        Assert.Contains("ircular", expanded);
+    }
+
+    [Fact]
+    public void MutualRecursion_ReportsCircularError_DoesNotOverflow()
+    {
+        var macroParser = new MacroParser();
+        var source = "#def alpha$ = beta$\n#def beta$ = alpha$\nalpha$\n";
+
+        var hasErrors = macroParser.Parse(source, out var expanded, null, 0, false);
+
+        Assert.True(hasErrors);
+        Assert.Contains("ircular", expanded);
+    }
+
+    [Fact]
+    public void ParameterizedSelfReference_ReportsCircularError_DoesNotOverflow()
+    {
+        var macroParser = new MacroParser();
+        var source = "#def grow$(x$) = grow$(x$)\ngrow$(1)\n";
+
+        var hasErrors = macroParser.Parse(source, out var expanded, null, 0, false);
+
+        Assert.True(hasErrors);
+        Assert.Contains("ircular", expanded);
+    }
+
+    [Fact]
+    public void NonCyclicNesting_StillExpandsFully()
+    {
+        var macroParser = new MacroParser();
+        var source = "#def one$ = 1\n#def two$ = one$ + one$\n#def three$ = two$ + one$\nthree$\n";
+
+        var hasErrors = macroParser.Parse(source, out var expanded, null, 0, false);
+
+        Assert.False(hasErrors);
+        Assert.Contains("1 + 1 + 1", expanded);
+    }
+}


### PR DESCRIPTION
Thread a `currentlyExpanding` set through macro expansion so a macro that references itself (directly, mutually, or via parameters) raises a clear "Circular reference detected for macro" error rather than recursing until the stack overflows. Adds RecursiveMacroTests covering direct, mutual and parameterized cycles plus a non-cyclic nesting regression check.