### PR TITLE
chore: fix Git history

### DIFF
--- a/Calcpad.Core/Messages.Designer.cs
+++ b/Calcpad.Core/Messages.Designer.cs
@@ -268,6 +268,15 @@ namespace Calcpad.Core {
         }
 
         // / <summary>
+        // /   Looks up a localized string similar to Circular #include detected: &quot;{0}&quot;..
+        // / </summary>
+        public static string Circular_include_detected_0 {
+            get {
+                return ResourceManager.GetString("Circular_include_detected_0", resourceCulture);
+            }
+        }
+
+        // / <summary>
         // /   Looks up a localized string similar to Condition block not initialized with &quot;#if&quot;..
         // / </summary>
         public static string Condition_block_not_initialized_with_if {

--- a/Calcpad.Core/Messages.resx
+++ b/Calcpad.Core/Messages.resx
@@ -253,6 +253,9 @@
   <data name="Circular_reference_detected_for_macro_0" xml:space="preserve">
         <value>Circular reference detected for macro "{0}".</value>
     </data>
+  <data name="Circular_include_detected_0" xml:space="preserve">
+        <value>Circular #include detected: "{0}".</value>
+    </data>
   <data name="Invalid_function_definition_exception" xml:space="preserve">
         <value>Invalid function definition. It has to match the pattern: "f(x; y; z...) = expression".</value>
     </data>

--- a/Calcpad.Core/Parsers/MacroParser.cs
+++ b/Calcpad.Core/Parsers/MacroParser.cs
@@ -82,8 +82,14 @@ namespace Calcpad.Core
             Include,
         }
         private readonly List<int> _lineNumbers = [];
+        // Filesystem path comparison must match the host OS to avoid false-positive circular
+        // detection on case-sensitive filesystems (Linux) or missed detection on Windows.
+        private static readonly StringComparer PathComparer =
+            OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+        private readonly HashSet<string> _includeStack = new(PathComparer);
         private static readonly Dictionary<string, Macro> Macros = new(StringComparer.Ordinal);
         public Func<string, Queue<string>, string> Include;
+        public string SourceFilePath { get; set; }
 
         private static Keywords GetKeyword(ReadOnlySpan<char> s)
         {
@@ -108,6 +114,7 @@ namespace Calcpad.Core
                 sb = new StringBuilder(sourceCode.Length);
                 Macros.Clear();
                 _lineNumbers.Clear();
+                _includeStack.Clear();
                 _parsedLineNumber = 0;
             }
             var macroBuilder = new StringBuilder(1000);
@@ -210,11 +217,7 @@ namespace Calcpad.Core
                 if (n < 9)
                     n = lineContent.Length;
 
-                var includeFileName = lineContent[8..n].Trim().ToString();
-                includeFileName = Path.GetFullPath(Environment.ExpandEnvironmentVariables(includeFileName));
-                var fileExists = File.Exists(includeFileName);
-                if (!fileExists)
-                    AppendError(lineContent, Messages.File_not_found);
+                var rawFileName = lineContent[8..n].Trim().ToString();
 
                 Queue<string> fields = new();
                 if (nf1 > 0)
@@ -229,8 +232,41 @@ namespace Calcpad.Core
                             fields.Enqueue(item.Trim().ToString());
                     }
                 }
-                if (fileExists)
-                    Parse(Include(includeFileName, fields), out _, sb, lineNumber, addLineNumbers);
+
+                var sourceDir = !string.IsNullOrEmpty(SourceFilePath)
+                    ? Path.GetDirectoryName(SourceFilePath) : null;
+                var expanded = Environment.ExpandEnvironmentVariables(rawFileName);
+                var resolvedPath = sourceDir != null
+                    ? Path.GetFullPath(expanded, sourceDir)
+                    : Path.GetFullPath(expanded);
+                var fileExists = File.Exists(resolvedPath);
+
+                if (!_includeStack.Add(resolvedPath))
+                {
+                    AppendError(lineContent, string.Format(Messages.Circular_include_detected_0, rawFileName));
+                    return;
+                }
+                try
+                {
+                    if (fileExists)
+                    {
+                        ParseWithSourcePath(Include(resolvedPath, fields), resolvedPath);
+                        return;
+                    }
+                    AppendError(lineContent, Messages.File_not_found);
+                }
+                finally
+                {
+                    _includeStack.Remove(resolvedPath);
+                }
+            }
+
+            void ParseWithSourcePath(string content, string newSourcePath)
+            {
+                var savedSourcePath = SourceFilePath;
+                SourceFilePath = newSourcePath;
+                try { Parse(content, out _, sb, lineNumber, addLineNumbers); }
+                finally { SourceFilePath = savedSourcePath; }
             }
 
             void ParseDef(ReadOnlySpan<char> lineContent)

--- a/Calcpad.Tests/IncludeResolutionTests.cs
+++ b/Calcpad.Tests/IncludeResolutionTests.cs
@@ -1,0 +1,125 @@
+namespace Calcpad.Tests;
+
+[Collection("CwdMutating")]
+public class IncludeResolutionTests
+{
+    [Fact]
+    public void DirectSelfInclude_ReportsCircularError_DoesNotOverflow()
+    {
+        using var temp = new TempDir();
+        temp.Write("a.cpd", "#include a.cpd\n");
+
+        var macroParser = new MacroParser { Include = (f, _) => File.ReadAllText(f) };
+        macroParser.Parse("#include a.cpd\n", out var expanded, null, 0, false);
+
+        Assert.Contains("ircular", expanded);
+    }
+
+    [Fact]
+    public void MutualCircularInclude_ReportsCircularError_DoesNotOverflow()
+    {
+        using var temp = new TempDir();
+        temp.Write("a.cpd", "#include b.cpd\n");
+        temp.Write("b.cpd", "#include a.cpd\n");
+
+        var macroParser = new MacroParser { Include = (f, _) => File.ReadAllText(f) };
+        macroParser.Parse("#include a.cpd\n", out var expanded, null, 0, false);
+
+        Assert.Contains("ircular", expanded);
+    }
+
+    [Fact]
+    public void SiblingInclude_ExpandsCleanly()
+    {
+        using var temp = new TempDir();
+        temp.Write("a.cpd", "#include b.cpd\n");
+        temp.Write("b.cpd", "leaf = 1\n");
+
+        var macroParser = new MacroParser { Include = (f, _) => File.ReadAllText(f) };
+        macroParser.Parse("#include a.cpd\n", out var expanded, null, 0, false);
+
+        Assert.DoesNotContain("ircular", expanded);
+        Assert.DoesNotContain("not found", expanded);
+        Assert.Contains("leaf = 1", expanded);
+    }
+
+    [Fact]
+    public void NestedRelativeInclude_ResolvesAgainstParentFileDirectory()
+    {
+        using var temp = new TempDir();
+        temp.Write("main.cpd", "#include lib/helper.cpd\n");
+        temp.WriteSub("lib", "helper.cpd", "#include sibling.cpd\n");
+        temp.WriteSub("lib", "sibling.cpd", "leaf = 1\n");
+
+        var macroParser = new MacroParser { Include = (f, _) => File.ReadAllText(f) };
+        macroParser.Parse("#include main.cpd\n", out var expanded, null, 0, false);
+
+        Assert.DoesNotContain("not found", expanded);
+        Assert.Contains("leaf = 1", expanded);
+    }
+
+    [Fact]
+    public void AbsoluteInclude_ToFileOutsideMainsTree_ResolvesAndChainsRelative()
+    {
+        using var temp = new TempDir();
+        var externalPath = temp.WriteSub("external", "x.cpd", "#include y.cpd\n");
+        temp.WriteSub("external", "y.cpd", "leaf = outside\n");
+        var mainPath = temp.WriteSub("project/sub", "main.cpd", $"#include {externalPath}\n");
+
+        var macroParser = new MacroParser { Include = (f, _) => File.ReadAllText(f) };
+        macroParser.Parse($"#include {mainPath}\n", out var expanded, null, 0, false);
+
+        Assert.DoesNotContain("not found", expanded);
+        Assert.Contains("leaf = outside", expanded);
+    }
+
+    [Fact]
+    public void DeepInclude_RelativeAndAbsoluteAndRelativeAgain_ResolveCorrectly()
+    {
+        using var temp = new TempDir();
+        temp.Write("main.cpd", "#include lvl1/a.cpd\n");
+        temp.WriteSub("lvl1", "a.cpd", "#include lvl2/b.cpd\n");
+        temp.WriteSub("lvl1/lvl2", "b.cpd", "#include lvl3/c.cpd\n");
+        temp.WriteSub("lvl1/lvl2/lvl3", "c.cpd", "#include lvl4/d.cpd\n");
+        var cousinPath = temp.WriteSub("lvl1/lvl2/other", "e.cpd", "#include f.cpd\n");
+        temp.WriteSub("lvl1/lvl2/other", "f.cpd", "leaf = chain\n");
+        temp.WriteSub("lvl1/lvl2/lvl3/lvl4", "d.cpd", $"#include {cousinPath}\n");
+
+        var macroParser = new MacroParser { Include = (f, _) => File.ReadAllText(f) };
+        macroParser.Parse("#include main.cpd\n", out var expanded, null, 0, false);
+
+        Assert.DoesNotContain("not found", expanded);
+        Assert.Contains("leaf = chain", expanded);
+    }
+
+    private sealed class TempDir : IDisposable
+    {
+        private readonly string _previousCwd;
+        public string Path { get; } = System.IO.Path.Combine(System.IO.Path.GetTempPath(), System.IO.Path.GetRandomFileName());
+        public TempDir()
+        {
+            Directory.CreateDirectory(Path);
+            _previousCwd = Directory.GetCurrentDirectory();
+            Directory.SetCurrentDirectory(Path);
+        }
+        public string Write(string name, string content)
+        {
+            var p = System.IO.Path.Combine(Path, name);
+            File.WriteAllText(p, content);
+            return p;
+        }
+        public string WriteSub(string sub, string name, string content)
+        {
+            var dir = System.IO.Path.Combine(Path, sub);
+            Directory.CreateDirectory(dir);
+            var p = System.IO.Path.Combine(dir, name);
+            File.WriteAllText(p, content);
+            return p;
+        }
+        public void Dispose()
+        {
+            Directory.SetCurrentDirectory(_previousCwd);
+            Directory.Delete(Path, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
I accidentally pushed directly to main, so this PR will just re-revert the removal. I figured this was safer than changing git history now that more people are involved.

Reapply "Fixing crash with recursive includes and fixing bug where nested includes would fail to resolve relative paths. Writing tests to prove the new behavior works (note that this test will crash older versions)."

This reverts commit 4bb131097f340e8c568e59173f32dc291f2ee04d.