### PR TITLE
Improved error links, navigation, and new error collection class

### DIFF
--- a/Calcpad.Core/CalcpadError.cs
+++ b/Calcpad.Core/CalcpadError.cs
@@ -1,0 +1,16 @@
+namespace Calcpad.Core
+{
+    public sealed class CalcpadError
+    {
+        public int SourceLine { get; init; }
+        public int OutputLine { get; init; }
+        public string Message { get; init; }
+        public CalcpadErrorSource Source { get; init; }
+    }
+
+    public enum CalcpadErrorSource
+    {
+        Macro,
+        Expression
+    }
+}

--- a/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.LineInfo.cs
+++ b/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.LineInfo.cs
@@ -7,12 +7,14 @@ namespace Calcpad.Core
         {
             internal readonly Keyword Keyword;
             internal readonly List<Token> Tokens;
+            internal readonly int SourceLine;
             internal bool IsCached => Tokens is not null;
 
-            internal LineInfo(List<Token> tokens, Keyword keyword)
+            internal LineInfo(List<Token> tokens, Keyword keyword, int sourceLine = 0)
             {
                 Tokens = tokens;
                 Keyword = keyword;
+                SourceLine = sourceLine;
             }
         }
     }

--- a/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.Loops.cs
+++ b/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.Loops.cs
@@ -13,6 +13,8 @@ namespace Calcpad.Core
             protected int _iteration;
             internal int Id { get; }
             internal int Iteration => _iteration;
+            internal int InitialCount { get; }
+            internal bool IsFirstPass => _iteration == InitialCount;
             private protected Loop(int startLine, double count, int id)
             {
                 _startLine = startLine;
@@ -20,6 +22,7 @@ namespace Calcpad.Core
                     count = MaxCount;
 
                 _iteration = (int)count;
+                InitialCount = _iteration;
                 Id = id;
             }
             internal bool Iterate(ref int currentLine)

--- a/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.cs
+++ b/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.cs
@@ -26,12 +26,16 @@ namespace Calcpad.Core
         private MathParser _parser;
         private readonly StringBuilder _sb = new(10000);
         private Queue<int> _errors;
+        private int _errIndex;
+        private Dictionary<int, int> _firstErrIndexByLine;
+        private List<CalcpadError> _errorList;
         private LineInfo[] _lineCache;
         private static bool[] IsLineExtension = new bool[128];
 
         public Settings Settings { get; set; } = new();
         public string SourceFilePath { get; set; }
         public string HtmlResult { get; private set; }
+        public IReadOnlyList<CalcpadError> Errors => _errorList;
         public static bool IsUs
         {
             get => Unit.IsUs;
@@ -51,10 +55,16 @@ namespace Calcpad.Core
         public void Cancel() => _parser?.Cancel();
         public void Pause() => _isPausedByUser = true;
 
-        private string HtmlId =>
-            Debug && (_loops.Count == 0 || _loops.Peek().Iteration == 1) ?
-            $" id=\"line-{_currentLine + 1}\" class=\"line\"" :
-            string.Empty;
+        private string HtmlId
+        {
+            get
+            {
+                if (!Debug) return string.Empty;
+                var isFirstPass = _loops.Count == 0 || _loops.Peek().IsFirstPass;
+                var idAttribute = isFirstPass ? $" id=\"line-{_currentLine + 1}\"" : string.Empty;
+                return $"{idAttribute} data-source-line=\"{_parser.Line}\" class=\"line\"";
+            }
+        }
 
         public void Parse(string sourceCode, bool calculate = true, bool getXml = true) =>
             Parse(sourceCode.AsSpan(), calculate, getXml);
@@ -91,6 +101,9 @@ namespace Calcpad.Core
                     {
                         if (IsEnabled())
                         {
+                            _parser.Line = currentLineCache.SourceLine != 0
+                                ? currentLineCache.SourceLine
+                                : _currentLine + 1;
                             _condition.SetCondition(-1);
                             _parser.IsCalculation = _isVal != -1;
                             ParseLine(currentLineCache.Tokens, Keyword.None);
@@ -143,7 +156,7 @@ namespace Calcpad.Core
                     _parser.IsConst = false;
                     var result = ParseKeyword(textSpan, ref keyword);
                     if (keyword != currentLineCache.Keyword)
-                        _lineCache[lineCache] = new(currentLineCache.Tokens, keyword);
+                        _lineCache[lineCache] = new(currentLineCache.Tokens, keyword, _parser.Line);
 
                     if (result == KeywordResult.Continue)
                         continue;
@@ -164,7 +177,7 @@ namespace Calcpad.Core
                             if (_isMarkdownOn)
                                 ParseMarkdown(tokens);
 
-                            _lineCache[_currentLine] = new(tokens, keyword);
+                            _lineCache[_currentLine] = new(tokens, keyword, _parser.Line);
                         }
                         _parser.HasInputFields = false;
                         ParseLine(tokens, keyword);
@@ -176,12 +189,14 @@ namespace Calcpad.Core
                 ApplyUnits(_sb, _calculate);
                 if (_currentLine == lineCount && (_calculate || !IsPaused))
                 {
-                    if (_condition.Id > 0 && !_condition.IsLoop)
+                    var ifNotClosed = _condition.Id > 0 && !_condition.IsLoop;
+                    var loopNotClosed = _loops.Count != 0;
+                    if (ifNotClosed)
                         _sb.Append(ErrHtml(Messages.if_block_not_closed_Missing_end_if, _currentLine));
-                    if (_loops.Count != 0)
+                    if (loopNotClosed)
                         _sb.Append(ErrHtml(Messages.Iteration_block_not_closed_Missing_loop, _currentLine));
-                    if (Debug && (_condition.Id > 0 || _loops.Count != 0))
-                        _errors.Enqueue(_currentLine);
+                    var msg = ifNotClosed ? Messages.if_block_not_closed_Missing_end_if : Messages.Iteration_block_not_closed_Missing_loop;
+                    RecordError(_currentLine, msg, Debug && (ifNotClosed || loopNotClosed));
                 }
             }
             catch (MathParserException ex)
@@ -190,9 +205,9 @@ namespace Calcpad.Core
             }
             catch (Exception ex)
             {
-                _sb.Append(ErrHtml(string.Format(Messages.Unexpected_error_0_Please_check_the_expression_consistency, ex.Message), _currentLine));
-                if (Debug)
-                    _errors.Enqueue(_currentLine);
+                var msg = string.Format(Messages.Unexpected_error_0_Please_check_the_expression_consistency, ex.Message);
+                _sb.Append(ErrHtml(msg, _currentLine));
+                RecordError(_currentLine, msg, Debug);
             }
             finally
             {
@@ -424,6 +439,9 @@ namespace Calcpad.Core
             _errorCount = 0;
             _calculate = calculate;
             _errors = new();
+            _errIndex = 0;
+            _firstErrIndexByLine = new();
+            _errorList = new();
             if (!_calculate)
                 _startLine = 0;
 
@@ -467,7 +485,7 @@ namespace Calcpad.Core
             if (_startLine > 0)
                 _sb.Append(Messages.Paused_Press_F5_to_continue);
 
-            if (Debug && lineCount > 30 && _errors.Count != 0)
+            if (Debug && _errors.Count != 0)
                 AppendErrors();
 
             HtmlResult = _sb.ToString();
@@ -489,11 +507,15 @@ namespace Calcpad.Core
             var prevLine = 0;
             while (_errors.Count != 0 && count < 20)
             {
-                var errLine = _errors.Dequeue() + 1;
+                var srcLine = _errors.Dequeue();
+                var errLine = srcLine + 1;
                 if (errLine != prevLine)
                 {
                     ++count;
-                    _sb.Append($" <span class=\"roundBox\" data-line=\"{errLine}\">{errLine}</span>");
+                    var errAttr = _firstErrIndexByLine.TryGetValue(srcLine, out var idx)
+                        ? $" data-error=\"err-{idx}\""
+                        : string.Empty;
+                    _sb.Append($" <span class=\"roundBox\" data-line=\"{errLine}\"{errAttr}>{errLine}</span>");
                 }
                 prevLine = errLine;
             }
@@ -501,7 +523,6 @@ namespace Calcpad.Core
                 _sb.Append(" ...");
 
             _sb.Append("</div>");
-            _sb.AppendLine("<style>body {padding-top:1em;}</style>");
             _errors.Clear();
         }
 
@@ -558,8 +579,7 @@ namespace Calcpad.Core
                             errText = HttpUtility.HtmlEncode(token.Value);
                         errText = string.Format(Messages.Error_in_0_on_line_1_2, errText, LineHtml(_currentLine), ex.Message);
                         _sb.Append($"<span class=\"err\"{Id(_currentLine)}>{errText}</span>");
-                        if (Debug)
-                            _errors.Enqueue(_currentLine);
+                        RecordError(_currentLine, ex.Message, Debug);
 
                         if (++_errorCount == 40)
                             throw new MathParserException(Messages.Too_many_errors);
@@ -574,14 +594,33 @@ namespace Calcpad.Core
         {
             string s = lineContent.Replace("<", "&lt;").Replace(">", "&gt;");
             _sb.Append(ErrHtml(string.Format(Messages.Error_in_0_on_line_1_2, s, LineHtml(line), text), line));
+            RecordError(line, text, Debug);
+        }
 
-            if (Debug)
-                _errors.Enqueue(line);
+        private void RecordError(int line, string message, bool enabled)
+        {
+            if (!enabled) return;
+            _errors.Enqueue(line);
+            var sourceLine = _parser?.Line > 0 ? _parser.Line : line + 1;
+            _errorList.Add(new CalcpadError
+            {
+                SourceLine = sourceLine,
+                OutputLine = line + 1,
+                Message = message,
+                Source = CalcpadErrorSource.Expression,
+            });
         }
 
         private static string LineHtml(int line) => $"[<a href=\"#0\" data-text=\"{line + 1}\">{line + 1}</a>]";
-        private string ErrHtml(string text, int line) => $"<p class=\"err\"{Id(line)}\">{text}</p>";
-        private string Id(int line) => Debug ? $" id=\"line-{line + 1}\"" : string.Empty;
+        private string ErrHtml(string text, int line) => $"<p class=\"err\"{Id(line)}>{text}</p>";
+        private string Id(int line)
+        {
+            if (!Debug) return string.Empty;
+            ++_errIndex;
+            if (!_firstErrIndexByLine.ContainsKey(line))
+                _firstErrIndexByLine[line] = _errIndex;
+            return $" id=\"err-{_errIndex}\" data-source-line=\"{line + 1}\"";
+        }
 
         private static string InsertAttribute(ReadOnlySpan<char> s, string attr)
         {

--- a/Calcpad.Core/Parsers/MacroParser.cs
+++ b/Calcpad.Core/Parsers/MacroParser.cs
@@ -90,6 +90,8 @@ namespace Calcpad.Core
         private static readonly Dictionary<string, Macro> Macros = new(StringComparer.Ordinal);
         public Func<string, Queue<string>, string> Include;
         public string SourceFilePath { get; set; }
+        private readonly List<CalcpadError> _errorList = new();
+        public IReadOnlyList<CalcpadError> Errors => _errorList;
 
         private static Keywords GetKeyword(ReadOnlySpan<char> s)
         {
@@ -116,6 +118,7 @@ namespace Calcpad.Core
                 _lineNumbers.Clear();
                 _includeStack.Clear();
                 _parsedLineNumber = 0;
+                _errorList.Clear();
             }
             var macroBuilder = new StringBuilder(1000);
             var macroName = string.Empty;
@@ -389,8 +392,17 @@ namespace Calcpad.Core
 
             void AppendError(ReadOnlySpan<char> lineContent, string errorMessage)
             {
-                sb.AppendLine(string.Format(Messages.Error_in_0_on_line_1_2, HttpUtility.HtmlEncode(lineContent.ToString()), LineHtml(lineNumber), errorMessage));
+                var marker = addLineNumbers ? $"\v{lineNumber}" : string.Empty;
+                sb.AppendLine(string.Format(Messages.Error_in_0_on_line_1_2, HttpUtility.HtmlEncode(lineContent.ToString()), LineHtml(lineNumber), errorMessage) + marker);
+                ++_parsedLineNumber;
                 hasErrors = true;
+                _errorList.Add(new CalcpadError
+                {
+                    SourceLine = lineNumber,
+                    OutputLine = _parsedLineNumber,
+                    Message = errorMessage,
+                    Source = CalcpadErrorSource.Macro,
+                });
             }
 
             void AddMacro(ReadOnlySpan<char> lineContent, string name, Macro macro)

--- a/Calcpad.Wpf/MainWindow.xaml.cs
+++ b/Calcpad.Wpf/MainWindow.xaml.cs
@@ -528,11 +528,11 @@ namespace Calcpad.Wpf
 
         private int _scrollOutputToLine;
         private double _scrollOffset;
-        private async void LineClicked(string data)
+        private async void LineClicked(string data, bool isSourceLink = false)
         {
             if (int.TryParse(data, out var line) && line > 0)
             {
-                if (_highlighter.Defined.HasMacros && !IsUnwarpedCode)
+                if (!isSourceLink && _highlighter.Defined.HasMacros && !IsUnwarpedCode)
                 {
                     _scrollOffset = await _wv2Warper.GetVerticalPositionAsync(line);
                     _scrollOutputToLine = line;
@@ -3814,7 +3814,7 @@ namespace Calcpad.Wpf
 
         private async void WebViewer_LinkClicked()
         {
-            var s = await _wv2Warper.GetLinkDataAsync();
+            var (s, className) = await _wv2Warper.GetLinkDataAndClassAsync();
             if (s is null)
                 return;
 
@@ -3848,7 +3848,10 @@ namespace Calcpad.Wpf
                 else if (s == "cancel")
                     Cancel();
                 else if (IsCalculated || _parser.IsPaused)
-                    LineClicked(s);
+                {
+                    var isSourceLink = className != null && className.Contains("lineLink");
+                    LineClicked(s, isSourceLink);
+                }
                 else if (!IsWebForm)
                     LinkClicked(s);
             }

--- a/Calcpad.Wpf/WebView2Wrapper.cs
+++ b/Calcpad.Wpf/WebView2Wrapper.cs
@@ -46,6 +46,12 @@ namespace Calcpad.Wpf
 
         internal async Task<string> GetLinkDataAsync()
         {
+            var (data, _) = await GetLinkDataAndClassAsync();
+            return data;
+        }
+
+        internal async Task<(string Data, string ClassName)> GetLinkDataAndClassAsync()
+        {
             try
             {
                 var tagName = await InvokeScriptAsync<string>("document.activeElement.tagName");
@@ -53,17 +59,20 @@ namespace Calcpad.Wpf
                 {
                     var linkData = await InvokeScriptAsync<string>("document.activeElement.getAttribute('data-text')");
                     if (linkData != "undefined")
-                        return linkData;
+                    {
+                        var className = await InvokeScriptAsync<string>("document.activeElement.className || ''");
+                        return (linkData, className ?? string.Empty);
+                    }
                 }
                 else if (tagName == "SELECT")
                 {
                     var linkData = await InvokeScriptAsync<string>("document.activeElement.value");
                     if (linkData != "undefined")
-                        return linkData;
+                        return (linkData, string.Empty);
                 }
             }
             catch { }
-            return null;
+            return (null, string.Empty);
         }
 
         internal async Task<string> GetUnitsAsync()

--- a/Calcpad.Wpf/doc/template.bg.html
+++ b/Calcpad.Wpf/doc/template.bg.html
@@ -709,6 +709,15 @@
             overflow-x: hidden;
         }
 
+        body:has(.errorHeader) {
+            padding-top: 2.2em;
+        }
+
+        body:has(.errorHeader) [id^="line-"],
+        body:has(.errorHeader) [id^="err-"] {
+            scroll-margin-top: 2.2em;
+        }
+
         .roundBox {
             background-color: #fee;
             color: crimson;
@@ -887,8 +896,9 @@
                 });
 
                 $(".line:not(style, script)").each(function () {
-                    var line = $(this).prop("id").split("-")[1];
-                    var $lineLink = $('<a class="lineLink" href="#0" data-text="' + line + '" title="Code line ' + line + '">&larr;</a>');
+                    var line = $(this).attr("data-source-line");
+                    if (!line) return;
+                    var $lineLink = $('<a class="lineLink" href="#0" data-text="' + line + '" title="Source line ' + line + '">&larr;</a>');
                     $(this).append($lineLink);
                     $lineLink.hide();
                     $(this).hover(function () {

--- a/Calcpad.Wpf/doc/template.html
+++ b/Calcpad.Wpf/doc/template.html
@@ -709,6 +709,15 @@
             overflow-x: hidden;
         }
 
+        body:has(.errorHeader) {
+            padding-top: 2.2em;
+        }
+
+        body:has(.errorHeader) [id^="line-"],
+        body:has(.errorHeader) [id^="err-"] {
+            scroll-margin-top: 2.2em;
+        }
+
         .roundBox {
             background-color: #fee;
             color: crimson;
@@ -887,8 +896,9 @@
                 });
 
                 $(".line:not(style, script)").each(function () {
-                    var line = $(this).prop("id").split("-")[1];
-                    var $lineLink = $('<a class="lineLink" href="#0" data-text="' + line + '" title="Code line ' + line + '">&larr;</a>');
+                    var line = $(this).attr("data-source-line");
+                    if (!line) return;
+                    var $lineLink = $('<a class="lineLink" href="#0" data-text="' + line + '" title="Source line ' + line + '">&larr;</a>');
                     $(this).append($lineLink);
                     $lineLink.hide();
                     $(this).hover(function () {

--- a/Calcpad.Wpf/doc/template.zh.html
+++ b/Calcpad.Wpf/doc/template.zh.html
@@ -709,6 +709,15 @@
             overflow-x: hidden;
         }
 
+        body:has(.errorHeader) {
+            padding-top: 2.2em;
+        }
+
+        body:has(.errorHeader) [id^="line-"],
+        body:has(.errorHeader) [id^="err-"] {
+            scroll-margin-top: 2.2em;
+        }
+
         .roundBox {
             background-color: #fee;
             color: crimson;
@@ -887,8 +896,9 @@
                 });
 
                 $(".line:not(style, script)").each(function () {
-                    var line = $(this).prop("id").split("-")[1];
-                    var $lineLink = $('<a class="lineLink" href="#0" data-text="' + line + '" title="Code line ' + line + '">&larr;</a>');
+                    var line = $(this).attr("data-source-line");
+                    if (!line) return;
+                    var $lineLink = $('<a class="lineLink" href="#0" data-text="' + line + '" title="Source line ' + line + '">&larr;</a>');
                     $(this).append($lineLink);
                     $lineLink.hide();
                     $(this).hover(function () {

--- a/Examples/Engineering/Fractals/Julia Set.html.stub
+++ b/Examples/Engineering/Fractals/Julia Set.html.stub
@@ -78,7 +78,7 @@
   </span>
   iterations
  </p>
- <p "="" class="err">
+ <p class="err">
   Error in "$Map{JuliaSet(x + 1i*y; c) @ x = -1.5 : 1.5 &amp; y = -1 : 1}" on line [
   <a data-text="9" href="#0">9</a>
   ]: Error parsing "i" as units.

--- a/Examples/Engineering/Numerical/Least Squares Fitting.html.stub
+++ b/Examples/Engineering/Numerical/Least Squares Fitting.html.stub
@@ -785,5 +785,5 @@
   </span>
  </p>
  <h4>Plot</h4>
- <p "="" class="err">Unexpected error: Index was outside the bounds of the array. Please check the expression consistency.</p>
+ <p class="err">Unexpected error: Index was outside the bounds of the array. Please check the expression consistency.</p>
 </div>


### PR DESCRIPTION
Track source lines through macros/includes/loops and expose errors as a list.

Calcpad.Core:
- Add CalcpadError type and Errors property on ExpressionParser and MacroParser so hosts can surface errors outside the HTML output (needed for hosts that render errors in a side panel, or when errors occur inside #hide blocks).
- Stamp data-source-line on every emitted .line, including loop iterations past the first pass. Loop.InitialCount/IsFirstPass distinguishes the first iteration (which owns the unique id="line-N" anchor) from later ones.
- Cache the source line on LineInfo so the fast path in loops restores _parser.Line — previously it drifted to whatever ran last, misdirecting line-link arrows and error targets.
- MacroParser writes a \v{line} marker on error lines so the expanded output keeps a source-line reference for downstream error links.
  - Adds error id field so error buttons get more accurate targets in loops.

Calcpad.Wpf:
- Templates: .lineLink now reads data-source-line (works for repeated loop output where id is dropped). Add errorHeader padding + scroll-margin so the fixed error bar doesn't overlap anchored lines when navigated to.
- MainWindow/WebView2Wrapper: link handler also reads the anchor's className so .lineLink clicks (already source lines) skip the wrapped→unwrapped two-step and navigate the editor directly.
- Doesn't consume the new CalcpadError list, but Calcpad.Web will.

I confimed the Cli and Wpf run and are not adversely affected. Some quality of life features related to error links did make it to Wpf as part of these changes though.