### PR TITLE
CI: add winget release automation

### DIFF
--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -1,0 +1,21 @@
+name: Publish to WinGet
+
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to submit (e.g. v7.6.4)'
+        required: true
+
+jobs:
+  winget-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: vedantmgoyal9/winget-releaser@main
+        with:
+          identifier: Imartincei.CalcpadCE
+          installers-regex: '\.exe$'
+          release-tag: ${{ inputs.tag || github.event.release.tag_name }}
+          token: ${{ secrets.WINGET_PKGS_TOKEN }}

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -83,3 +83,22 @@ Generation can be started by invoking this command.
 A local webserver will spawn to serve the rendered documentation:
 
 `mkdocs serve`
+
+## Creating a Release
+
+Releasing is automated via GitHub Actions.
+The workflow is as follows:
+
+Items marked with 🫵, require an action by you.
+
+- 🫵 Push a tag in the format `vX.Y.Z`.
+- The artifacts for all platforms are built.
+- A release draft is created on the repo's Releases page.
+- A workflow is triggered to create a PR updating the version on the website.
+- 🫵 Edit the draft and the automatically generated release notes. Remove all release notes lines:
+  - starting with `chore:`, `CI:`, `docs:`
+  - refactorings, which are not relevant from the user's perspective
+  - fixes which addressed only unreleased code
+- 🫵 Click on "Publish Release".
+- A workflow is triggered to create a PR in the winget repo updating the version.
+- 🫵 Write an announcement on GitHub Discussions.


### PR DESCRIPTION
This automatically files a PR in `microsoft/winget-pkgs` when a CalcpadCE release is published.

The PR is filed in the name of the repo owner (imartincei). Therefore, a Personal Access Token needs to be created to grant the workflow access to other public repos.

GitHub profile -> Credentials -> Personal access token (classic) -> Generate new token (classic) -> Check "public_repo"

This PAT needs to be added in the repo's settings:

Secrets and variables → Actions → New repository secret (name: WINGET_PKGS_TOKEN)

Finally, fork `microsoft/winget-pkgs` so that the Action can create a branch for the PR being filed.

I also added a documentation how the release workflow works.