### PR TITLE
Allow empty parameters to be passed to macros

### DIFF
--- a/Calcpad.Core/Parsers/MacroParser.cs
+++ b/Calcpad.Core/Parsers/MacroParser.cs
@@ -63,7 +63,7 @@ namespace Calcpad.Core
                 {
                     var j = _order[i];
                     var s = arguments[j];
-                    if (s[0] == ' ' && s.Length > 1)
+                    if (s.Length > 1 && s[0] == ' ')
                         sb.Replace(_parameters[j], s[1..]);
                     else
                         sb.Replace(_parameters[j], s);
@@ -452,7 +452,7 @@ namespace Calcpad.Core
                     if (c == ';' && bracketCount == 1 || c == ')' && bracketCount == 0)
                     {
                         var s = ApplyMacros(textSpan.Cut(), currentlyExpanding);
-                        macroArguments.Add(s);
+                        macroArguments.Add(string.IsNullOrWhiteSpace(s) ? string.Empty : s);
                         textSpan.Reset(i + 1);
                         if ((macroArguments.Count == macro.ParameterCount) != (c == ')'))
                             throw Exceptions.InvalidNumberOfArguments();

--- a/Calcpad.Tests/EmptyMacroArgumentTests.cs
+++ b/Calcpad.Tests/EmptyMacroArgumentTests.cs
@@ -1,0 +1,47 @@
+namespace Calcpad.Tests;
+
+public class EmptyMacroArgumentTests
+{
+    private static string Expand(string source)
+    {
+        var macroParser = new MacroParser();
+        var hasErrors = macroParser.Parse(source, out var expanded, null, 0, false);
+        Assert.False(hasErrors, expanded);
+        return expanded;
+    }
+
+    [Fact]
+    public void LeadingEmptyArguments_ExpandToEmptyStrings()
+    {
+        var expanded = Expand("#def m$(a$;b$;c$) = a$|b$|c$\nm$(;;2)\n");
+        Assert.Contains("||2", expanded);
+    }
+
+    [Fact]
+    public void TrailingEmptyArguments_ExpandToEmptyStrings()
+    {
+        var expanded = Expand("#def m$(a$;b$;c$) = a$|b$|c$\nm$(1;;)\n");
+        Assert.Contains("1||", expanded);
+    }
+
+    [Fact]
+    public void MiddleEmptyArgument_ExpandsToEmptyString()
+    {
+        var expanded = Expand("#def m$(a$;b$;c$) = a$|b$|c$\nm$(1;;3)\n");
+        Assert.Contains("1||3", expanded);
+    }
+
+    [Fact]
+    public void WhitespaceOnlyArgument_TreatedAsEmpty()
+    {
+        var expanded = Expand("#def m$(a$;b$;c$) = a$|b$|c$\nm$( ; ;2)\n");
+        Assert.Contains("||2", expanded);
+    }
+
+    [Fact]
+    public void AllEmptyArguments_ExpandToEmptyStrings()
+    {
+        var expanded = Expand("#def m$(a$;b$) = [a$b$]\nm$(;)\n");
+        Assert.Contains("[]", expanded);
+    }
+}


### PR DESCRIPTION
Empty or whitespace-only macro arguments now expand to empty strings instead of failing, e.g. m$(;;2) or m$(1;;).