### PR TITLE
Line-link arrows now target the true source line in for loops

### DIFF
--- a/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.LineInfo.cs
+++ b/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.LineInfo.cs
@@ -7,12 +7,19 @@ namespace Calcpad.Core
         {
             internal readonly Keyword Keyword;
             internal readonly List<Token> Tokens;
+            // Original source-file line number carried through macro/include expansion
+            // (via the '\v{line}' marker MacroParser writes). Cached alongside Tokens so
+            // repeat-loop iterations that hit the fast path can restore _parser.Line and
+            // any downstream HTML markers (data-source-line, error-link targets) stay
+            // pointed at the true source line instead of drifting to whatever ran last.
+            internal readonly int SourceLine;
             internal bool IsCached => Tokens is not null;
 
-            internal LineInfo(List<Token> tokens, Keyword keyword)
+            internal LineInfo(List<Token> tokens, Keyword keyword, int sourceLine = 0)
             {
                 Tokens = tokens;
                 Keyword = keyword;
+                SourceLine = sourceLine;
             }
         }
     }

--- a/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.LineInfo.cs
+++ b/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.LineInfo.cs
@@ -7,11 +7,6 @@ namespace Calcpad.Core
         {
             internal readonly Keyword Keyword;
             internal readonly List<Token> Tokens;
-            // Original source-file line number carried through macro/include expansion
-            // (via the '\v{line}' marker MacroParser writes). Cached alongside Tokens so
-            // repeat-loop iterations that hit the fast path can restore _parser.Line and
-            // any downstream HTML markers (data-source-line, error-link targets) stay
-            // pointed at the true source line instead of drifting to whatever ran last.
             internal readonly int SourceLine;
             internal bool IsCached => Tokens is not null;
 

--- a/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.Loops.cs
+++ b/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.Loops.cs
@@ -13,9 +13,6 @@ namespace Calcpad.Core
             protected int _iteration;
             internal int Id { get; }
             internal int Iteration => _iteration;
-            // The starting iteration count (a countdown that _iteration reaches on the
-            // final pass). Kept alongside _iteration so callers can tell "first pass"
-            // (Iteration == InitialCount) from "final pass" (Iteration == 1).
             internal int InitialCount { get; }
             internal bool IsFirstPass => _iteration == InitialCount;
             private protected Loop(int startLine, double count, int id)

--- a/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.Loops.cs
+++ b/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.Loops.cs
@@ -13,6 +13,11 @@ namespace Calcpad.Core
             protected int _iteration;
             internal int Id { get; }
             internal int Iteration => _iteration;
+            // The starting iteration count (a countdown that _iteration reaches on the
+            // final pass). Kept alongside _iteration so callers can tell "first pass"
+            // (Iteration == InitialCount) from "final pass" (Iteration == 1).
+            internal int InitialCount { get; }
+            internal bool IsFirstPass => _iteration == InitialCount;
             private protected Loop(int startLine, double count, int id)
             {
                 _startLine = startLine;
@@ -20,6 +25,7 @@ namespace Calcpad.Core
                     count = MaxCount;
 
                 _iteration = (int)count;
+                InitialCount = _iteration;
                 Id = id;
             }
             internal bool Iterate(ref int currentLine)

--- a/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.cs
+++ b/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.cs
@@ -51,10 +51,21 @@ namespace Calcpad.Core
         public void Cancel() => _parser?.Cancel();
         public void Pause() => _isPausedByUser = true;
 
-        private string HtmlId =>
-            Debug && (_loops.Count == 0 || _loops.Peek().Iteration == 1) ?
-            $" id=\"line-{_currentLine + 1}\" class=\"line\"" :
-            string.Empty;
+        // Debug mode emits class="line" + data-source-line on every iteration so the
+        // preview line-link arrows appear on repeated loop output too, but only stamps
+        // id="line-N" once (first loop pass or outside any loop) since the id is the
+        // scroll target and getElementById returns only the first match.
+        private string HtmlId
+        {
+            get
+            {
+                if (!Debug) return string.Empty;
+                var isFirstPass = _loops.Count == 0 || _loops.Peek().IsFirstPass;
+                return isFirstPass
+                    ? $" id=\"line-{_currentLine + 1}\" data-source-line=\"{_parser.Line}\" class=\"line\""
+                    : $" data-source-line=\"{_parser.Line}\" class=\"line\"";
+            }
+        }
 
         public void Parse(string sourceCode, bool calculate = true, bool getXml = true) =>
             Parse(sourceCode.AsSpan(), calculate, getXml);
@@ -91,6 +102,14 @@ namespace Calcpad.Core
                     {
                         if (IsEnabled())
                         {
+                            // Restore the source line from cache. Loop iterations reach
+                            // this fast path without re-reading the '\v' marker, so
+                            // without this _parser.Line would drift to whatever the last
+                            // non-cached line set — pulling data-source-line and error
+                            // targets off the actual source line.
+                            _parser.Line = currentLineCache.SourceLine != 0
+                                ? currentLineCache.SourceLine
+                                : _currentLine + 1;
                             _condition.SetCondition(-1);
                             _parser.IsCalculation = _isVal != -1;
                             ParseLine(currentLineCache.Tokens, Keyword.None);
@@ -143,7 +162,7 @@ namespace Calcpad.Core
                     _parser.IsConst = false;
                     var result = ParseKeyword(textSpan, ref keyword);
                     if (keyword != currentLineCache.Keyword)
-                        _lineCache[lineCache] = new(currentLineCache.Tokens, keyword);
+                        _lineCache[lineCache] = new(currentLineCache.Tokens, keyword, _parser.Line);
 
                     if (result == KeywordResult.Continue)
                         continue;
@@ -164,7 +183,7 @@ namespace Calcpad.Core
                             if (_isMarkdownOn)
                                 ParseMarkdown(tokens);
 
-                            _lineCache[_currentLine] = new(tokens, keyword);
+                            _lineCache[_currentLine] = new(tokens, keyword, _parser.Line);
                         }
                         _parser.HasInputFields = false;
                         ParseLine(tokens, keyword);

--- a/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.cs
+++ b/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.cs
@@ -51,19 +51,14 @@ namespace Calcpad.Core
         public void Cancel() => _parser?.Cancel();
         public void Pause() => _isPausedByUser = true;
 
-        // Debug mode emits class="line" + data-source-line on every iteration so the
-        // preview line-link arrows appear on repeated loop output too, but only stamps
-        // id="line-N" once (first loop pass or outside any loop) since the id is the
-        // scroll target and getElementById returns only the first match.
         private string HtmlId
         {
             get
             {
                 if (!Debug) return string.Empty;
                 var isFirstPass = _loops.Count == 0 || _loops.Peek().IsFirstPass;
-                return isFirstPass
-                    ? $" id=\"line-{_currentLine + 1}\" data-source-line=\"{_parser.Line}\" class=\"line\""
-                    : $" data-source-line=\"{_parser.Line}\" class=\"line\"";
+                var idAttribute = isFirstPass ? $" id=\"line-{_currentLine + 1}\"" : string.Empty;
+                return $"{idAttribute} data-source-line=\"{_parser.Line}\" class=\"line\"";
             }
         }
 
@@ -102,11 +97,6 @@ namespace Calcpad.Core
                     {
                         if (IsEnabled())
                         {
-                            // Restore the source line from cache. Loop iterations reach
-                            // this fast path without re-reading the '\v' marker, so
-                            // without this _parser.Line would drift to whatever the last
-                            // non-cached line set — pulling data-source-line and error
-                            // targets off the actual source line.
                             _parser.Line = currentLineCache.SourceLine != 0
                                 ? currentLineCache.SourceLine
                                 : _currentLine + 1;

--- a/Calcpad.Wpf/MainWindow.xaml.cs
+++ b/Calcpad.Wpf/MainWindow.xaml.cs
@@ -528,11 +528,15 @@ namespace Calcpad.Wpf
 
         private int _scrollOutputToLine;
         private double _scrollOffset;
-        private async void LineClicked(string data)
+        private async void LineClicked(string data, bool isSourceLink = false)
         {
             if (int.TryParse(data, out var line) && line > 0)
             {
-                if (_highlighter.Defined.HasMacros && !IsUnwarpedCode)
+                // isSourceLink means the click came from a .lineLink arrow whose data-text
+                // is already the source line (from Calcpad.Core's data-source-line
+                // attribute), so the wrapped→unwrapped two-step below would misroute the
+                // scroll — skip it and navigate the editor directly.
+                if (!isSourceLink && _highlighter.Defined.HasMacros && !IsUnwarpedCode)
                 {
                     _scrollOffset = await _wv2Warper.GetVerticalPositionAsync(line);
                     _scrollOutputToLine = line;
@@ -3814,7 +3818,7 @@ namespace Calcpad.Wpf
 
         private async void WebViewer_LinkClicked()
         {
-            var s = await _wv2Warper.GetLinkDataAsync();
+            var (s, className) = await _wv2Warper.GetLinkDataAndClassAsync();
             if (s is null)
                 return;
 
@@ -3848,7 +3852,14 @@ namespace Calcpad.Wpf
                 else if (s == "cancel")
                     Cancel();
                 else if (IsCalculated || _parser.IsPaused)
-                    LineClicked(s);
+                {
+                    // .lineLink arrows carry the source line in data-text (Calcpad.Core's
+                    // data-source-line attribute), so they can skip the wrapped→unwrapped
+                    // two-step and navigate the editor directly. Error links and line-num
+                    // anchors go through the normal LineClicked path.
+                    var isSourceLink = className != null && className.Contains("lineLink");
+                    LineClicked(s, isSourceLink);
+                }
                 else if (!IsWebForm)
                     LinkClicked(s);
             }

--- a/Calcpad.Wpf/MainWindow.xaml.cs
+++ b/Calcpad.Wpf/MainWindow.xaml.cs
@@ -532,10 +532,6 @@ namespace Calcpad.Wpf
         {
             if (int.TryParse(data, out var line) && line > 0)
             {
-                // isSourceLink means the click came from a .lineLink arrow whose data-text
-                // is already the source line (from Calcpad.Core's data-source-line
-                // attribute), so the wrapped→unwrapped two-step below would misroute the
-                // scroll — skip it and navigate the editor directly.
                 if (!isSourceLink && _highlighter.Defined.HasMacros && !IsUnwarpedCode)
                 {
                     _scrollOffset = await _wv2Warper.GetVerticalPositionAsync(line);

--- a/Calcpad.Wpf/WebView2Wrapper.cs
+++ b/Calcpad.Wpf/WebView2Wrapper.cs
@@ -46,6 +46,16 @@ namespace Calcpad.Wpf
 
         internal async Task<string> GetLinkDataAsync()
         {
+            var (data, _) = await GetLinkDataAndClassAsync();
+            return data;
+        }
+
+        // Returns both the anchor's data-text and its className so the caller can
+        // tell a .lineLink click (data-text is a source line — navigate directly)
+        // from an error-link or line-num click (data-text may be an output line —
+        // may need the wrapped→unwrapped two-step).
+        internal async Task<(string Data, string ClassName)> GetLinkDataAndClassAsync()
+        {
             try
             {
                 var tagName = await InvokeScriptAsync<string>("document.activeElement.tagName");
@@ -53,17 +63,20 @@ namespace Calcpad.Wpf
                 {
                     var linkData = await InvokeScriptAsync<string>("document.activeElement.getAttribute('data-text')");
                     if (linkData != "undefined")
-                        return linkData;
+                    {
+                        var className = await InvokeScriptAsync<string>("document.activeElement.className || ''");
+                        return (linkData, className ?? string.Empty);
+                    }
                 }
                 else if (tagName == "SELECT")
                 {
                     var linkData = await InvokeScriptAsync<string>("document.activeElement.value");
                     if (linkData != "undefined")
-                        return linkData;
+                        return (linkData, string.Empty);
                 }
             }
             catch { }
-            return null;
+            return (null, string.Empty);
         }
 
         internal async Task<string> GetUnitsAsync()

--- a/Calcpad.Wpf/WebView2Wrapper.cs
+++ b/Calcpad.Wpf/WebView2Wrapper.cs
@@ -50,10 +50,6 @@ namespace Calcpad.Wpf
             return data;
         }
 
-        // Returns both the anchor's data-text and its className so the caller can
-        // tell a .lineLink click (data-text is a source line — navigate directly)
-        // from an error-link or line-num click (data-text may be an output line —
-        // may need the wrapped→unwrapped two-step).
         internal async Task<(string Data, string ClassName)> GetLinkDataAndClassAsync()
         {
             try

--- a/Calcpad.Wpf/doc/template.bg.html
+++ b/Calcpad.Wpf/doc/template.bg.html
@@ -887,8 +887,12 @@
                 });
 
                 $(".line:not(style, script)").each(function () {
-                    var line = $(this).prop("id").split("-")[1];
-                    var $lineLink = $('<a class="lineLink" href="#0" data-text="' + line + '" title="Code line ' + line + '">&larr;</a>');
+                    // data-source-line is stamped by Calcpad.Core (ExpressionParser)
+                    // on every emitted .line, including loop iterations past the first
+                    // where the id is dropped (id is the scroll anchor and must be unique).
+                    var line = $(this).attr("data-source-line");
+                    if (!line) return;
+                    var $lineLink = $('<a class="lineLink" href="#0" data-text="' + line + '" title="Source line ' + line + '">&larr;</a>');
                     $(this).append($lineLink);
                     $lineLink.hide();
                     $(this).hover(function () {

--- a/Calcpad.Wpf/doc/template.bg.html
+++ b/Calcpad.Wpf/doc/template.bg.html
@@ -887,9 +887,6 @@
                 });
 
                 $(".line:not(style, script)").each(function () {
-                    // data-source-line is stamped by Calcpad.Core (ExpressionParser)
-                    // on every emitted .line, including loop iterations past the first
-                    // where the id is dropped (id is the scroll anchor and must be unique).
                     var line = $(this).attr("data-source-line");
                     if (!line) return;
                     var $lineLink = $('<a class="lineLink" href="#0" data-text="' + line + '" title="Source line ' + line + '">&larr;</a>');

--- a/Calcpad.Wpf/doc/template.html
+++ b/Calcpad.Wpf/doc/template.html
@@ -887,8 +887,12 @@
                 });
 
                 $(".line:not(style, script)").each(function () {
-                    var line = $(this).prop("id").split("-")[1];
-                    var $lineLink = $('<a class="lineLink" href="#0" data-text="' + line + '" title="Code line ' + line + '">&larr;</a>');
+                    // data-source-line is stamped by Calcpad.Core (ExpressionParser)
+                    // on every emitted .line, including loop iterations past the first
+                    // where the id is dropped (id is the scroll anchor and must be unique).
+                    var line = $(this).attr("data-source-line");
+                    if (!line) return;
+                    var $lineLink = $('<a class="lineLink" href="#0" data-text="' + line + '" title="Source line ' + line + '">&larr;</a>');
                     $(this).append($lineLink);
                     $lineLink.hide();
                     $(this).hover(function () {

--- a/Calcpad.Wpf/doc/template.html
+++ b/Calcpad.Wpf/doc/template.html
@@ -887,9 +887,6 @@
                 });
 
                 $(".line:not(style, script)").each(function () {
-                    // data-source-line is stamped by Calcpad.Core (ExpressionParser)
-                    // on every emitted .line, including loop iterations past the first
-                    // where the id is dropped (id is the scroll anchor and must be unique).
                     var line = $(this).attr("data-source-line");
                     if (!line) return;
                     var $lineLink = $('<a class="lineLink" href="#0" data-text="' + line + '" title="Source line ' + line + '">&larr;</a>');

--- a/Calcpad.Wpf/doc/template.zh.html
+++ b/Calcpad.Wpf/doc/template.zh.html
@@ -887,8 +887,12 @@
                 });
 
                 $(".line:not(style, script)").each(function () {
-                    var line = $(this).prop("id").split("-")[1];
-                    var $lineLink = $('<a class="lineLink" href="#0" data-text="' + line + '" title="Code line ' + line + '">&larr;</a>');
+                    // data-source-line is stamped by Calcpad.Core (ExpressionParser)
+                    // on every emitted .line, including loop iterations past the first
+                    // where the id is dropped (id is the scroll anchor and must be unique).
+                    var line = $(this).attr("data-source-line");
+                    if (!line) return;
+                    var $lineLink = $('<a class="lineLink" href="#0" data-text="' + line + '" title="Source line ' + line + '">&larr;</a>');
                     $(this).append($lineLink);
                     $lineLink.hide();
                     $(this).hover(function () {

--- a/Calcpad.Wpf/doc/template.zh.html
+++ b/Calcpad.Wpf/doc/template.zh.html
@@ -887,9 +887,6 @@
                 });
 
                 $(".line:not(style, script)").each(function () {
-                    // data-source-line is stamped by Calcpad.Core (ExpressionParser)
-                    // on every emitted .line, including loop iterations past the first
-                    // where the id is dropped (id is the scroll anchor and must be unique).
                     var line = $(this).attr("data-source-line");
                     if (!line) return;
                     var $lineLink = $('<a class="lineLink" href="#0" data-text="' + line + '" title="Source line ' + line + '">&larr;</a>');


### PR DESCRIPTION
Line-link arrows now target the true source line in every loop iteration instead of drifting to whichever line last populated the cache. Calcpad.Core stamps data-source-line on every emitted .line (the id, which must stay unique for the scroll anchor, is still only set on the first pass).