### PR TITLE
installer: fix potential font file in use error when updating CalcpadCE or uninstalling it

### DIFF
--- a/Calcpad.Wpf/Installer/CalcpadCE.nsi
+++ b/Calcpad.Wpf/Installer/CalcpadCE.nsi
@@ -59,7 +59,6 @@ ManifestDPIAware System
 !macro ProcessFonts ACTION UID_PREFIX
   !insertmacro ProcessFontPattern "${ACTION}" "*.ttf" "${UID_PREFIX}ttf"
   !insertmacro ProcessFontPattern "${ACTION}" "*.otf" "${UID_PREFIX}otf"
-  System::Call 'user32::SendMessageTimeoutW(p 0xFFFF, i ${WM_FONTCHANGE}, p 0, p 0, i 2, i 1000, *p .r2)'
 !macroend
 
 ;--------------------------------


### PR DESCRIPTION
This disables the system broadcast, notifiying other running applications, that a new font file has been installed.

This seemed to cause trouble at least with Firefox. I observed this on the examples website that Georgia Pro isn't displayed correctly anymore immediately after the CalcpadCE installer has been run, adding these fonts. Also, when running the installer again, Firefox seems to keep the Georgia Pro font files open, although they are only installed inside the CalcpadCE directory. Then, the installer fails to overwrite them during update. Looks like a bug in Firefox.

Maybe other programs behave also weird, so I removed this broadcast, which is only required when installing fonts system-wide, actually.