### PR TITLE
Examples updates to work with Calcpad.Web

### DIFF
--- a/Examples/Engineering/Areas/Circle.cpd
+++ b/Examples/Engineering/Areas/Circle.cpd
@@ -1,9 +1,9 @@
 '<!-- Area $A = \pi d^2/4$ and circumference $P = \pi d$ of a circle, parameterised by diameter. -->
 '<div style="max-width:100mm;"><img style="height:70pt;" class="side" alt="circle.png" src="../../Images/math/area/circle.png"></div>
 'Diameter
-'2&middot;<i>r</i> ='d = ?
+'2&middot;<i>r</i> ='d = ? {1}
 'Area
 A = π*d^2/4
 'Circumference
 P = π*d
-'1
+'

--- a/Examples/Engineering/Areas/Ellipse.cpd
+++ b/Examples/Engineering/Areas/Ellipse.cpd
@@ -1,7 +1,7 @@
 '<!-- Area $A = \pi\, a\, b$ and approximate circumference of an ellipse from its two semi-axes. -->
 '<div style="max-width:110mm;"><img style="height:65pt;" class="side" alt="ellipse.png" src="../../Images/math/area/ellipse.png"></div>
 'Dimensions
-a = ?','b = ?
+a = ? {2}','b = ? {1}
 'Area
 A = π*a*b/4
 'Circumference
@@ -10,4 +10,4 @@ A = π*a*b/4
 P = π*(a+b)/2*(1 + 3*h/(10 + sqr(4 - 3*h)))
 'Using series (up to the 4-th member)
 P = π*(a+b)/2*(1 + 1/4*h + 1/64*h^2 + 1/256*h^3)
-'2	1
+'

--- a/Examples/Engineering/Areas/Equilateral Triangle.cpd
+++ b/Examples/Engineering/Areas/Equilateral Triangle.cpd
@@ -1,7 +1,7 @@
 '<!-- Area $A = \tfrac{\sqrt{3}}{4} a^2$ and perimeter $P = 3a$ of an equilateral triangle. -->
 '<div style="max-width:110mm;"><img style="height:60pt;" class="side" alt="equilateral-triangle.png" src="../../Images/math/area/equilateral-triangle.png"></div>
 'Side length
-a = ?
+a = ? {1}
 'Area
 A = a^2*sqr(3)/4
 'Perimeter
@@ -9,4 +9,4 @@ P = 3*a
 P = 3*a
 P = 3*a
 P = 3*a
-'1
+'

--- a/Examples/Engineering/Areas/Parabola.cpd
+++ b/Examples/Engineering/Areas/Parabola.cpd
@@ -2,12 +2,12 @@
 "Area and Arc Length of Parabolic Segment
 '<div style="max-width:120mm;"><img style="height:60pt;" class="side" alt="parabola.png" src="../../Images/math/area/parabola.png"></div>
 'Dimensions
-'Length -'a = ?
-'Height -'b = ?
+'Length -'a = ? {4}
+'Height -'b = ? {2}
 'Area
 A = 2/3*a*b
 'Arc length
 'Assume'h = 4*b/a
 'and'q = sqr(1 + h^2)
 S = 0.5*a*(q + ln(h + q)/h)
-'4	2
+'

--- a/Examples/Engineering/Areas/Polygon.cpd
+++ b/Examples/Engineering/Areas/Polygon.cpd
@@ -1,10 +1,10 @@
 '<!-- Area and perimeter of a regular $n$-gon from side length $a$, using $A = \tfrac{n a^2}{4}\cot(\pi/n)$. -->
 '<div style="max-width:110mm;"><img style="height:70pt;" class="side" alt="polygon.png" src="../../Images/math/area/polygon.png"></div>
-'Number of sides -'n = ?
-'Side length -'a = ?
+'Number of sides -'n = ? {8}
+'Side length -'a = ? {1}
 'Area
 α = 180/n'&deg;
 A = a^2*n/4*cot(α)
 'Perimeter
 P = n*a
-'8	1
+'

--- a/Examples/Engineering/Areas/Rectangle.cpd
+++ b/Examples/Engineering/Areas/Rectangle.cpd
@@ -1,9 +1,9 @@
 '<!-- Area $A = a\, b$ and perimeter $P = 2(a + b)$ of a rectangle from its two side lengths. -->
 '<div style="max-width:100mm;"><img style="height:55pt;" class="side" alt="rectangle.png" src="../../Images/math/area/rectangle.png"></div>
 'Dimensions
-a = ?', 'b = ?
+a = ? {2}', 'b = ? {1}
 'Area
 A = a*b
 'Perimeter
 P = 2*(a+b)
-'2	1
+'

--- a/Examples/Engineering/Areas/Right Triangle.cpd
+++ b/Examples/Engineering/Areas/Right Triangle.cpd
@@ -1,10 +1,10 @@
 '<!-- Area $A = \tfrac{1}{2} a\, b$ and perimeter of a right triangle from its two legs (hypotenuse via Pythagoras). -->
 '<div style="max-width:110mm;"><img style="height:60pt;" class="side" alt="right-triangle.png" src="../../Images/math/area/right-triangle.png"></div>
 'Dimensions
-a = ?','b = ?
+a = ? {4}','b = ? {3}
 c = sqr(a^2 + b^2)
 'Area
 A = a*b/2
 'Perimeter
 P = a + b + c
-'4	3
+'

--- a/Examples/Engineering/Areas/Sector (Angle).cpd
+++ b/Examples/Engineering/Areas/Sector (Angle).cpd
@@ -1,8 +1,8 @@
 '<!-- Area and arc length of a circular sector from radius and central angle, valid for $\alpha \le 360°$. -->
 "Area and Arch Length of Circular Sector
 '<div style="max-width:110mm;"><img style="height:60pt;" class="side" alt="sector-angle.png" src="../../Images/math/area/sector-angle.png"></div>
-'Radius -'r = ?
-'Angle -'α = ?'&deg;
+'Radius -'r = ? {1}
+'Angle -'α = ? {60}'&deg;
 '<!--
 #if α ≤ 180
 	'<-->
@@ -16,4 +16,4 @@
 	'Angle must be less or equal to 180 &deg;
 	'<!--
 #end if
-'<-->1	60
+'<-->

--- a/Examples/Engineering/Areas/Sector (Chord).cpd
+++ b/Examples/Engineering/Areas/Sector (Chord).cpd
@@ -2,8 +2,8 @@
 "Area and Arch Length of Circular Sector
 '<div style="max-width:110mm;"><img style="height:60pt;" class="side" alt="sector-chord.png" src="../../Images/math/area/sector-chord.png"></div>
 'Dimensions
-'Radius -'r = ?
-'Chord -'a = ?
+'Radius -'r = ? {1}
+'Chord -'a = ? {1}
 '<!--
 #if a ≤ 2*r
 	'<-->
@@ -19,4 +19,4 @@
 	'Chord <i>a</i> must be less or equal to 2&middot;<i>r</i>
 	'<!--
 #end if
-'<-->1	1
+'<-->

--- a/Examples/Engineering/Areas/Segment (Angle).cpd
+++ b/Examples/Engineering/Areas/Segment (Angle).cpd
@@ -1,8 +1,8 @@
 '<!-- Area and arc length of a circular segment from radius and central angle. -->
 "Area and Arch Length of Circular Segment
 '<div style="max-width:120mm;"><img style="height:70pt;" class="side" alt="segment-angle.png" src="../../Images/math/area/segment-angle.png"></div>
-'Radius -'r = ?
-'Angle -'α = ?'&deg;
+'Radius -'r = ? {1}
+'Angle -'α = ? {60}'&deg;
 '<!--
 #if α ≤ 180
 	'<-->
@@ -16,4 +16,4 @@
 	'Angle must be less or equal to 180 &deg;
 	'<!--
 #end if
-'<-->1	60
+'<-->

--- a/Examples/Engineering/Areas/Segment (Chord).cpd
+++ b/Examples/Engineering/Areas/Segment (Chord).cpd
@@ -1,8 +1,8 @@
 '<!-- Area and arc length of a circular segment specified by chord and height, with a chord-vs-height feasibility guard. -->
 '<div style="max-width:120mm;"><img style="height:60pt;" class="side" alt="segment-chord.png" src="../../Images/math/area/segment-chord.png"></div>
 'Dimensions
-'Chord -'a = ?
-'Height -'b = ?
+'Chord -'a = ? {2}
+'Height -'b = ? {1}
 '<!--
 #if a ≥ 2*b
 	'<-->
@@ -20,4 +20,4 @@
 	'Chord <i>a</i> must be greater or equal to 2&middot;<i>b</i>
 	'<!--
 #end if
-'<-->2	1
+'<-->

--- a/Examples/Engineering/Areas/Square.cpd
+++ b/Examples/Engineering/Areas/Square.cpd
@@ -1,9 +1,9 @@
 '<!-- Area $A = a^2$ and perimeter $P = 4a$ of a square from a single side length. -->
 '<div style="max-width:80mm;"><img style="height:60pt;" class="side" alt="square.png" src="../../Images/math/area/square.png"></div>
 'Side length
-a = ?
+a = ? {1}
 'Area
 A = a^2
 'Perimeter
 P = 4*a
-'1
+'

--- a/Examples/Engineering/Areas/Trapezoid.cpd
+++ b/Examples/Engineering/Areas/Trapezoid.cpd
@@ -2,12 +2,12 @@
 "Area and Perimeter of Trapezoid
 '<div style="max-width:90mm;"><img style="height:60pt;" class="side" alt="trapezoid.png" src="../../Images/math/area/trapezoid.png"></div>
 'Base lengths
-a = ?','b = ?
+a = ? {2}','b = ? {1}
 'Height
-h = ?
+h = ? {1}
 'Area
 A = (a+b)*h/2
 'Perimeter (symmetrical figure only)
 c = sqr(h^2 + (a - b)^2/4)
 P = a+b + 2*c
-'2	1	1
+'

--- a/Examples/Engineering/Areas/Triangle (Height).cpd
+++ b/Examples/Engineering/Areas/Triangle (Height).cpd
@@ -1,6 +1,6 @@
 '<!-- Area $A = \tfrac{1}{2} a\, h_a$ of a triangle from base and corresponding height. -->
 '<div style="max-width:100mm;"><img style="height:55pt;" class="side" alt="triangle.png" src="../../Images/math/area/triangle.png"></div>
-'Base -'a = ?
-'Height -'h_a = ?
+'Base -'a = ? {2}
+'Height -'h_a = ? {1}
 'Area -'A = a*h_a/2
-'2	1
+'

--- a/Examples/Engineering/Areas/Triangle.cpd
+++ b/Examples/Engineering/Areas/Triangle.cpd
@@ -1,7 +1,7 @@
 '<!-- Area and perimeter of a general triangle from three side lengths via Heron formula, with a triangle-inequality guard. -->
 '<div style="max-width:110mm;"><img style="height:55pt;" class="side" alt="triangle.png" src="../../Images/math/area/triangle.png"></div>
 'Side lengths
-a = ?','b = ?','c = ?
+a = ? {5}','b = ? {4}','c = ? {3}
 '<!--
 #if (a + b > c)*(b + c > a)*(c + a > b)
 	'<-->
@@ -16,4 +16,4 @@ a = ?','b = ?','c = ?
 	'The sum of the lengths of each two sides must be greater than the third side.
 	'<!--
 #end if
-'<-->5	4	3
+'<-->

--- a/Examples/Engineering/Fractals/Kochwave Animated.cpd
+++ b/Examples/Engineering/Fractals/Kochwave Animated.cpd
@@ -5,6 +5,7 @@ x = hp([0; 1])', 'y = hp([0; 0])
 'Number of iterations -'n = 7
 '<h4>Animation</h4>
 #val
+'<script src="https://code.jquery.com/jquery-3.6.3.min.js"></script>
 '<style>#kochwaveWave polyline{display:none; stroke:Teal; stroke-width:0.08; stroke-linejoin:round;}</style>
 #hide 8
 w = 400', 'h = 200', 'k = 120

--- a/Examples/Engineering/Fractals/Kochwave Animated.html.stub
+++ b/Examples/Engineering/Fractals/Kochwave Animated.html.stub
@@ -44,6 +44,8 @@
   </span>
  </p>
  <h4>Animation</h4>
+ <script src="https://code.jquery.com/jquery-3.6.3.min.js">
+ </script>
  <style>#kochwaveWave polyline{display:none; stroke:Teal; stroke-width:0.08; stroke-linejoin:round;}</style>
  <svg id="kochwaveWave" style="width:400pt; height:200pt;" viewbox="0 48 120 60">
   <defs>

--- a/Examples/Engineering/Fractals/Kochwave Snowflake Animated.cpd
+++ b/Examples/Engineering/Fractals/Kochwave Snowflake Animated.cpd
@@ -5,6 +5,7 @@ x = hp([0; 1; 0.5; 0])', 'y = hp([0; 0; -a$; 0])
 'Number of iterations -'n = 7
 '<h4>Animation</h4>
 #val
+'<script src="https://code.jquery.com/jquery-3.6.3.min.js"></script>
 '<style>#kochwaveAnim polygon{display:none; stroke:Teal; stroke-width:0.1; stroke-linejoin:round;fill:Turquoise;}</style>
 #hide 8
 w = 360', 'h = w', 'k = 100

--- a/Examples/Engineering/Fractals/Kochwave Snowflake Animated.html.stub
+++ b/Examples/Engineering/Fractals/Kochwave Snowflake Animated.html.stub
@@ -56,6 +56,8 @@
   </span>
  </p>
  <h4>Animation</h4>
+ <script src="https://code.jquery.com/jquery-3.6.3.min.js">
+ </script>
  <style>#kochwaveAnim polygon{display:none; stroke:Teal; stroke-width:0.1; stroke-linejoin:round;fill:Turquoise;}</style>
  <svg id="kochwaveAnim" style="width:360pt; height:360pt" viewbox="0 0 100 100">
   <polygon fill="url(#sff)" id="kochwaveAnim-fr-1" points="0,86.602540378444 100,86.602540378444 50,0 0,86.602540378444 ">

--- a/Examples/Engineering/Geometrical/Angle Section.cpd
+++ b/Examples/Engineering/Geometrical/Angle Section.cpd
@@ -2,8 +2,8 @@
 "Geometrical Properties of Angle Section
 '<div style="max-width:120mm"><img style="height:150pt;" alt="angle.png" class="side" src="../../Images/mechanics/sections/angle.png"></div>
 'Dimensions
-h = ?'%u,'t_w = ?'%u
-b_f = ?'%u,'t_f = ?'%u
+h = ? {20}'%u,'t_w = ? {2}'%u
+b_f = ? {10}'%u,'t_f = ? {5}'%u
 'Area
 A_w = h*t_w'%u<sup>2</sup>
 A_f = (b_f - t_w)*t_f'%u<sup>2</sup>
@@ -35,4 +35,4 @@ r_y = sqrt(I_y/A)'%u
 r_z = sqrt(I_z/A)'%u
 r_1 = sqrt(I_1/A)'%u
 r_2 = sqrt(I_2/A)'%u
-r_x = sqrt(I_x/A)'%u20	2	10	5
+r_x = sqrt(I_x/A)'%u

--- a/Examples/Engineering/Geometrical/Channel Section.cpd
+++ b/Examples/Engineering/Geometrical/Channel Section.cpd
@@ -2,8 +2,8 @@
 "Geometrical Properties of Channel Section
 '<div style="max-width:120mm"><img style="height:150pt;" alt="channel.png" class="side" src="../../Images/mechanics/sections/channel.png"></div>
 'Dimensions
-h = ?'%u,'t_w = ?'%u
-b_f = ?'%u,'t_f = ?'%u
+h = ? {20}'%u,'t_w = ? {1}'%u
+b_f = ? {10}'%u,'t_f = ? {2}'%u
 'Area
 A_w = h*t_w'%u<sup>2</sup>
 A_f = (b_f - t_w)*t_f'%u<sup>2</sup>
@@ -24,4 +24,4 @@ I_x = I_y + I_z'%u<sup>4</sup>
 'Radii of gyration
 r_y = sqrt(I_y/A)'%u
 r_z = sqrt(I_z/A)'%u
-r_x = sqrt(I_x/A)'%u20	1	10	2
+r_x = sqrt(I_x/A)'%u

--- a/Examples/Engineering/Geometrical/Circle.cpd
+++ b/Examples/Engineering/Geometrical/Circle.cpd
@@ -2,7 +2,7 @@
 "Geometrical Properties of Circle
 '<div style="max-width:120mm"><img style="height:135pt;" alt="circle.png" class="side" src="../../Images/mechanics/sections/circle.png"></div>
 'Diameter
-d = ?'%u
+d = ? {1}'%u
 'Area
 A = π*d^2/4'%u<sup>2</sup>
 'Centroid
@@ -19,4 +19,4 @@ r_x = sqr(I_x/A)'%u
 'Torsional constant
 I_t = π*d^4/32'%u<sup>4</sup>
 'Torsional section modulus
-W_t = 2*I_t/d'%u<sup>3</sup>1
+W_t = 2*I_t/d'%u<sup>3</sup>

--- a/Examples/Engineering/Geometrical/Circlular Pipe.cpd
+++ b/Examples/Engineering/Geometrical/Circlular Pipe.cpd
@@ -2,7 +2,7 @@
 "Geometrical Properties of Circular Pipe
 '<div style="max-width:150mm"><img style="height:135pt;" alt="circular-pipe.png" class="side" src="../../Images/mechanics/sections/circular-pipe.png"></div>
 'Dimensions
-d = ?'%u,'t = ?'%u
+d = ? {1}'%u,'t = ? {0.1}'%u
 d_1 = d - 2*t'%u
 'Area
 A = π*(d^2 - d_1^2)/4'%u<sup>2</sup>
@@ -20,4 +20,4 @@ I_t = π*(d^4 - d_1^4)/32'%u<sup>4</sup>
 W_t = 2*I_t/d'%u<sup>3</sup>
 'Radii of gyration
 '<p><i>r</i><sub>z</sub> ='r_y = sqrt(I_y/A)'%u</p>
-r_x = sqr(I_x/A)'%u1	0.1
+r_x = sqr(I_x/A)'%u

--- a/Examples/Engineering/Geometrical/Double Tee Section.cpd
+++ b/Examples/Engineering/Geometrical/Double Tee Section.cpd
@@ -2,9 +2,9 @@
 "Geometrical Properties of Double Tee Section
 '<div style="max-width:150mm"><img style="height:165pt;" alt="double-tee.png" class="side" src="../../Images/mechanics/sections/double-tee.png"></div>
 'Dimensions
-h = ?'%u,'t_w = ?'%u
-b_f1 = ?'%u,'t_f1 = ?'%u
-b_f2 = ?'%u,'t_f2 = ?'%u
+h = ? {20}'%u,'t_w = ? {1}'%u
+b_f1 = ? {10}'%u,'t_f1 = ? {2}'%u
+b_f2 = ? {15}'%u,'t_f2 = ? {3}'%u
 'Area
 A_w = h*t_w'%u<sup>2</sup>
 A_f1 = (b_f1 - t_w)*t_f1'%u<sup>2</sup>
@@ -27,4 +27,4 @@ I_x = I_y + I_z'%u<sup>4</sup>
 'Radii of gyration
 r_y = sqrt(I_y/A)'%u
 r_z = sqrt(I_z/A)'%u
-r_x = sqrt(I_x/A)'%u20	1	10	2	15	3
+r_x = sqrt(I_x/A)'%u

--- a/Examples/Engineering/Geometrical/Ellipse.cpd
+++ b/Examples/Engineering/Geometrical/Ellipse.cpd
@@ -2,7 +2,7 @@
 "Geometrical Properties of Ellipse
 '<div style="max-width:120mm"><img style="height:112pt;" alt="ellipse.png" class="side" src="../../Images/mechanics/sections/ellipse.png"></div>
 'Dimensions
-a=?'%u,'b=?'%u
+a=? {2}'%u,'b=? {1}'%u
 'Area
 A = π*a*b'%u<sup>2</sup>
 'Centroid
@@ -27,4 +27,4 @@ W_t = π*b*a^2/2'%u<sup>3</sup>
 'Radii of gyration
 r_y = sqrt(I_y/A)'%u
 r_z = sqrt(I_z/A)'%u
-r_x = sqrt(I_x/A)'%u2	1
+r_x = sqrt(I_x/A)'%u

--- a/Examples/Engineering/Geometrical/Elliptical Pipe.cpd
+++ b/Examples/Engineering/Geometrical/Elliptical Pipe.cpd
@@ -3,8 +3,8 @@
 '<div style="max-width:120mm"><img style="height:112pt;" alt="elliptical-pipe.png" class="side" src="../../Images/mechanics/sections/elliptical-pipe.png"></div>
 '(ellipse with elliptical hole)
 'Dimensions
-a = ?'%u,'b = ?'%u
-t = ?'%u
+a = ? {20}'%u,'b = ? {10}'%u
+t = ? {2}'%u
 a_1 = a - t'%u
 b_1 = b - t'%u
 'Area
@@ -34,4 +34,4 @@ W_t = π*b*a^2/2*(1 - k^4)'%u<sup>3</sup>
 'Radii of gyration
 r_y = sqrt(I_y/A)'%u
 r_z = sqrt(I_z/A)'%u
-r_x = sqrt(I_x/A)'%u20	10	2
+r_x = sqrt(I_x/A)'%u

--- a/Examples/Engineering/Geometrical/Equilateral Triangle.cpd
+++ b/Examples/Engineering/Geometrical/Equilateral Triangle.cpd
@@ -2,7 +2,7 @@
 "Geometrical Properties of Equilateral Triangle
 '<div style="max-width:120mm"><img style="height:135pt;" alt="equilateral-triangle.png" class="side" src="../../Images/mechanics/sections/equilateral-triangle.png"></div>
 'Side length
-a = ?'%u
+a = ? {1}'%u
 'Height
 h = sqr(3)/2*a'%u
 'Area
@@ -24,4 +24,4 @@ W_t = a^3/20'%u<sup>3</sup>
 'Radii of gyration
 r_y = sqrt(I_y/A)'%u
 r_z = sqrt(I_z/A)'%u
-r_x = sqrt(I_x/A)'%u1
+r_x = sqrt(I_x/A)'%u

--- a/Examples/Engineering/Geometrical/Half Circle.cpd
+++ b/Examples/Engineering/Geometrical/Half Circle.cpd
@@ -2,7 +2,7 @@
 "Geometrical Properties of Half Circle
 '<div style="max-width:120mm"><img style="height:112pt;" alt="half-circle.png" class="side"  src="../../Images/mechanics/sections/half-circle.png"></div>
 'Diameter
-d = ?'%u
+d = ? {1}'%u
 'Area
 A = π*d^2/8'%u<sup>2</sup>
 'Perimeter
@@ -18,4 +18,4 @@ I_x = I_y + I_z'%u<sup>4</sup>
 'Radii of gyration
 r_y = sqrt(I_y/A)'%u
 r_z = sqrt(I_z/A)'%u
-r_x = sqrt(I_x/A)'%u1
+r_x = sqrt(I_x/A)'%u

--- a/Examples/Engineering/Geometrical/Hexagon.cpd
+++ b/Examples/Engineering/Geometrical/Hexagon.cpd
@@ -2,7 +2,7 @@
 "Geometrical Properties of Regular Hexagon
 '<div style="max-width:120mm"><img style="height:135pt;" alt="hexagon.png" class="side" src="../../Images/mechanics/sections/hexagon.png"></div>
 'Dimensions
-a = ?'%u
+a = ? {1}'%u
 h = sqr(3)*a'%u
 'Area
 A = 1.5*a*h'%u<sup>2</sup>
@@ -17,4 +17,4 @@ P = 6*a'%u
 I_x=2*I_y'%u<sup>4</sup>
 'Radii of gyration
 '<p><i>r</i><sub>z</sub> ='r_y = sqrt(I_y/A)'%u</p>
-r_x = sqrt(I_x/A)'%u1
+r_x = sqrt(I_x/A)'%u

--- a/Examples/Engineering/Geometrical/Quarter Circle.cpd
+++ b/Examples/Engineering/Geometrical/Quarter Circle.cpd
@@ -1,7 +1,7 @@
 '<!-- Section properties of a quarter circle: area, centroid offsets, second moments of area and radii of gyration. -->
 "Geometrical Properties of Quarter Circle
 '<div style="max-width:120mm"><img style="height:120pt;" alt="quarter-circle.png" class="side" src="../../Images/mechanics/sections/quarter-circle.png"></div>
-'Radius -'r = ?'%u
+'Radius -'r = ? {1}'%u
 'Area
 A = π*r^2/4'%u<sup>2</sup>
 'Centroid
@@ -22,4 +22,4 @@ I_x = 2*I_y'%u<sup>4</sup>
 '<p><i>r</i><sub>z</sub> ='r_y = sqr(I_y/A)'%u</p>
 r_1 = sqr(I_1/A)'%u
 r_2 = sqr(I_2/A)'%u
-r_x = sqr(I_x/A)'%u1
+r_x = sqr(I_x/A)'%u

--- a/Examples/Engineering/Geometrical/Rectangle.cpd
+++ b/Examples/Engineering/Geometrical/Rectangle.cpd
@@ -2,7 +2,7 @@
 "Geometrical Properties of Rectangle
 '<div style = "max-width:120mm"><img style="height:150pt;" alt="rectangle.png" class="side" src="../../Images/mechanics/sections/rectangle.png"></div>
 'Dimensions
-h = ?'%u,'b = ?'%u
+h = ? {2}'%u,'b = ? {1}'%u
 'Area
 A = h*b'%u<sup>2</sup>
 'Centroid
@@ -36,4 +36,4 @@ I_t = b*h^3*(1 - 0.630*h/b + 0.052*(h/b)^5)/3'%u<sup>4</sup>
 'Torsional section modulus
 W_t = b*h^2*(1 - 0.630*h/b + 0.250*(h/b)^2)/3'%u<sup>3</sup>
 #end if
-#end if2	1
+#end if

--- a/Examples/Engineering/Geometrical/Rectangular Tube.cpd
+++ b/Examples/Engineering/Geometrical/Rectangular Tube.cpd
@@ -2,8 +2,8 @@
 "Geometrical Properties of Rectangular Tube
 '<div style="max-width:150mm"><img style="height:150pt;" alt="rectangular-tube.png" class="side" src="../../Images/mechanics/sections/rectangular-tube.png"></div>
 'Dimensions
-h = ?'%u,'t_w = ?'%u
-b = ?'%u,'t_f = ?'%u
+h = ? {300}'%u,'t_w = ? {20}'%u
+b = ? {200}'%u,'t_f = ? {30}'%u
 b_1 = b - 2*t_w'%u
 h_1 = h - 2*t_f'%u
 'Area
@@ -22,4 +22,4 @@ I_x = I_y + I_z'%u<sup>4</sup>
 'Radii of gyration
 r_y = sqrt(I_y/A)'%u
 r_z = sqrt(I_z/A)'%u
-r_x = sqrt(I_x/A)'%u300	20	200	30
+r_x = sqrt(I_x/A)'%u

--- a/Examples/Engineering/Geometrical/Rhombus (Square).cpd
+++ b/Examples/Engineering/Geometrical/Rhombus (Square).cpd
@@ -2,7 +2,7 @@
 "Geometrical Properties of Square Rhombus
 '<div style="max-width:120mm"><img style="height:135pt;" alt="rombus-square.png" class="side" src="../../Images/mechanics/sections/rhombus.png"></div>
 'Side length
-a = ?'%u
+a = ? {1}'%u
 'Diagonal length
 d = sqr(2*a^2)'%u
 'Area
@@ -17,4 +17,4 @@ P = 4*a'%u
 I_x = 2*I_y'%u<sup>4</sup>
 'Radii of gyration
 '<p><i>r</i><sub>z</sub> ='r_y = sqrt(I_y/A)'</p>
-r_x = sqr(I_x/A)'%u1
+r_x = sqr(I_x/A)'%u

--- a/Examples/Engineering/Geometrical/Right Triangle.cpd
+++ b/Examples/Engineering/Geometrical/Right Triangle.cpd
@@ -2,7 +2,7 @@
 "Geometrical Properties of Right Triangle
 '<div style="max-width:120mm"><img style="height:127pt;" alt="right-triangle.png" class="side" src="../../Images/mechanics/sections/right-triangle.png"></div>
 'Side lengths
-a = ?'%u,'b = ?'%u
+a = ? {2}'%u,'b = ? {1}'%u
 'Area
 A = a*b/2'%u<sup>2</sup>
 'Perimeter
@@ -26,4 +26,4 @@ r_y = sqrt(I_y/A)'%u
 r_z = sqrt(I_z/A)'%u
 r_1 = sqr(I_1/A)'%u
 r_2 = sqr(I_2/A)'%u
-r_x = sqrt(I_x/A)'%u2	1
+r_x = sqrt(I_x/A)'%u

--- a/Examples/Engineering/Geometrical/Sector.cpd
+++ b/Examples/Engineering/Geometrical/Sector.cpd
@@ -1,8 +1,8 @@
 '<!-- Section properties of a circular sector: area, centroid, second moments of area and radii of gyration as functions of radius and central angle. -->
 "Geometrical Properties of Circular Sector
 '<div style="max-width:150mm"><img style="height:120pt;" alt="sector.png" class="side" src="../../Images/mechanics/sections/sector.png"></div>
-'Radius -'r = ?'%u
-'Angle -'α = ?'&deg;
+'Radius -'r = ? {1}'%u
+'Angle -'α = ? {90}'&deg;
 k = π/180
 a = sqr(2*r^2*(1 - cos(α)))'%u
 'Area
@@ -20,4 +20,4 @@ I_x = I_y + I_z'%u<sup>4</sup>
 'Radii of gyration
 r_y = sqrt(I_y/A)'%u
 r_z = sqrt(I_z/A)'%u
-r_x = sqrt(I_x/A)'%u1	90
+r_x = sqrt(I_x/A)'%u

--- a/Examples/Engineering/Geometrical/Segment.cpd
+++ b/Examples/Engineering/Geometrical/Segment.cpd
@@ -1,8 +1,8 @@
 '<!-- Section properties of a circular segment: area, centroid, second moments of area and radii of gyration from radius and central angle. -->
 "Geometrical Properties of Circular Segment
 '<div style="max-width:150mm"><img style="height:120pt;" alt="segment.png" class="side" src="../../Images/mechanics/sections/segment.png"></div>
-'Radius -'r = ?'%u
-'Angle -'α = ?'&deg;
+'Radius -'r = ? {1}'%u
+'Angle -'α = ? {90}'&deg;
 k = π/180
 a = sqr(2*r^2*(1 - cos(α)))'%u
 h = sqr(r^2 - a^2/4)'%u
@@ -21,4 +21,4 @@ I_x = I_y + I_z'%u<sup>4</sup>
 'Radii of gyration
 r_y = sqrt(I_y/A)'%u
 r_z = sqrt(I_z/A)'%u
-r_x = sqrt(I_x/A)'%u1	90
+r_x = sqrt(I_x/A)'%u

--- a/Examples/Engineering/Geometrical/Square.cpd
+++ b/Examples/Engineering/Geometrical/Square.cpd
@@ -2,7 +2,7 @@
 "Geometrical Properties of Square
 '<div style="max-width:100mm"><img style="height:135pt;" alt="square.png" class="side" src="../../Images/mechanics/sections/square.png"></div>
 'Side length
-a= ?'%u
+a= ? {1}'%u
 'Area
 A = a^2'%u<sup>2</sup>
 'Centroid
@@ -15,4 +15,4 @@ P = 4*a'%u
 I_x=2*I_y'%u<sup>4</sup>
 'Radii of gyration
 '<p><i>r</i><sub>z</sub> ='r_y = sqrt(I_y/A)'%u</p>
-r_x = sqr(I_x/A)'%u1
+r_x = sqr(I_x/A)'%u

--- a/Examples/Engineering/Geometrical/Tee Section.cpd
+++ b/Examples/Engineering/Geometrical/Tee Section.cpd
@@ -2,8 +2,8 @@
 "Geometrical Properties of Tee Section
 '<div style="max-width:120mm"><img style="height:150pt;" alt="tee.png" class="side" src="../../Images/mechanics/sections/tee.png"></div>
 'Dimensions
-h = ?'%u,'t_w = ?'%u
-b_f = ?'%u,'t_f = ?'%u
+h = ? {20}'%u,'t_w = ? {2}'%u
+b_f = ? {10}'%u,'t_f = ? {5}'%u
 'Area
 A_w = h*t_w'%u<sup>2</sup>
 A_f = (b_f - t_w)*t_f'%u<sup>2</sup>
@@ -24,4 +24,4 @@ I_x = I_y + I_z'%u<sup>4</sup>
 'Radii of gyration
 r_y = sqrt(I_y/A)'%u
 r_z = sqrt(I_z/A)'%u
-r_x = sqrt(I_x/A)'%u20	2	10	5
+r_x = sqrt(I_x/A)'%u

--- a/Examples/Engineering/Geometrical/Trapezoid.cpd
+++ b/Examples/Engineering/Geometrical/Trapezoid.cpd
@@ -2,9 +2,9 @@
 "Geometrical Properties of Trapezoid
 '<div style="max-width:130mm"><img style="height:135pt;" alt="Trapezoid.png" class="side" src="../../Images/mechanics/sections/trapezoid.png"></div>
 'Dimensions
-a = ?'%u,'b = ?'%u
+a = ? {2}'%u,'b = ? {1}'%u
 'Height
-h = ?'%u
+h = ? {1}'%u
 'Area
 A = h*(a + b)/2'%u<sup>2</sup>
 'Centroid
@@ -20,4 +20,4 @@ I_x = I_y + I_z'%u<sup>4</sup>
 'Radii of gyration
 r_y = sqrt(I_y/A)'%u
 r_z = sqrt(I_z/A)'%u
-r_x = sqrt(I_x/A)'%u2	1	1
+r_x = sqrt(I_x/A)'%u

--- a/Examples/Engineering/Geometrical/Zed Section.cpd
+++ b/Examples/Engineering/Geometrical/Zed Section.cpd
@@ -2,8 +2,8 @@
 "Geometrical Properties of Zed Section
 '<div style="max-width:120mm"><img style="height:150pt;" alt="zed.png" class="side" src="../../Images/mechanics/sections/zed.png"></div>
 'Dimensions
-h = ?'%u,'t_w = ?'%u
-b_f = ?'%u,'t_f = ?'%u
+h = ? {20}'%u,'t_w = ? {2}'%u
+b_f = ? {10}'%u,'t_f = ? {5}'%u
 'Area
 A_w = h*t_w'%u<sup>2</sup>
 A_f = (b_f - t_w)*t_f'%u<sup>2</sup>
@@ -27,4 +27,4 @@ I_x=I_1+I_2'%u<sup>4</sup>
 'Radii of gyration
 r_y = sqr(I_y/A)'%u
 r_z = sqr(I_z/A)'%u
-r_x = sqr(I_x/A)'%u20	2	10	5
+r_x = sqr(I_x/A)'%u

--- a/Examples/Engineering/Others/Bitwise Operations.cpd
+++ b/Examples/Engineering/Others/Bitwise Operations.cpd
@@ -1,7 +1,7 @@
 '<!-- Custom multiline functions implementing decimal-to-binary, octal and hexadecimal conversions and the standard bitwise operators. -->
 '<h5>Decimal to binary:</h5>
 dec2bin(x; n) = $sum{mod(floor(x/2^k); 2)*10^k @ k = 0 : n - 1}
-#def dec2bin$(x; n$) = dec2bin(x; n$):Dn$'₂
+#def dec2bin$(x$; n$) = dec2bin(x$; n$):Dn$'₂
 '<h5>Binary to decimal:</h5>
 bin2dec(x; n) = $sum{mod(floor(x/10^k); 2)*2^k @ k = 0 : n - 1}
 'Helper function -'fl_2(x) = floor(log_2(x))

--- a/Examples/Engineering/Parametric Curves/Epicycloid.cpd
+++ b/Examples/Engineering/Parametric Curves/Epicycloid.cpd
@@ -5,8 +5,8 @@
 'General equation:
 x(θ) = (k + 1)*cos(θ) - cos((k + 1)*θ)
 y(θ) = (k + 1)*sin(θ) - sin((k + 1)*θ)
-'Larger radius: 'R = ?
-'Smaller radius: 'r = ?
+'Larger radius: 'R = ? {21}
+'Smaller radius: 'r = ? {10}
 'Ratio: 'k = R/r
 #pre
 
@@ -18,4 +18,4 @@ PlotWidth = 400
 #post
 $Plot{x(θ)|y(θ) @ θ = 0 : 2*π*r}
 #show
-'</div>21	10
+'</div>

--- a/Examples/Engineering/Parametric Curves/Hypocycloid.cpd
+++ b/Examples/Engineering/Parametric Curves/Hypocycloid.cpd
@@ -5,8 +5,8 @@
 'General equation:
 x(θ) = (k - 1)*cos(θ) + cos((k - 1)*θ)
 y(θ) = (k - 1)*sin(θ) - sin((k - 1)*θ)
-'Outer radius: 'R = ?
-'Inner radius: 'r = ?
+'Outer radius: 'R = ? {22}
+'Inner radius: 'r = ? {3}
 'Ratio: 'k = R/r
 #pre
 
@@ -18,4 +18,4 @@ PlotWidth = 400
 #post
 $Plot{x(θ)|y(θ) @ θ = 0 : 2*π*r}
 #show
-'</div>22	3
+'</div>

--- a/Examples/Engineering/Parametric Curves/Lissajous Curve.cpd
+++ b/Examples/Engineering/Parametric Curves/Lissajous Curve.cpd
@@ -7,9 +7,9 @@ PlotWidth = 400
 'Equation:
 x(θ) = sin(a*θ)
 y(θ) = sin(b*θ)
-'Coefficients:'a = ?','b = ?
+'Coefficients:'a = ? {2}','b = ? {3}
 #pre
 
 'Tip: Click "<b>Calculate</b>" to see the respective plot.
 #post
-$Plot{x(θ)|y(θ) @ θ = 0 : 2*π}2	3
+$Plot{x(θ)|y(θ) @ θ = 0 : 2*π}

--- a/Examples/Engineering/Volumes/Cone.cpd
+++ b/Examples/Engineering/Volumes/Cone.cpd
@@ -1,8 +1,8 @@
 '<!-- Volume $V = \tfrac{1}{3}\pi r^2 h$ and lateral / total surface area of a right circular cone from radius and height. -->
 '<div style = "max-width:90mm"><img style="height:55pt;" class="side" alt="cone.png" src = "../../Images/math/volume/cone.png"></div>
 'Dimensions
-'Base radius -'r = ?
-'Height -'h = ?
+'Base radius -'r = ? {1}
+'Height -'h = ? {2}
 'Volume
 V = 1/3*π*r^2*h
 'Area of side surface
@@ -11,4 +11,4 @@ S_o = π*r*sqr(h^2 + r^2)
 A = π*r^2
 'Total surface area
 S = S_o + A
-'1	2
+'

--- a/Examples/Engineering/Volumes/Cube.cpd
+++ b/Examples/Engineering/Volumes/Cube.cpd
@@ -1,9 +1,9 @@
 '<!-- Volume $V = a^3$ and surface area $S = 6 a^2$ of a cube from a single edge length. -->
 '<div style = "max-width:90mm"><img style="height:65pt;" class="side" alt="cube.png" src = "../../Images/math/volume/cube.png"></div>
 'Side length
-a = ?
+a = ? {1}
 'Volume
 V = a^3
 'Surface area
 S = 6*a^2
-'1
+'

--- a/Examples/Engineering/Volumes/Cylinder.cpd
+++ b/Examples/Engineering/Volumes/Cylinder.cpd
@@ -1,8 +1,8 @@
 '<!-- Volume $V = \pi r^2 h$ and surface area $S = 2\pi r (r + h)$ of a right circular cylinder. -->
 '<div style = "max-width:100mm"><img style="height:55pt;" class="side" alt="cylinder.png" src = "../../Images/math/volume/cylinder.png"></div>
 'Dimensions
-'Base radius -'r = ?
-'Height -'h = ?
+'Base radius -'r = ? {1}
+'Height -'h = ? {2}
 'Area of base
 A = π*r^2
 'Volume
@@ -11,4 +11,4 @@ V = A*h
 S_o = 2*π*r*h
 'Total surface area
 S = S_o + 2*A
-'1	2
+'

--- a/Examples/Engineering/Volumes/Ellipsoid.cpd
+++ b/Examples/Engineering/Volumes/Ellipsoid.cpd
@@ -1,12 +1,12 @@
 '<!-- Volume $V = \tfrac{4}{3}\pi\, a\, b\, c$ and approximate surface area of an ellipsoid from its three semi-axes. -->
 '<div style = "max-width:110mm"><img style="height:70pt;" class="side" alt="ellipsoid.png" src = "../../Images/math/volume/ellipsoid.png"></div>
 'Dimensions
-a = ?
-b = ?
-c = ?
+a = ? {3}
+b = ? {2}
+c = ? {1}
 'Volume
 V = 4/3*π*a*b*c
 p = 1.6075
 'Surface area (approx.)
 S = 4*π*(((a*b)^p + (a*c)^p + (b*c)^p)/3)^(1/p)
-'3	2	1
+'

--- a/Examples/Engineering/Volumes/Rectangular Frustum.cpd
+++ b/Examples/Engineering/Volumes/Rectangular Frustum.cpd
@@ -2,9 +2,9 @@
 '<div style = "max-width:130mm"><img style="height:70pt;" class="side" alt="rectangular-frustum.png" src = "../../Images/math/volume/rectangular-frustum.png"></div>
 'Dimensions
 '<table>
-'<tr><td>Bottom base -</td><td>'A = ?'</td><td>'B = ?'</td></tr>
-'<tr><td>Top base -</td><td>'a = ?'</td><td>'b = ?'</td></tr>
-'<tr><td><p>Height -</p></td><td>'h = ?'</td><td> </td></tr>
+'<tr><td>Bottom base -</td><td>'A = ? {8}'</td><td>'B = ? {2}'</td></tr>
+'<tr><td>Top base -</td><td>'a = ? {6}'</td><td>'b = ? {4}'</td></tr>
+'<tr><td><p>Height -</p></td><td>'h = ? {5}'</td><td> </td></tr>
 '</table>
 'Heights of side faces
 h_a = sqr(h^2 + (B - b)^2/4)
@@ -18,4 +18,4 @@ A_1 = A*B
 A_2 = a*b
 'Total surface area
 S = S_o + A_1 + A_2
-'8	2	6	4	5
+'

--- a/Examples/Engineering/Volumes/Rectangular Prism.cpd
+++ b/Examples/Engineering/Volumes/Rectangular Prism.cpd
@@ -1,11 +1,11 @@
 '<!-- Volume $V = a\, b\, c$ and surface area $S = 2(a b + b c + c a)$ of a rectangular prism (box). -->
 '<div style = "max-width:130mm"><img style="height:65pt;" class="side" alt="rectangular-prism.png" src = "../../Images/math/volume/rectangular-prism.png"></div>
 'Dimensions of base
-a = ?','b = ?
+a = ? {3}','b = ? {2}
 'Height
-h = ?
+h = ? {1}
 'Volume
 V = a*b*h
 'Surface area
 S = 2*(a*b + b*h + a*h)
-'3	2	1
+'

--- a/Examples/Engineering/Volumes/Rectangular Pyramid.cpd
+++ b/Examples/Engineering/Volumes/Rectangular Pyramid.cpd
@@ -1,9 +1,9 @@
 '<!-- Volume $V = \tfrac{1}{3} a\, b\, h$ and surface area of a rectangular-base pyramid. -->
 '<div style = "max-width:130mm"><img style="height:65pt;" class="side" alt="rectangular-pyramid.png" src = "../../Images/math/volume/rectangular-pyramid.png"></div>
 'Dimensions of base
-a = ?','b = ?
+a = ? {3}','b = ? {2}
 'Height
-h = ?
+h = ? {1}
 'Volume
 V = 1/3*a*b*h
 'Area of side faces
@@ -12,4 +12,4 @@ S_o = a*sqr(h^2 + b^2/4) + b*sqr(h^2 + a^2/4)
 A = a*b
 'Total surface area
 S = S_o + A
-'3	2	1
+'

--- a/Examples/Engineering/Volumes/Right Polygonal Prism.cpd
+++ b/Examples/Engineering/Volumes/Right Polygonal Prism.cpd
@@ -1,9 +1,9 @@
 '<!-- Volume and surface area of a right prism with a regular $n$-gon base, from side length and height. -->
 '<div style = "max-width:130mm"><img style="height:65pt;" class="side" alt="polygonal-prism.png" src = "../../Images/math/volume/polygonal-prism.png"></div>
 'Dimensions
-'Number of sides -'n = ?
-'Side length -'a = ?
-'Height -'h = ?
+'Number of sides -'n = ? {6}
+'Side length -'a = ? {1}
+'Height -'h = ? {2}
 '<!--
 #if n > 2
 '<-->
@@ -19,4 +19,4 @@ S = 2*A + n*a*h
 'It is required that n > 2
 '<!--
 #end if
-'<-->6	1	2
+'<-->

--- a/Examples/Engineering/Volumes/Sphere.cpd
+++ b/Examples/Engineering/Volumes/Sphere.cpd
@@ -1,9 +1,9 @@
 '<!-- Volume $V = \tfrac{4}{3}\pi r^3$ and surface area $S = 4\pi r^2$ of a sphere from its radius. -->
 '<div style = "max-width:100mm"><img style="height:60pt;" class="side" alt="sphere.png" src = "../../Images/math/volume/sphere.png"></div>
 'Radius
-r = ?
+r = ? {1}
 'Volume
 V = 4/3*π*r^3
 'Surface area
 S = 4*π*r^2
-'1
+'

--- a/Examples/Engineering/Volumes/Spherical Cap.cpd
+++ b/Examples/Engineering/Volumes/Spherical Cap.cpd
@@ -1,8 +1,8 @@
 '<!-- Volume and surface area of a spherical cap from sphere radius and cap height. -->
 '<div style = "max-width:120mm"><img style="height:55pt;" class="side" alt="cap.png" src = "../../Images/math/volume/cap.png"></div>
 'Dimensions
-'Base radius -'r = ?
-'Height -'h = ?
+'Base radius -'r = ? {2}
+'Height -'h = ? {1}
 'Radius of sphere
 R = (r^2 + h^2)/(2*h)
 'Volume
@@ -13,4 +13,4 @@ S_o = 2*π*R*h
 A = π*r^2
 'Total surface area
 S = S_o + A
-'2	1
+'

--- a/Examples/Engineering/Volumes/Spherical Segment.cpd
+++ b/Examples/Engineering/Volumes/Spherical Segment.cpd
@@ -1,9 +1,9 @@
 '<!-- Volume and surface area of a spherical segment (the slab between two parallel planes cutting a sphere). -->
 '<div style = "max-width:130mm"><img style="height:60pt;" class="side" alt="segment.png" src = "../../Images/math/volume/segment.png"></div>
 'Raduses of bases
-a = ?','b = ?
+a = ? {3}','b = ? {2}
 'Height
-h = ?
+h = ? {1}
 'Radius of sphere
 R = sqr(((a - b)^2 + h^2)*((a + b)^2 + h^2))/(2*h)
 'Volume
@@ -15,4 +15,4 @@ A = π*a^2
 B = π*b^2
 'Total surface area
 S = S_o + A + B
-'3	2	1
+'

--- a/Examples/Engineering/Volumes/Tetrahedron.cpd
+++ b/Examples/Engineering/Volumes/Tetrahedron.cpd
@@ -1,9 +1,9 @@
 '<!-- Volume $V = \tfrac{a^3}{6\sqrt{2}}$ and surface area $S = \sqrt{3}\, a^2$ of a regular tetrahedron from its edge length. -->
 '<div style = "max-width:110mm"><img style="height:60pt;" class="side" alt="tetrahedron.png" src = "../../Images/math/volume/tetrahedron.png"></div>
 'Side length
-a = ?
+a = ? {1}
 'Volume
 V = sqr(2)*a^3/12
 'Surface area
 S = sqr(3)*a^2
-'1
+'

--- a/Examples/Engineering/Volumes/Triangular Frustum.cpd
+++ b/Examples/Engineering/Volumes/Triangular Frustum.cpd
@@ -2,10 +2,10 @@
 '<div style = "max-width:120mm"><img style="height:60pt;" class="side" alt="triangular-frustum.png" src = "../../Images/math/volume/triangular-frustum.png"></div>
 '<p><b>Dimensions:</b></p>
 'Bottom base
-A = ?','B = ?','C = ?
+A = ? {10}','B = ? {8}','C = ? {6}
 'Top base
-a = ?','b = B*a/A','c = C*a/A
-'Height -'h = ?
+a = ? {5}','b = B*a/A','c = C*a/A
+'Height -'h = ? {2}
 '<!--
 #if (A + B > C)*(B + C > A)*(C + A > B)
 '<-->
@@ -27,4 +27,4 @@ V = h/3*(A_1 + sqr(A_1*A_2) + A_2)
 'The sum of each two sides must be greater than the third.
 '<!--
 #end if
-'<-->10	8	6	5	2
+'<-->

--- a/Examples/Engineering/Volumes/Triangular Prism.cpd
+++ b/Examples/Engineering/Volumes/Triangular Prism.cpd
@@ -1,9 +1,9 @@
 '<!-- Volume and surface area of a right triangular prism, from triangle sides and prism length. -->
 '<div style = "max-width:120mm"><img style="height:60pt;" class="side" alt="triangular-prism.png" src = "../../Images/math/volume/triangular-prism.png"></div>
 'Dimensions of base
-a = ?','b = ?','c = ?
+a = ? {5}','b = ? {4}','c = ? {3}
 'Height
-h = ?
+h = ? {2}
 '<!--
 #if (a + b > c)*(b + c > a)*(c + a > b)
 '<-->
@@ -23,4 +23,4 @@ S = 2*A + h*P
 'The sum of each two sides must be greater than the third.
 '<!--
 #end if
-'<-->5	4	3	2
+'<-->

--- a/Examples/Engineering/Volumes/Triangular Pyramid.cpd
+++ b/Examples/Engineering/Volumes/Triangular Pyramid.cpd
@@ -1,9 +1,9 @@
 '<!-- Volume $V = \tfrac{1}{3} A_b\, h$ of a pyramid with a general triangular base. -->
 '<div style = "max-width:110mm"><img style="height:60pt;" class="side" alt="triangular-pyramid.png" src = "../../Images/math/volume/triangular-pyramid.png"></div>
 'Dimensions of base
-a = ?','b = ?','c = ?
+a = ? {5}','b = ? {4}','c = ? {3}
 'Height
-h = ?
+h = ? {2}
 '<!--
 #if (a + b > c)*(b + c > a)*(c + a > b)
 '<-->
@@ -19,4 +19,4 @@ V = 1/3*A*h
 'The sum of each two sides must be greater than the third.
 '<!--
 #end if
-'<-->5	4	3	2
+'<-->

--- a/Examples/Structural/Cantilevers/Concentrated Force.cpd
+++ b/Examples/Structural/Cantilevers/Concentrated Force.cpd
@@ -2,8 +2,8 @@
 '<div style="max-width:180mm;">
 '<img style="width:165pt;" alt="cantilever-beam-concentrated-force.png" class="side" src="../../Images/mechanics/beams/cantilever-beam-concentrated-force.png">
 '<p><b>Input data</b></p>
-'Beam Length -'l = ?'m
-'Load -'F = ?'kN
+'Beam Length -'l = ? {5}'m
+'Load -'F = ? {10}'kN
 #post
 '<p><b>Internal forces</b></p>
 'Bending -'M = F*l'kN·m
@@ -13,7 +13,7 @@
 PlotWidth = 600
 PlotHeight = 150
 #show
-'Calculate internal forces at'x_1 = ?'m
+'Calculate internal forces at'x_1 = ? {1}'m
 #pre
 
 
@@ -27,4 +27,4 @@ V(x) = F
 $Plot{V(x) @ x = 0 : l}
 V(x_1)'kN
 #show
-'</div>5	10	1
+'</div>

--- a/Examples/Structural/Cantilevers/Concentrated Moment.cpd
+++ b/Examples/Structural/Cantilevers/Concentrated Moment.cpd
@@ -2,8 +2,8 @@
 '<div style="max-width:180mm;">
 '<img style="width:165pt;" alt="cantilever-beam-concentrated-moment.png" class="side" src="../../Images/mechanics/beams/cantilever-beam-concentrated-moment.png">
 '<p><b>Input data</b></p>
-'Beam Length -'l = ?'m
-'Load -'M = ?'kN·m
+'Beam Length -'l = ? {5}'m
+'Load -'M = ? {10}'kN·m
 #post
 '<p><b>Internal forces</b></p>
 'Bending -'M = M'kN·m
@@ -13,7 +13,7 @@
 PlotWidth = 600
 PlotHeight = 150
 #show
-'Calculate internal forces at'x_1 = ?'m
+'Calculate internal forces at'x_1 = ? {1}'m
 #pre
 
 #post
@@ -26,4 +26,4 @@ V(x) = 0
 $Plot{V(x) @ x = 0 : l}
 V(x_1)'kN
 #show
-'</div>5	10	1
+'</div>

--- a/Examples/Structural/Cantilevers/Linearly Distributed Load.cpd
+++ b/Examples/Structural/Cantilevers/Linearly Distributed Load.cpd
@@ -2,8 +2,8 @@
 '<div style="max-width:180mm;">
 '<img style="width:165pt;" alt="cantilever-beam-distributed-load-linear.png" class="side" src="../../Images/mechanics/beams/cantilever-beam-distributed-load-linear.png">
 '<p><b>Input data</b></p>
-'Beam Length -'l = ?'m
-'Load -'q_1 = ?'kN/m,'q_2 = ?'kN/m
+'Beam Length -'l = ? {5}'m
+'Load -'q_1 = ? {10}'kN/m,'q_2 = ? {5}'kN/m
 #post
 '<p><b>Internal forces</b></p>
 'Bending -'M = l^2*(q_1 + 2*q_2)/6'kN·m
@@ -13,7 +13,7 @@
 PlotWidth = 600
 PlotHeight = 150
 #show
-'Calculate internal forces at'x_1 = ?'m
+'Calculate internal forces at'x_1 = ? {1}'m
 #pre
 
 
@@ -28,4 +28,4 @@ V(x) = V - (q_1 + q(x))*x/2
 $Plot{V(x) @ x = 0 : l}
 V(x_1)'kN
 #show
-'</div>5	10	5	1
+'</div>

--- a/Examples/Structural/Cantilevers/Partially Distributed Load.cpd
+++ b/Examples/Structural/Cantilevers/Partially Distributed Load.cpd
@@ -2,9 +2,9 @@
 '<div style="max-width:180mm;">
 '<img style="width:165pt;" alt="cantilever-beam-distributed-load-partial.png" class="side" src="../../Images/mechanics/beams/cantilever-beam-distributed-load-partial.png">
 '<p><b>Input data</b></p>
-'Beam Length -'l = ?'m
-'Load -'q = ?'kN/m
-'Distances -'b = ?'m,'a = l - b'm
+'Beam Length -'l = ? {5}'m
+'Load -'q = ? {5}'kN/m
+'Distances -'b = ? {3}'m,'a = l - b'm
 #post
 '<p><b>Internal forces</b></p>
 'Bending -'M = q*b*(a + b/2)'kN·m
@@ -14,7 +14,7 @@
 PlotWidth = 600
 PlotHeight = 150
 #show
-'Calculate internal forces at'x_1 = ?'m
+'Calculate internal forces at'x_1 = ? {1}'m
 #pre
 
 #post
@@ -27,4 +27,4 @@ V(x) = V - q*(x - a)*(x > a)
 $Plot{V(x) @ x = 0 : l}
 V(x_1)'kN
 #show
-'</div>5	5	3	1
+'</div>

--- a/Examples/Structural/Cantilevers/Uniformly Distributed Load.cpd
+++ b/Examples/Structural/Cantilevers/Uniformly Distributed Load.cpd
@@ -1,8 +1,7 @@
 '<!-- Full-span uniform load $q$ giving the textbook support actions $M = q l^2 / 2$ and $V = q l$. -->
 '<img style="width:165pt;" alt="cantilever-beam-distributed-load-uniform.png" class="side" src="../../Images/mechanics/beams/cantilever-beam-distributed-load-uniform.png">
-'Beam Length - 'l = ? 'm
-'Load- 'q = ? 'kN/m
+'Beam Length - 'l = ?  {5}'m
+'Load- 'q = ?  {5}'kN/m
 '<p><b>Internal forces</b></p>
 'Bending - 'M = q*l^2/2'kN·m
 'Shear  - 'V = q*l'kN
-5	5

--- a/Examples/Structural/Deflections/Cantilever with Concentrated Load.cpd
+++ b/Examples/Structural/Deflections/Cantilever with Concentrated Load.cpd
@@ -1,10 +1,10 @@
 '<!-- Rotation $\varphi(x)$ and deflection $d(x)$ along a cantilever loaded by a tip force $F$, recovering the textbook tip values $\varphi_{max} = F l^2 / (2 E I)$ and $d_{max} = F l^3 / (3 E I)$. -->
 '<div style = "max-width: 180mm;">
 '<img style="width:165pt;" class="side" src="../../Images/mechanics/beams/deflection-cantilever-force.png" alt="deflection-cantilever-force.png">
-'Beam length - 'l = ?'m
-'Load - 'F = ?'kN
-'Second moment of area - 'I = ?'cm<sup>4</sup>
-'Modulus of elasticity - 'E = ?'GPa
+'Beam length - 'l = ? {3}'m
+'Load - 'F = ? {50}'kN
+'Second moment of area - 'I = ? {160000}'cm<sup>4</sup>
+'Modulus of elasticity - 'E = ? {30}'GPa
 'Functions of rotation and deflection along the beam
 EI = E*I*0.01
 φ(x) = F/EI*(l*x - x^2/2)
@@ -18,6 +18,6 @@ $Plot{-d(x)*10^3 @ x = 0 : l}
 d_max = d(l)*10^3'mm
 'Maximum rotation
 φ_max = φ(l)*10^3'rad·10³
-'Calculate deflection at'x = ?'m
+'Calculate deflection at'x = ? {3}'m
 d(x)*10^3'mm
-'</div>3	50	160000	30	3
+'</div>

--- a/Examples/Structural/Deflections/Cantilever with Unifrom Load.cpd
+++ b/Examples/Structural/Deflections/Cantilever with Unifrom Load.cpd
@@ -1,10 +1,10 @@
 '<!-- Cantilever under a full-span uniform load $q$, integrating the curvature to obtain $\varphi(x)$ and $d(x)$ with the tip deflection $d_{max} = q l^4 / (8 E I)$. -->
 '<div style = "max-width: 180mm;">
 '<img style="width:165pt;" class="side" src="../../Images/mechanics/beams/deflection-cantilever-distributed-load.png" alt="deflection-cantilever-distributed-load.png">
-'Beam length - 'l = ?'m
-'Load - 'q = ?'kN/m
-'Second moment of area - 'I = ?'cm<sup>4</sup>
-'Modulus of elasticity - 'E = ?'GPa
+'Beam length - 'l = ? {3}'m
+'Load - 'q = ? {30}'kN/m
+'Second moment of area - 'I = ? {160000}'cm<sup>4</sup>
+'Modulus of elasticity - 'E = ? {30}'GPa
 'Functions of rotation and deflection along the beam
 EI = E*I*0.01
 φ(x) = q/(2*EI)*(x^3/3 - l*x^2 + l^2*x)
@@ -18,6 +18,6 @@ $Plot{-d(x)*10^3 @ x = 0 : l}
 d_max = d(l)*10^3'mm
 'Maximum rotation
 φ_max = φ(l)*10^3'rad·10³
-'Calculate deflection at'x = ?'m
+'Calculate deflection at'x = ? {2}'m
 d(x)*10^3'mm
-'</div>3	30	160000	30	2
+'</div>

--- a/Examples/Structural/Deflections/Simply Supported Beam with Concentrated Load.cpd
+++ b/Examples/Structural/Deflections/Simply Supported Beam with Concentrated Load.cpd
@@ -1,10 +1,10 @@
 '<!-- Simply supported beam with a mid-span point force $F$, giving the maximum deflection $d_{max} = F l^3 / (48 E I)$ and the support rotation $\varphi_{max} = F l^2 / (16 E I)$. -->
 '<div style = "max-width: 180mm;">
 '<img style="width:165pt;" class="side" src="../../Images/mechanics/beams/deflection-simply-supported-beam-force.png" alt="deflection-simply-supported-beam-force.png">
-'Beam length - 'l = ?'m
-'Load - 'F = ?'kN
-'Second moment of area - 'I = ?'cm<sup>4</sup>
-'Modulus of elasticity - 'E = ?'GPa
+'Beam length - 'l = ? {6}'m
+'Load - 'F = ? {100}'kN
+'Second moment of area - 'I = ? {160000}'cm<sup>4</sup>
+'Modulus of elasticity - 'E = ? {30}'GPa
 'Functions of rotation and deflection along the beam
 EI = 0.01*E*I
 d(x) = F/(4*EI)*((l^2/4*x - x^3/3)*(x ≤ l/2) + (l^2/4*(l - x) - (l - x)^3/3)*(x > l/2))
@@ -18,6 +18,6 @@ $Plot{-d(x)*10^3 @ x = 0 : l}
 d_max = d(l/2)*10^3'mm
 'Maximum rotation
 φ_max = φ(0)*10^3'rad·10³
-'Calculate deflection at'x = ?'m
+'Calculate deflection at'x = ? {3}'m
 d(x)*10^3'mm
-'</div>6	100	160000	30	3
+'</div>

--- a/Examples/Structural/Deflections/Simply Supported Beam with Unifrom Load.cpd
+++ b/Examples/Structural/Deflections/Simply Supported Beam with Unifrom Load.cpd
@@ -1,10 +1,10 @@
 '<!-- Simply supported beam under a full-span uniform load $q$, recovering the serviceability-relevant mid-span deflection $d_{max} = 5 q l^4 / (384 E I)$ and the support rotation $\varphi_{max} = q l^3 / (24 E I)$. -->
 '<div style = "max-width: 180mm;">
 '<img style="width:165pt;" class="side" src="../../Images/mechanics/beams/deflection-simply-supported-beam-distributed-load.png" alt="deflection-simply-supported-beam-distributed-load.png">
-'Beam length - 'l = ?'m
-'Load - 'q = ?'kN/m
-'Second moment of area - 'I = ?'cm<sup>4</sup>
-'Modulus of elasticity - 'E = ?'GPa
+'Beam length - 'l = ? {6}'m
+'Load - 'q = ? {30}'kN/m
+'Second moment of area - 'I = ? {160000}'cm<sup>4</sup>
+'Modulus of elasticity - 'E = ? {30}'GPa
 'Functions of rotation and deflection along the beam
 EI = E*I*0.01
 φ(x) = q/EI*(x^3/6 - l*x^2/4 + l^3/24)
@@ -18,6 +18,6 @@ $Plot{-d(x)*10^3 @ x = 0 : l}
 d_max = d(l/2)*10^3'mm
 'Maximum rotation
 φ_max = φ(0)*10^3'rad·10³
-'Calculate deflection at'x = ?'m
+'Calculate deflection at'x = ? {3}'m
 d(x)*10^3'mm
-'</div>6	30	160000	30	3
+'</div>

--- a/Examples/Structural/Fully Restrained Beams/Concentrated Force.cpd
+++ b/Examples/Structural/Fully Restrained Beams/Concentrated Force.cpd
@@ -2,9 +2,9 @@
 '<div style="max-width:180mm">
 '<img style="width:210pt;" alt="fixed-beam-concentrated-force.png" class="side" src="../../Images/mechanics/beams/fixed-beam-concentrated-force.png">
 '<p><b>Input data</b></p>
-'Beam Length -'l=?'m
-'Load -'F=?'kN
-'Distances -'a=?'m,'b=l-a'm
+'Beam Length -'l=? {10}'m
+'Load -'F=? {10}'kN
+'Distances -'a=? {2}'m,'b=l-a'm
 #post
 '<p><b>Internal forces</b></p>
 'Bending at supports
@@ -20,7 +20,7 @@ V_B = F*a^2/l^2*(1+2*b/l)'kN
 PlotWidth = 600
 PlotHeight = 150
 #show
-'Calculate internal forces at'x_1 = ?'m
+'Calculate internal forces at'x_1 = ? {1}'m
 #pre
 
 
@@ -34,4 +34,4 @@ V(x) = V_A - F*(x > a)
 $Plot{V(x) @ x = 0 : l}
 V(x_1)'kN
 #show
-'</div>10	10	2	1
+'</div>

--- a/Examples/Structural/Fully Restrained Beams/Concentrated Moment.cpd
+++ b/Examples/Structural/Fully Restrained Beams/Concentrated Moment.cpd
@@ -2,9 +2,9 @@
 '<div style="max-width:180mm">
 '<img class="side" style="width:210pt;" alt="fixed-beam-concentrated-moment.png" src="../../Images/mechanics/beams/fixed-beam-concentrated-moment.png">
 '<p><b>Input data</b></p>
-'Beam length -'l = ?'m
-'Load -'M = ?'kN·m
-'Distances -'a = ?'m,'b = l - a'm
+'Beam length -'l = ? {10}'m
+'Load -'M = ? {10}'kN·m
+'Distances -'a = ? {4}'m,'b = l - a'm
 #post
 '<p><b>Internal forces</b></p>
 'Bending at supports
@@ -20,7 +20,7 @@ M_b = V*b - M_B'kN·m
 PlotWidth = 600
 PlotHeight = 150
 #show
-'Calculate internal forces at'x_1 = ?'m
+'Calculate internal forces at'x_1 = ? {1}'m
 #pre
 
 #post
@@ -33,4 +33,4 @@ V(x) = -V
 $Plot{V(x) @ x = 0 : l}
 V(x_1)'kN
 #show
-'</div>10	10	4	1
+'</div>

--- a/Examples/Structural/Fully Restrained Beams/Linearly Distributed Load.cpd
+++ b/Examples/Structural/Fully Restrained Beams/Linearly Distributed Load.cpd
@@ -2,8 +2,8 @@
 '<div style="max-width:180mm;">
 '<img style="width:210pt;" alt="fixed-beam-distributed-load-linear.png" class="side" src="../../Images/mechanics/beams/fixed-beam-distributed-load-linear.png">
 '<p><b>Input data</b></p>
-'Beam Length -'l = ?'m
-'Load -'q_1 = ?'kN/m,'q_2 = ?'kN/m
+'Beam Length -'l = ? {10}'m
+'Load -'q_1 = ? {5}'kN/m,'q_2 = ? {10}'kN/m
 Δq = q_2 - q_1'kN/m
 #post
 '<p><b>Internal forces</b></p>
@@ -25,7 +25,7 @@ M_max = V_A*x_max - (3*l*q_1 + Δq*x_max)*x_max^2/(6*l) - M_A'kN·m
 PlotWidth = 600
 PlotHeight = 150
 #show
-'Calculate internal forces at'x_1 = ?'m
+'Calculate internal forces at'x_1 = ? {1}'m
 #pre
 
 
@@ -40,4 +40,4 @@ V(x) = V_A - (q_1 + q(x))*x/2
 $Plot{V(x) @ x = 0 : l}
 V(x_1)'kN
 #show
-'</div>10	5	10	1
+'</div>

--- a/Examples/Structural/Fully Restrained Beams/Partially Distributed Load.cpd
+++ b/Examples/Structural/Fully Restrained Beams/Partially Distributed Load.cpd
@@ -2,9 +2,9 @@
 '<div style="max-width:180mm;">
 '<img style="width:210pt;" alt="fixed-beam-distributed-load-partial.png" class="side" src="../../Images/mechanics/beams/fixed-beam-distributed-load-partial.png">
 '<p><b>Input data</b></p>
-'Beam Length -'l = ?'m
-'Load -'q = ?'kN/m
-'Distances -'a = ?'m,'b = ?'m,'c = l - a - b'm
+'Beam Length -'l = ? {10}'m
+'Load -'q = ? {5}'kN/m
+'Distances -'a = ? {1}'m,'b = ? {6}'m,'c = l - a - b'm
 '<!--
 #if c < 0
 	'<-->
@@ -29,7 +29,7 @@
 	PlotWidth = 600
 	PlotHeight = 150
 	#show
-	'Calculate internal forces at'x_1 = ?'m
+	'Calculate internal forces at'x_1 = ? {1}'m
 	#pre
 
 	#post
@@ -45,4 +45,4 @@
 	'<!--
 #end if
 '<-->
-'</div>10	5	1	6	1
+'</div>

--- a/Examples/Structural/Fully Restrained Beams/Uniformly Distributed Load.cpd
+++ b/Examples/Structural/Fully Restrained Beams/Uniformly Distributed Load.cpd
@@ -2,8 +2,8 @@
 '<div style="max-width:180mm">
 '<img style="width:210pt;" alt="fixed-beam-distributed-load-uniform.png" class="side" src="../../Images/mechanics/beams/fixed-beam-distributed-load-uniform.png">
 '<p><b>Input data</b></p>
-'Beam Length -'l=?'m
-'Load -'q=?'kN/m
+'Beam Length -'l=? {10}'m
+'Load -'q=? {5}'kN/m
 #post
 '<p><b>Internal forces</b></p>
 'Bending at supports
@@ -19,7 +19,7 @@ V_A = V_B
 PlotWidth = 600
 PlotHeight = 150
 #show
-'Calculate internal forces at'x_1 = ?'m
+'Calculate internal forces at'x_1 = ? {1}'m
 #pre
 
 
@@ -33,4 +33,4 @@ V(x) = V_A - q*x
 $Plot{V(x) @ x = 0 : l}
 V(x_1)'kN
 #show
-'</div>10	5	1
+'</div>

--- a/Examples/Structural/Loads/Snow Drift.cpd
+++ b/Examples/Structural/Loads/Snow Drift.cpd
@@ -2,12 +2,12 @@
 '<small>According to <strong>Eurocode</strong>: EN 1991-1-3, § 5.3.6</small>
 '<div style="max-width:180mm">
 '<img class="side" style="width:210pt;" src="../../Images/structures/loads/snow-drift.png" alt="snow-drift.png">
-'Characteristic snow load on the ground -'s_k = ?'kN/m<sup>2</sup>
-'Higher roof width -'b_1 = ?'m
-'Sliding surface width -'b_s = ?'m
-'Lower roof width -'b_2 = ?'m
-'height difference -'h = ?'m
-'Pitch angle of the higher roof -'α = ?'<sup>o</sup>
+'Characteristic snow load on the ground -'s_k = ? {1.5}'kN/m<sup>2</sup>
+'Higher roof width -'b_1 = ? {18}'m
+'Sliding surface width -'b_s = ? {9}'m
+'Lower roof width -'b_2 = ? {36}'m
+'height difference -'h = ? {6.2}'m
+'Pitch angle of the higher roof -'α = ? {3}'<sup>o</sup>
 #post
 'Shape coefficient for the higher roof
 #if α ≤ 15
@@ -41,4 +41,4 @@ l_s = max(5; min(2*h;15))'m
 	μ_12 = (μ_1 - μ_2)*b_2/l_s + μ_2
 #end if
 #show
-'</div>1.5	18	9	36	6.2	3
+'</div>

--- a/Examples/Structural/Loads/Snow Load.cpd
+++ b/Examples/Structural/Loads/Snow Load.cpd
@@ -2,8 +2,8 @@
 '<small>According to <strong>Eurocode</strong>: EN 1991-1-3</small>
 '<div style="max-width:180mm">
 '<img style="width:200pt;" src="../../Images/structures/loads/snow.png" alt="snow.png"><br /><br />
-'Characteristic snow load on the ground -'s_k = ?'kN/m<sup>2</sup>
-'Roof pitch angle -'α = ?'<sup>o</sup>
+'Characteristic snow load on the ground -'s_k = ? {1}'kN/m<sup>2</sup>
+'Roof pitch angle -'α = ? {0}'<sup>o</sup>
 #post
 #if α ≤ 30
 	'Snow shape coefficient -'μ_1 = 0.8'(α &le; 30 <sup>o</sup>)
@@ -13,11 +13,11 @@
 	'Snow shape coefficient -'μ_1 = 0'(α &gt; 60 <sup>o</sup>)
 #end if
 #show
-'Exposure factor -'C_e = ?
-'Thermal factor -'C_t = ?
+'Exposure factor -'C_e = ? {1}
+'Thermal factor -'C_t = ? {1}
 #post
 '<p class="ref">[EN 1991-1-3, Clause 5.2 (3)a]</p>
 'Snow load on roof
 s =μ_1*C_e*C_t*s_k'kN/m<sup>2</sup>
 #show
-'</div>1	0	1	1
+'</div>

--- a/Examples/Structural/Propped Cantilevers/Concentrated Force.cpd
+++ b/Examples/Structural/Propped Cantilevers/Concentrated Force.cpd
@@ -2,9 +2,9 @@
 '<div style="max-width:180mm;">
 '<img style="width:210pt;" alt="propped-cantilever-beam-concentrated-force.png" class="side" src="../../Images/mechanics/beams/propped-cantilever-beam-concentrated-force.png">
 '<p><b>Input data</b></p>
-'Beam Length -'l = ?'m
-'Load -'F = ?'kN
-'Distances -'a = ?'m,
+'Beam Length -'l = ? {10}'m
+'Load -'F = ? {10}'kN
+'Distances -'a = ? {4}'m,
 #post
 b = l - a'm,'k = b/l
 '<p><b>Internal forces</b></p>
@@ -19,7 +19,7 @@ V_B = F - V_A'kN
 PlotWidth = 600
 PlotHeight = 150
 #show
-'Calculate internal forces at'x_1 = ?'m
+'Calculate internal forces at'x_1 = ? {1}'m
 #pre
 
 #post
@@ -32,4 +32,4 @@ V(x) = V_A - F*(x > a)
 $Plot{V(x) @ x = 0 : l}
 V(x_1)'kN
 #show
-'</div>10	10	4	1
+'</div>

--- a/Examples/Structural/Propped Cantilevers/Concentrated Moment.cpd
+++ b/Examples/Structural/Propped Cantilevers/Concentrated Moment.cpd
@@ -2,9 +2,9 @@
 '<div style="max-width:180mm;">
 '<img style="width:210pt;" alt="propped-cantilever-beam-concentrated-moment.png" class="side" src="../../Images/mechanics/beams/propped-cantilever-beam-concentrated-moment.png">
 '<p><b>Input data</b></p>
-'Beam Length -'l = ?'m
-'Load -'M = ?'kN·m
-'Distances -'a = ?'m,
+'Beam Length -'l = ? {10}'m
+'Load -'M = ? {10}'kN·m
+'Distances -'a = ? {6}'m,
 #post
 b = l - a'm,'k = b/l
 '<p><b>Internal forces</b></p>
@@ -20,7 +20,7 @@ M_b = V*b'kN·m
 PlotWidth = 600
 PlotHeight = 150
 #show
-'Calculate internal forces at'x_1 = ?'m
+'Calculate internal forces at'x_1 = ? {1}'m
 #pre
 
 #post
@@ -33,4 +33,4 @@ V(x) = -V
 $Plot{V(x) @ x = 0 : l}
 V(x_1)'kN
 #show
-'</div>10	10	6	1
+'</div>

--- a/Examples/Structural/Propped Cantilevers/Linearly Distributed Load.cpd
+++ b/Examples/Structural/Propped Cantilevers/Linearly Distributed Load.cpd
@@ -4,8 +4,8 @@
 '<img style="width:210pt;" class="side" alt="propped-cantilever-beam-distributed-load-linear-left.png" src="../../Images/mechanics/beams/propped-cantilever-beam-distributed-load-linear-left.png">
 #show
 '<p><b>Input data</b></p>
-'Beam Length -'l = ?'m
-'Load -'q_1 = ?'kN/m,'q_2 = ?'kN/m
+'Beam Length -'l = ? {10}'m
+'Load -'q_1 = ? {5}'kN/m,'q_2 = ? {10}'kN/m
 #post
 '<div class="side">
 #hide
@@ -39,7 +39,7 @@ M_max = V_A*x_max - x_max^2*(3*l*q_1 + Δq*x_max)/(6*l) - M_A'kN·m
 PlotWidth = 600
 PlotHeight = 150
 #show
-'Calculate internal forces at'x_1 = ?'m
+'Calculate internal forces at'x_1 = ? {1}'m
 #pre
 
 
@@ -55,4 +55,4 @@ V(x) = V_A - (q_1 + q(x))*x/2
 $Plot{V(x) @ x = 0 : l}
 V(x_1)'kN
 #show
-'</div>10	5	10	1
+'</div>

--- a/Examples/Structural/Propped Cantilevers/Partially Distributed Load.cpd
+++ b/Examples/Structural/Propped Cantilevers/Partially Distributed Load.cpd
@@ -2,9 +2,9 @@
 '<div style="max-width:180mm;">
 '<img style="width:210pt;" alt="propped-cantilever-beam-distributed-load-p.png" class="side" src="../../Images/mechanics/beams/propped-cantilever-beam-distributed-load-p.png">
 '<p><b>Input data</b></p>
-'Beam Length -'l = ?'m
-'Load -'q = ?'kN/m
-'Distances -'a = ?'m,'b = ?'m
+'Beam Length -'l = ? {10}'m
+'Load -'q = ? {5}'kN/m
+'Distances -'a = ? {2}'m,'b = ? {6}'m
 #post
 c = l - a - b'm,
 d = b + c'm, 'e = a + b'm
@@ -22,7 +22,7 @@ M_max = V_A*x_max - (x_max - a)^2*q/2 - M_A'kN·m
 PlotWidth = 600
 PlotHeight = 150
 #show
-'Calculate internal forces at'x_1 = ?'m
+'Calculate internal forces at'x_1 = ? {1}'m
 #pre
 
 #post
@@ -35,4 +35,4 @@ V(x) = V_A - q*(x - a)*(x > a) + q*(x - e)*(x > e)
 $Plot{V(x) @ x = 0 : l}
 V(x_1)'kN
 #show
-'</div>10	5	2	6	1
+'</div>

--- a/Examples/Structural/Propped Cantilevers/Uniformly Distributed Load.cpd
+++ b/Examples/Structural/Propped Cantilevers/Uniformly Distributed Load.cpd
@@ -2,8 +2,8 @@
 '<div style="max-width:180mm;">
 '<img style="width:210pt;" alt="propped-cantilever-beam-distributed-load.png" class="side" src="../../Images/mechanics/beams/propped-cantilever-beam-distributed-load.png">
 '<p><b>Input data</b></p>
-'Beam Length -'l = ?'m
-'Load -'q = ?'kN/m
+'Beam Length -'l = ? {10}'m
+'Load -'q = ? {5}'kN/m
 #post
 '<p><b>Internal forces</b></p>
 'Bending
@@ -18,7 +18,7 @@ V_B = 3*q*l/8'kN
 PlotWidth = 600
 PlotHeight = 150
 #show
-'Calculate internal forces at'x_1 = ?'m
+'Calculate internal forces at'x_1 = ? {1}'m
 #pre
 
 
@@ -32,4 +32,4 @@ V(x) = V_A - q*x
 $Plot{V(x) @ x = 0 : l}
 V(x_1)'kN
 #show
-'</div>10	5	1
+'</div>

--- a/Examples/Structural/Reinforced Concrete - Plates/Fully Restrained Slab Panel.cpd
+++ b/Examples/Structural/Reinforced Concrete - Plates/Fully Restrained Slab Panel.cpd
@@ -4,11 +4,11 @@
 '<img alt="f-span-cl.png" class="side" style="height:180pt;" src="../../Images/structures/rc/spans/f-span-cl.png">
 '<h4>Dimensions</h4>
 'Clear spans(<i>l</i><sub>x</sub> &lt; <i>l</i><sub>y</sub>)
-l_x_cl = ?'m,'l_y_cl = ?'m
-'Beam width along <i>x</i> -'b_y = ?'cm
-'Beam width along <i>y</i> -'b_x = ?'cm
-'Slab thickness -'h = ?'cm
-'Concrete cover -'c = ?'cm
+l_x_cl = ? {4}'m,'l_y_cl = ? {6}'m
+'Beam width along <i>x</i> -'b_y = ? {25}'cm
+'Beam width along <i>y</i> -'b_x = ? {25}'cm
+'Slab thickness -'h = ? {14}'cm
+'Concrete cover -'c = ? {2}'cm
 #post
 'Design span lengths
 l_x = l_x_cl + min(b_x/100;h/100)'m
@@ -23,13 +23,13 @@ l_y = l_y_cl + min(b_y/100;h/100)'m
 	'<table><tr><td rowspan="2">
 	'Parallel to <i>x</i> - <br />
 	'</td><td>
-	l_x1 = ?'m;
+	l_x1 = ? {0}'m;
 	'</td><td>
-	M_Ed_xt1_ = ?'kN·m/m
+	M_Ed_xt1_ = ? {0}'kN·m/m
 	'</td></tr><tr><td>
-	l_x2 = ?'m;
+	l_x2 = ? {0}'m;
 	'</td><td>
-	M_Ed_xt2_ = ?'kN·m/m
+	M_Ed_xt2_ = ? {0}'kN·m/m
 	'</td></tr></table>
 	'<!--
 	#if k ≤ 2
@@ -37,13 +37,13 @@ l_y = l_y_cl + min(b_y/100;h/100)'m
 		'<table><tr><td rowspan="2">
 		'Along <i>y</i> -
 		'</td><td>
-		l_y1 = ?'m;
+		l_y1 = ? {0}'m;
 		'</td><td>
-		M_Ed_yt1_ = ?'kN·m/m
+		M_Ed_yt1_ = ? {0}'kN·m/m
 		'</td></tr><tr><td>
-		l_y2 = ?'m;
+		l_y2 = ? {0}'m;
 		'</td><td>
-		M_Ed_yt2_ = ?'kN·m/m
+		M_Ed_yt2_ = ? {0}'kN·m/m
 		'</td></tr></table>
 	'<!--
 	#end if
@@ -52,8 +52,8 @@ l_y = l_y_cl + min(b_y/100;h/100)'m
 	'<h4>Loads</h4>
 	'Characteristic uniform loads
 	'Self weight -'g_sw = 0.25*h'kN/m²
-	'Permanent - 'g_k = ?'kN/m²
-	'Variable -'q_k = ?'kN/m²
+	'Permanent - 'g_k = ? {2.5}'kN/m²
+	'Variable -'q_k = ? {2}'kN/m²
 	'Partial safety factor -'γ_G = 1.35';'γ_Q = 1.5
 	#post
 	'Design uniform loads
@@ -82,8 +82,8 @@ l_y = l_y_cl + min(b_y/100;h/100)'m
 	#show
 	'<h4>Material properties</h4>
 	'<p><b>Concrete</b> &nbsp;&nbsp;[EN 1992-1-1, Table 3.1]</p>
-	'Characteristic compressive cylinder strength -'f_ck = ?'MPa
-	'Partial safety factors for concrete -'γ_c = 1.5','α_cc = ?
+	'Characteristic compressive cylinder strength -'f_ck = ? {25}'MPa
+	'Partial safety factors for concrete -'γ_c = 1.5','α_cc = ? {0.85}
 	#post
 	'Design compressive cylinder strength -'f_cd = α_cc*f_ck/γ_c'MPa
 	'Factor defining the effective height of the compression zone -'λ = 0.8'
@@ -91,15 +91,15 @@ l_y = l_y_cl + min(b_y/100;h/100)'m
 	'Mean value of axial tensile strength -'f_ctm = 0.30*f_ck^(2/3)'MPa
 	#show
 	'<p><b>Steel</b></p>
-	'Characteristic yield strength -'f_yk = ?'MPa
+	'Characteristic yield strength -'f_yk = ? {500}'MPa
 	#post
 	'Partial safety factor for steel - 'γ_s = 1.15
 	'Design yield strength - 'f_yd = f_yk/γ_s'MPa
 	'Limit relative compressive zone depth -'ξ_lim = 0.45
 	#show
 	'<p><b>Bar diameters</b></p>
-	'- Bottom parallel to <i>x</i> -'d_bxb = ?'mm, parallel to <i>y</i> -'d_byb = ?'mm
-	'- Top parallel to <i>x</i> -'d_bxt = ?'mm, parallel to <i>y</i> -'d_byt = ?'mm
+	'- Bottom parallel to <i>x</i> -'d_bxb = ? {8}'mm, parallel to <i>y</i> -'d_byb = ? {8}'mm
+	'- Top parallel to <i>x</i> -'d_bxt = ? {6}'mm, parallel to <i>y</i> -'d_byt = ? {6}'mm
 	#post
 	'<div class="fold">
 	'<h4>Static calculations</h4>
@@ -435,4 +435,4 @@ l_y = l_y_cl + min(b_y/100;h/100)'m
 	'</table>
 #end if
 #show
-'</div>4	6	25	25	14	2	0	0	0	0	0	0	0	0	2.5	2	25	0.85	500	8	8	6	6
+'</div>

--- a/Examples/Structural/Reinforced Concrete - Plates/Restrained Adjacent Edges.cpd
+++ b/Examples/Structural/Reinforced Concrete - Plates/Restrained Adjacent Edges.cpd
@@ -4,11 +4,11 @@
 '<img alt="sffs-span-cl.png" class="side" style="height:180pt;" src="../../Images/structures/rc/spans/sffs-span-cl.png">
 '<h4>Dimensions</h4>
 'Clear spans (<i>l</i><sub>x</sub> &lt; <i>l</i><sub>y</sub>)
-l_x_cl = ?'m,'l_y_cl = ?'m
-'Beam width along<i>x</i> -'b_y = ?'cm
-'Beam width along <i>y</i> -'b_x = ?'cm
-'Slab thickness -'h = ?'cm
-'Concrete cover -'c = ?'cm
+l_x_cl = ? {4}'m,'l_y_cl = ? {6}'m
+'Beam width along<i>x</i> -'b_y = ? {25}'cm
+'Beam width along <i>y</i> -'b_x = ? {25}'cm
+'Slab thickness -'h = ? {14}'cm
+'Concrete cover -'c = ? {2}'cm
 #post
 'Design span lengths
 l_x = l_x_cl + min(b_x/100;h/100)'m
@@ -23,9 +23,9 @@ l_y = l_y_cl + min(b_y/100;h/100)'m
 	'<table><tr><td>
 	'Along <i>x</i> - <br />
 	'</td><td>
-	l_x2 = ?'m;
+	l_x2 = ? {0}'m;
 	'</td><td>
-	M_Ed_xt2_ = ?'kN·m/m
+	M_Ed_xt2_ = ? {0}'kN·m/m
 	'</td></tr></table>
 	'<!--
 	#if k ≤ 2
@@ -33,9 +33,9 @@ l_y = l_y_cl + min(b_y/100;h/100)'m
 		'<table><tr><td>
 		'Along <i>y</i> -
 		'</td><td>
-		l_y2 = ?'m;
+		l_y2 = ? {0}'m;
 		'</td><td>
-		M_Ed_yt2_ = ?'kN·m/m
+		M_Ed_yt2_ = ? {0}'kN·m/m
 		'</td></tr></table>
 		'<!--
 	#end if
@@ -44,8 +44,8 @@ l_y = l_y_cl + min(b_y/100;h/100)'m
 	'<h4>Loads</h4>
 	'Characteristic uniform loads
 	'Self weight -'g_sw = 0.25*h'kN/m²
-	'Permanent -'g_k = ?'kN/m²
-	'Variable -'q_k = ?'kN/m²
+	'Permanent -'g_k = ? {2.5}'kN/m²
+	'Variable -'q_k = ? {2}'kN/m²
 	'Partial safety factor -'γ_G = 1.35';'γ_Q = 1.5
 	#post
 	'Design uniform loads
@@ -74,8 +74,8 @@ l_y = l_y_cl + min(b_y/100;h/100)'m
 	#show
 	'<h4>Material properties</h4>
 	'<p><b>Concrete</b> &nbsp;&nbsp;[EN 1992-1-1, Table 3.1]</p>
-	'Characteristic compressive cylinder strength -'f_ck = ?'MPa
-	'Partial safety factors for concrete -'γ_c = 1.5','α_cc = ?
+	'Characteristic compressive cylinder strength -'f_ck = ? {25}'MPa
+	'Partial safety factors for concrete -'γ_c = 1.5','α_cc = ? {0.85}
 	#post
 	'Design compressive cylinder strength -'f_cd = α_cc*f_ck/γ_c'MPa
 	'Factor defining the effective height of the compression zone -'λ = 0.8'
@@ -83,15 +83,15 @@ l_y = l_y_cl + min(b_y/100;h/100)'m
 	'Mean value of axial tensile strength -'f_ctm = 0.30*f_ck^(2/3)'MPa
 	#show
 	'<p><b>Steel</b></p>
-	'Characteristic yield strength -'f_yk = ?'MPa
+	'Characteristic yield strength -'f_yk = ? {500}'MPa
 	#post
 	'Partial safety factor for steel - 'γ_s = 1.15
 	'Design yield strength - 'f_yd = f_yk/γ_s'MPa
 	'Limit relative compressive zone depth -'ξ_lim = 0.45
 	#show
 	'<p><b>Bar diameters</b></p>
-	'- Bottom parallel to <i>x</i> -'d_bxb = ?'mm, parallel to <i>y</i> -'d_byb = ?'mm
-	'- Top parallel to <i>x</i> -'d_bxt = ?'mm, parallel to <i>y</i> -'d_byt = ?'mm
+	'- Bottom parallel to <i>x</i> -'d_bxb = ? {8}'mm, parallel to <i>y</i> -'d_byb = ? {8}'mm
+	'- Top parallel to <i>x</i> -'d_bxt = ? {6}'mm, parallel to <i>y</i> -'d_byt = ? {6}'mm
 	#post
 	'<div class="fold">
 	'<h4>Static calculations</h4>
@@ -391,4 +391,4 @@ l_y = l_y_cl + min(b_y/100;h/100)'m
 	'</table>
 #end if
 #show
-'</div>4	6	25	25	14	2	0	0	0	0	2.5	2	25	0.85	500	8	8	6	6
+'</div>

--- a/Examples/Structural/Reinforced Concrete - Plates/Restrained Both Longer Edges.cpd
+++ b/Examples/Structural/Reinforced Concrete - Plates/Restrained Both Longer Edges.cpd
@@ -4,11 +4,11 @@
 '<img alt="fsfs-span-cl.png" class="side" style="height:180pt;" src="../../Images/structures/rc/spans/fsfs-span-cl.png">
 '<h4>Dimensions</h4>
 'Clear spans (<i>l</i><sub>x</sub> &lt; <i>l</i><sub>y</sub>)
-l_x_cl = ?'m,'l_y_cl = ?'m
-'Beam width along <i>x</i> -'b_y = ?'cm
-'Beam width along <i>y</i> -'b_x = ?'cm
-'Slab thickness -'h = ?'cm
-'Concrete cover -'c = ?'cm
+l_x_cl = ? {4}'m,'l_y_cl = ? {6}'m
+'Beam width along <i>x</i> -'b_y = ? {25}'cm
+'Beam width along <i>y</i> -'b_x = ? {25}'cm
+'Slab thickness -'h = ? {14}'cm
+'Concrete cover -'c = ? {2}'cm
 #post
 'Design span lengths
 l_x = l_x_cl + min(b_x/100;h/100)'m
@@ -23,20 +23,20 @@ l_y = l_y_cl + min(b_y/100;h/100)'m
 	'<table><tr><td rowspan="2">
 	'Parallel to <i>x</i> - <br />
 	'</td><td>
-	l_x1 = ?'m;
+	l_x1 = ? {0}'m;
 	'</td><td>
-	M_Ed_xt1_ = ?'kN·m/m
+	M_Ed_xt1_ = ? {0}'kN·m/m
 	'</td></tr><tr><td>
-	l_x2 = ?'m;
+	l_x2 = ? {0}'m;
 	'</td><td>
-	M_Ed_xt2_ = ?'kN·m/m
+	M_Ed_xt2_ = ? {0}'kN·m/m
 	'</td></tr></table>
 	'(in absence of contiguous span - <i>l</i> = 0)
 	'<h4>Loads</h4>
 	'Characteristic uniform loads
 	'Self weight -'g_sw = 0.25*h'kN/m²
-	'Permanent -'g_k = ?'kN/m²
-	'Variable -'q_k = ?'kN/m²
+	'Permanent -'g_k = ? {2.5}'kN/m²
+	'Variable -'q_k = ? {2}'kN/m²
 	'Partial safety factor -'γ_G = 1.35';'γ_Q = 1.5
 	#post
 	'Design uniform loads
@@ -65,8 +65,8 @@ l_y = l_y_cl + min(b_y/100;h/100)'m
 	#show
 	'<h4>Material properties</h4>
 	'<p><b>Бетон</b> &nbsp;&nbsp;[EN 1992-1-1, EN 1992-1-1, Table 3.1]</p>
-	'Characteristic compressive cylinder strength -'f_ck = ?'MPa
-	'Partial safety factors for concrete -'γ_c = 1.5','α_cc = ?
+	'Characteristic compressive cylinder strength -'f_ck = ? {25}'MPa
+	'Partial safety factors for concrete -'γ_c = 1.5','α_cc = ? {0.85}
 	#post
 	'Design compressive cylinder strength -'f_cd = α_cc*f_ck/γ_c'MPa
 	'Factor defining the effective height of the compression zone -'λ = 0.8'
@@ -74,15 +74,15 @@ l_y = l_y_cl + min(b_y/100;h/100)'m
 	'Mean value of axial tensile strength -'f_ctm = 0.30*f_ck^(2/3)'MPa
 	#show
 	'<p><b>Steel</b></p>
-	'Characteristic yield strength -'f_yk = ?'MPa
+	'Characteristic yield strength -'f_yk = ? {500}'MPa
 	#post
 	'Partial safety factor for steel - 'γ_s = 1.15
 	'Design yield strength - 'f_yd = f_yk/γ_s'MPa
 	'Limit relative compressive zone depth -'ξ_lim = 0.45
 	#show
 	'<p><b>Bar diameters</b></p>
-	'- Bottom parallel to <i>x</i> -'d_bxb = ?'mm, parallel to <i>y</i> -'d_byb = ?'mm
-	'- Top parallel to <i>x</i> -'d_bxt = ?'mm
+	'- Bottom parallel to <i>x</i> -'d_bxb = ? {8}'mm, parallel to <i>y</i> -'d_byb = ? {8}'mm
+	'- Top parallel to <i>x</i> -'d_bxt = ? {6}'mm
 	#post
 	'<div class="fold">
 	'<h4>Static calculations</h4>
@@ -355,4 +355,4 @@ l_y = l_y_cl + min(b_y/100;h/100)'m
 	'</table>
 #end if
 #show
-'</div>4	6	25	25	14	2	0	0	0	0	2.5	2	25	0.85	500	8	8	6
+'</div>

--- a/Examples/Structural/Reinforced Concrete - Plates/Restrained Both Shorter Edges.cpd
+++ b/Examples/Structural/Reinforced Concrete - Plates/Restrained Both Shorter Edges.cpd
@@ -4,11 +4,11 @@
 '<img alt="sfsf-span-cl.png" class="side" style="height:190pt;" src="../../Images/structures/rc/spans/sfsf-span-cl.png">
 '<h4>Dimensions</h4>
 'Clear spans (<i>l</i><sub>x</sub> &lt; <i>l</i><sub>y</sub>)
-l_x_cl = ?'m,'l_y_cl = ?'m
-'Beam width along <i>x</i> -'b_y = ?'cm
-'Beam width along <i>y</i> -'b_x = ?'cm
-'Slab thickness -'h = ?'cm
-'Concrete cover -'c = ?'cm
+l_x_cl = ? {4}'m,'l_y_cl = ? {6}'m
+'Beam width along <i>x</i> -'b_y = ? {25}'cm
+'Beam width along <i>y</i> -'b_x = ? {25}'cm
+'Slab thickness -'h = ? {14}'cm
+'Concrete cover -'c = ? {2}'cm
 #post
 'Design span lengths
 l_x = l_x_cl + min(b_x/100;h/100)'m
@@ -26,13 +26,13 @@ l_y = l_y_cl + min(b_y/100;h/100)'m
 		'<table><tr><td rowspan="2">
 		'Along <i>y</i> -
 		'</td><td>
-		l_y1 = ?'m;
+		l_y1 = ? {0}'m;
 		'</td><td>
-		M_Ed_yt1_ = ?'kN·m/m
+		M_Ed_yt1_ = ? {0}'kN·m/m
 		'</td></tr><tr><td>
-		l_y2 = ?'m;
+		l_y2 = ? {0}'m;
 		'</td><td>
-		M_Ed_yt2_ = ?'kN·m/m
+		M_Ed_yt2_ = ? {0}'kN·m/m
 		'</td></tr></table>
 		'<!--
 	#end if
@@ -41,8 +41,8 @@ l_y = l_y_cl + min(b_y/100;h/100)'m
 	'<h4>Loads</h4>
 	'Characteristic uniform loads
 	'Self weight -'g_sw = 0.25*h'kN/m²
-	'Permanent - 'g_k = ?'kN/m²
-	'Variable -'q_k = ?'kN/m²
+	'Permanent - 'g_k = ? {2.5}'kN/m²
+	'Variable -'q_k = ? {2}'kN/m²
 	'Partial safety factor -'γ_G = 1.35';'γ_Q = 1.5
 	#post
 	'Design uniform loads
@@ -71,8 +71,8 @@ l_y = l_y_cl + min(b_y/100;h/100)'m
 	#show
 	'<h4>Material properties</h4>
 	'<p><b>Concrete</b> &nbsp;&nbsp;[ EN 1992-1-1, Table 3.1]</p>
-	'Characteristic compressive cylinder strength -'f_ck = ?'MPa
-	'Partial safety factors for concrete -'γ_c = 1.5','α_cc = ?
+	'Characteristic compressive cylinder strength -'f_ck = ? {25}'MPa
+	'Partial safety factors for concrete -'γ_c = 1.5','α_cc = ? {0.85}
 	#post
 	'Design compressive cylinder strength -'f_cd = α_cc*f_ck/γ_c'MPa
 	'Factor defining the effective height of the compression zone -'λ = 0.8'
@@ -80,15 +80,15 @@ l_y = l_y_cl + min(b_y/100;h/100)'m
 	'Mean value of axial tensile strength -'f_ctm = 0.30*f_ck^(2/3)'MPa
 	#show
 	'<p><b>Steel</b></p>
-	'Characteristic yield strength -'f_yk = ?'MPa
+	'Characteristic yield strength -'f_yk = ? {500}'MPa
 	#post
 	'Partial safety factor for steel - 'γ_s = 1.15
 	'Design yield strength - 'f_yd = f_yk/γ_s'MPa
 	'Limit relative compressive zone depth -'ξ_lim = 0.45
 	#show
 	'<p><b>Bar diameters</b></p>
-	'- Bottom parallel to <i>x</i> -'d_bxb = ?'mm, parallel to <i>y</i> -'d_byb = ?'mm
-	'- Top parallel to <i>x</i> -'d_bxt = ?'mm, parallel to <i>y</i> -'d_byt = ?'mm
+	'- Bottom parallel to <i>x</i> -'d_bxb = ? {8}'mm, parallel to <i>y</i> -'d_byb = ? {8}'mm
+	'- Top parallel to <i>x</i> -'d_bxt = ? {6}'mm, parallel to <i>y</i> -'d_byt = ? {6}'mm
 	#post
 	'<div class="fold">
 	'<h4>Static calculations</h4>
@@ -351,4 +351,4 @@ l_y = l_y_cl + min(b_y/100;h/100)'m
 	'</table>
 #end if
 #show
-'</div>4	6	25	25	14	2	0	0	0	0	2.5	2	25	0.85	500	8	8	6	6
+'</div>

--- a/Examples/Structural/Reinforced Concrete - Plates/Restrained Longer Edge.cpd
+++ b/Examples/Structural/Reinforced Concrete - Plates/Restrained Longer Edge.cpd
@@ -4,11 +4,11 @@
 '<img alt="ssfs-span-cl.png" class="side" style="height:170pt;" src="../../Images/structures/rc/spans/ssfs-span-cl.png">
 '<h4>Dimensions</h4>
 'Clear spans (<i>l</i><sub>x</sub> &lt; <i>l</i><sub>y</sub>)
-l_x_cl = ?'m,'l_y_cl = ?'m
-'Beam width along <i>x</i> -'b_y = ?'cm
-'Beam width along <i>y</i> -'b_x = ?'cm
-'Slab thickness -'h = ?'cm
-'Concrete cover -'c = ?'cm
+l_x_cl = ? {4}'m,'l_y_cl = ? {6}'m
+'Beam width along <i>x</i> -'b_y = ? {25}'cm
+'Beam width along <i>y</i> -'b_x = ? {25}'cm
+'Slab thickness -'h = ? {14}'cm
+'Concrete cover -'c = ? {2}'cm
 #post
 'Design span lengths
 l_x = l_x_cl + min(b_x/100;h/100)'m
@@ -23,16 +23,16 @@ l_y = l_y_cl + min(b_y/100;h/100)'m
 	'<table><tr><td>
 	'Parallel to <i>x</i> - <br />
 	'</td><td>
-	l_x2 = ?'m;
+	l_x2 = ? {0}'m;
 	'</td><td>
-	M_Ed_xt2_ = ?'kN·m/m
+	M_Ed_xt2_ = ? {0}'kN·m/m
 	'</td></tr></table>
 	'(in absence of contiguous span - <i>l</i> = 0)
 	'<h4>Loads</h4>
 	'Characteristic uniform loads
 	'Self weight -'g_sw = 0.25*h'kN/m²
-	'Permanent -'g_k = ?'kN/m²
-	'Variable -'q_k = ?'kN/m²
+	'Permanent -'g_k = ? {2.5}'kN/m²
+	'Variable -'q_k = ? {2}'kN/m²
 	'Partial safety factor -'γ_G = 1.35';'γ_Q = 1.5
 	#post
 	'Design uniform loads
@@ -61,8 +61,8 @@ l_y = l_y_cl + min(b_y/100;h/100)'m
 	#show
 	'<h4>Material properties</h4>
 	'<p><b>Concrete</b> &nbsp;&nbsp;[EN 1992-1-1, Table 3.1]</p>
-	'Characteristic compressive cylinder strength -'f_ck = ?'MPa
-	'Partial safety factors for concrete -'γ_c = 1.5','α_cc = ?
+	'Characteristic compressive cylinder strength -'f_ck = ? {25}'MPa
+	'Partial safety factors for concrete -'γ_c = 1.5','α_cc = ? {0.85}
 	#post
 	'Design compressive cylinder strength -'f_cd = α_cc*f_ck/γ_c'MPa
 	'Factor defining the effective height of the compression zone -'λ = 0.8
@@ -70,15 +70,15 @@ l_y = l_y_cl + min(b_y/100;h/100)'m
 	'Mean value of axial tensile strength -'f_ctm = 0.30*f_ck^(2/3)'MPa
 	#show
 	'<p><b>Steel</b></p>
-	'Characteristic yield strength -'f_yk = ?'MPa
+	'Characteristic yield strength -'f_yk = ? {500}'MPa
 	#post
 	'Partial safety factor for steel - 'γ_s = 1.15
 	'Design yield strength - 'f_yd = f_yk/γ_s'MPa
 	'Limit relative compressive zone depth -'ξ_lim = 0.45
 	#show
 	'<p><b>Bar diameters</b></p>
-	'- Bottom parallel to <i>x</i> -'d_bxb = ?'mm, parallel to <i>y</i> -'d_byb = ?'mm
-	'- Top parallel to <i>x</i> -'d_bxt = ?'mm
+	'- Bottom parallel to <i>x</i> -'d_bxb = ? {8}'mm, parallel to <i>y</i> -'d_byb = ? {8}'mm
+	'- Top parallel to <i>x</i> -'d_bxt = ? {6}'mm
 	#post
 	'<div class="fold">
 	'<h4>Static calculations</h4>
@@ -339,4 +339,4 @@ l_y = l_y_cl + min(b_y/100;h/100)'m
 	'</table>
 #end if
 #show
-'</div>4	6	25	25	14	2	0	0	2.5	2	25	0.85	500	8	8	6
+'</div>

--- a/Examples/Structural/Reinforced Concrete - Plates/Restrained Panel with Unrestrained Longer Edge.cpd
+++ b/Examples/Structural/Reinforced Concrete - Plates/Restrained Panel with Unrestrained Longer Edge.cpd
@@ -4,11 +4,11 @@
 '<img alt="sfff-span-cl.png" class="side" style="height:180pt;" src="../../Images/structures/rc/spans/sfff-span-cl.png">
 '<h4>Dimensions</h4>
 'Clear spans (<i>l</i><sub>x</sub> &lt; <i>l</i><sub>y</sub>)
-l_x_cl = ?'m,'l_y_cl = ?'m
-'Beam width along <i>x</i> -'b_y = ?'cm
-'Beam width along <i>y</i> -'b_x = ?'cm
-'Slab thickness -'h = ?'cm
-'Concrete cover -'c = ?'cm
+l_x_cl = ? {4}'m,'l_y_cl = ? {6}'m
+'Beam width along <i>x</i> -'b_y = ? {25}'cm
+'Beam width along <i>y</i> -'b_x = ? {25}'cm
+'Slab thickness -'h = ? {14}'cm
+'Concrete cover -'c = ? {2}'cm
 #post
 'Design span lengths
 l_x = l_x_cl + min(b_x/100;h/100)'md
@@ -23,9 +23,9 @@ l_y = l_y_cl + min(b_y/100;h/100)'m
 	'<table><tr><td>
 	'Parallel to <i>x</i> - <br />
 	'</td><td>
-	l_x2 = ?'m;
+	l_x2 = ? {0}'m;
 	'</td><td>
-	M_Ed_xt2_ = ?'kN·m/m
+	M_Ed_xt2_ = ? {0}'kN·m/m
 	'</td></tr></table>
 	'<!--
 	#if k ≤ 2
@@ -33,13 +33,13 @@ l_y = l_y_cl + min(b_y/100;h/100)'m
 		'<table><tr><td rowspan="2">
 		'Parallel to <i>y</i> -
 		'</td><td>
-		l_y1 = ?'m;
+		l_y1 = ? {0}'m;
 		'</td><td>
-		M_Ed_yt1_ = ?'kN·m/m
+		M_Ed_yt1_ = ? {0}'kN·m/m
 		'</td></tr><tr><td>
-		l_y2 = ?'m;
+		l_y2 = ? {0}'m;
 		'</td><td>
-		M_Ed_yt2_ = ?'kN·m/m
+		M_Ed_yt2_ = ? {0}'kN·m/m
 		'</td></tr></table>
 		'<!--
 	#end if
@@ -48,8 +48,8 @@ l_y = l_y_cl + min(b_y/100;h/100)'m
 	'<h4>Loads</h4>
 	'Characteristic uniform loads
 	'Self weight -'g_sw = 0.25*h'kN/m²
-	'Permanent - 'g_k = ?'kN/m²
-	'Variable -'q_k = ?'kN/m²
+	'Permanent - 'g_k = ? {2.5}'kN/m²
+	'Variable -'q_k = ? {2}'kN/m²
 	'Partial safety factor -'γ_G = 1.35';'γ_Q = 1.5
 	#post
 	'Design uniform loads
@@ -78,8 +78,8 @@ l_y = l_y_cl + min(b_y/100;h/100)'m
 	#show
 	'<h4>Material properties</h4>
 	'<p><b>Concrete</b> &nbsp;&nbsp;[EN 1992-1-1, Table 3.1]</p>
-	'Characteristic compressive cylinder strength -'f_ck = ?'MPa
-	'Partial safety factors for concrete -'γ_c = 1.5','α_cc = ?
+	'Characteristic compressive cylinder strength -'f_ck = ? {25}'MPa
+	'Partial safety factors for concrete -'γ_c = 1.5','α_cc = ? {0.85}
 	#post
 	'Design compressive cylinder strength -'f_cd = α_cc*f_ck/γ_c'MPa
 	'Factor defining the effective height of the compression zone -'λ = 0.8'
@@ -87,15 +87,15 @@ l_y = l_y_cl + min(b_y/100;h/100)'m
 	'Mean value of axial tensile strength -'f_ctm = 0.30*f_ck^(2/3)'MPa
 	#show
 	'<p><b>Steel</b></p>
-	'Characteristic yield strength -'f_yk = ?'MPa
+	'Characteristic yield strength -'f_yk = ? {500}'MPa
 	#post
 	'Partial safety factor for steel - 'γ_s = 1.15
 	'Design yield strength - 'f_yd = f_yk/γ_s'MPa
 	'Limit relative compressive zone depth -'ξ_lim = 0.45
 	#show
 	'<p><b>Bar diameters</b></p>
-	'- Bottom parallel to <i>x</i> -'d_bxb = ?'mm, parallel to <i>y</i> -'d_byb = ?'mm
-	'- Top parallel to <i>x</i> -'d_bxt = ?'mm, parallel to <i>y</i> -'d_byt = ?'mm
+	'- Bottom parallel to <i>x</i> -'d_bxb = ? {8}'mm, parallel to <i>y</i> -'d_byb = ? {8}'mm
+	'- Top parallel to <i>x</i> -'d_bxt = ? {6}'mm, parallel to <i>y</i> -'d_byt = ? {6}'mm
 	#post
 	'<div class="fold">
 	'<h4>Static calculations</h4>
@@ -417,4 +417,4 @@ l_y = l_y_cl + min(b_y/100;h/100)'m
 	'</table>
 #end if
 #show
-'</div>4	6	25	25	14	2	0	0	0	0	0	0	2.5	2	25	0.85	500	8	8	6	6
+'</div>

--- a/Examples/Structural/Reinforced Concrete - Plates/Restrained Panel with Unrestrained Shorter Edge.cpd
+++ b/Examples/Structural/Reinforced Concrete - Plates/Restrained Panel with Unrestrained Shorter Edge.cpd
@@ -4,11 +4,11 @@
 '<img alt="fsff-span-cl.png" class="side" style="height:180pt;" src="../../Images/structures/rc/spans/fsff-span-cl.png">
 '<h4>Dimensions</h4>
 'Clear spans (<i>l</i><sub>x</sub> &lt; <i>l</i><sub>y</sub>)
-l_x_cl = ?'m,'l_y_cl = ?'m
-'Beam width along <i>x</i> -'b_y = ?'cm
-'Beam width along <i>y</i> -'b_x = ?'cm
-'Slab thickness -'h = ?'cm
-'Concrete cover -'c = ?'cm
+l_x_cl = ? {4}'m,'l_y_cl = ? {6}'m
+'Beam width along <i>x</i> -'b_y = ? {25}'cm
+'Beam width along <i>y</i> -'b_x = ? {25}'cm
+'Slab thickness -'h = ? {14}'cm
+'Concrete cover -'c = ? {2}'cm
 #post
 'Design span lengths
 l_x = l_x_cl + min(b_x/100;h/100)'m
@@ -23,13 +23,13 @@ l_y = l_y_cl + min(b_y/100;h/100)'m
 	'<table><tr><td rowspan="2">
 	'Parallel to <i>x</i> - <br />
 	'</td><td>
-	l_x1 = ?'m;
+	l_x1 = ? {0}'m;
 	'</td><td>
-	M_Ed_xt1_ = ?'kN·m/m
+	M_Ed_xt1_ = ? {0}'kN·m/m
 	'</td></tr><tr><td>
-	l_x2 = ?'m;
+	l_x2 = ? {0}'m;
 	'</td><td>
-	M_Ed_xt2_ = ?'kN·m/m
+	M_Ed_xt2_ = ? {0}'kN·m/m
 	'</td></tr></table>
 	'<!--
 	#if k ≤ 2
@@ -37,9 +37,9 @@ l_y = l_y_cl + min(b_y/100;h/100)'m
 		'<table><tr><td>
 		'Parallel to <i>y</i> -
 		'</td><td>
-		l_y1 = ?'m;
+		l_y1 = ? {0}'m;
 		'</td><td>
-		M_Ed_yt1_ = ?'kN·m/m
+		M_Ed_yt1_ = ? {0}'kN·m/m
 		'</td></tr></table>
 		'<!--
 	#end if
@@ -48,8 +48,8 @@ l_y = l_y_cl + min(b_y/100;h/100)'m
 	'<h4>Loads</h4>
 	'Characteristic uniform loads
 	'Self weight -'g_sw = 0.25*h'kN/m<sup>2</sup>
-	'Permanent -'g_k = ?'kN/m<sup>2</sup>
-	'Variable -'q_k = ?'kN/m<sup>2</sup>
+	'Permanent -'g_k = ? {2.5}'kN/m<sup>2</sup>
+	'Variable -'q_k = ? {2}'kN/m<sup>2</sup>
 	'Partial safety factor -'γ_G = 1.35';'γ_Q = 1.5
 	#post
 	'Design uniform loads
@@ -78,8 +78,8 @@ l_y = l_y_cl + min(b_y/100;h/100)'m
 	#show
 	'<h4>Material properties</h4>
 	'<p><b>Concrete</b> &nbsp;&nbsp;[EN 1992-1-1, Table 3.1]</p>
-	'Characteristic compressive cylinder strength -'f_ck = ?'MPa
-	'Partial safety factors for concrete -'γ_c = 1.5','α_cc = ?
+	'Characteristic compressive cylinder strength -'f_ck = ? {25}'MPa
+	'Partial safety factors for concrete -'γ_c = 1.5','α_cc = ? {0.85}
 	#post
 	'Design compressive cylinder strength -'f_cd = α_cc*f_ck/γ_c'MPa
 	'Factor defining the effective height of the compression zone -'λ = 0.8'
@@ -87,15 +87,15 @@ l_y = l_y_cl + min(b_y/100;h/100)'m
 	'Mean value of axial tensile strength -'f_ctm = 0.30*f_ck^(2/3)'MPa
 	#show
 	'<p><b>Steel</b></p>
-	'Characteristic yield strength -'f_yk = ?'MPa
+	'Characteristic yield strength -'f_yk = ? {500}'MPa
 	#post
 	'Partial safety factor for steel - 'γ_s = 1.15
 	'Design yield strength - 'f_yd = f_yk/γ_s'MPa
 	'Limit relative compressive zone depth -'ξ_lim = 0.45
 	#show
 	'<p><b>Bar diameters</b></p>
-	'- Bottom parallel to <i>x</i> -'d_bxb = ?'mm, parallel to <i>y</i> -'d_byb = ?'mm
-	'- Top parallel to <i>x</i> -'d_bxt = ?'mm, parallel to <i>y</i> -'d_byt = ?'mm
+	'- Bottom parallel to <i>x</i> -'d_bxb = ? {8}'mm, parallel to <i>y</i> -'d_byb = ? {8}'mm
+	'- Top parallel to <i>x</i> -'d_bxt = ? {6}'mm, parallel to <i>y</i> -'d_byt = ? {6}'mm
 	#post
 	'<div class="fold">
 	'<h4>Static calculations</h4>
@@ -408,4 +408,3 @@ l_y = l_y_cl + min(b_y/100;h/100)'m
 #end if
 #show
 '</div>
-4	6	25	25	14	2	0	0	0	0	0	0	2.5	2	25	0.85	500	8	8	6	6

--- a/Examples/Structural/Reinforced Concrete - Plates/Restrained Shorter Edge.cpd
+++ b/Examples/Structural/Reinforced Concrete - Plates/Restrained Shorter Edge.cpd
@@ -4,11 +4,11 @@
 '<img alt="sssf-span-cl.png" class="side" style="height:180pt;" src="../../Images/structures/rc/spans/sssf-span-cl.png">
 '<h4>Dimensions</h4>
 'Clear spans (<i>l</i><sub>x</sub> &lt; <i>l</i><sub>y</sub>)
-l_x_cl = ?'m,'l_y_cl = ?'m
-'Beam width along <i>x</i> -'b_y = ?'cm
-'Beam width along <i>y</i> -'b_x = ?'cm
-'Slab thickness -'h = ?'cm
-'Concrete cover -'c = ?'cm
+l_x_cl = ? {4}'m,'l_y_cl = ? {6}'m
+'Beam width along <i>x</i> -'b_y = ? {25}'cm
+'Beam width along <i>y</i> -'b_x = ? {25}'cm
+'Slab thickness -'h = ? {14}'cm
+'Concrete cover -'c = ? {2}'cm
 #post
 'Design span lengths
 l_x = l_x_cl + min(b_x/100;h/100)'m
@@ -26,9 +26,9 @@ l_y = l_y_cl + min(b_y/100;h/100)'m
 		'<table><tr><td>
 		'Along <i>y</i> -
 		'</td><td>
-		l_y1 = ?'m;
+		l_y1 = ? {0}'m;
 		'</td><td>
-		M_Ed_yt1_ = ?'kN·m/m
+		M_Ed_yt1_ = ? {0}'kN·m/m
 		'</td></tr></table>
 		'<!--
 	#end if
@@ -37,8 +37,8 @@ l_y = l_y_cl + min(b_y/100;h/100)'m
 	'<h4>Loads</h4>
 	'Characteristic uniform loads
 	'Self weight -'g_sw = 0.25*h'kN/m²
-	'Permanent -'g_k = ?'kN/m²
-	'Variable -'q_k = ?'kN/m²
+	'Permanent -'g_k = ? {2.5}'kN/m²
+	'Variable -'q_k = ? {2}'kN/m²
 	'Partial safety factor -'γ_G = 1.35';'γ_Q = 1.5
 	#post
 	'Design uniform loads
@@ -67,8 +67,8 @@ l_y = l_y_cl + min(b_y/100;h/100)'m
 	#show
 	'<h4>Material properties</h4>
 	'<p><b>Concrete</b> &nbsp;&nbsp;[EN 1992-1-1, EN 1992-1-1, Table 3.1]</p>
-	'Characteristic compressive cylinder strength -'f_ck = ?'MPa
-	'Partial safety factors for concrete -'γ_c = 1.5','α_cc = ?
+	'Characteristic compressive cylinder strength -'f_ck = ? {25}'MPa
+	'Partial safety factors for concrete -'γ_c = 1.5','α_cc = ? {0.85}
 	#post
 	'Design compressive cylinder strength -'f_cd = α_cc*f_ck/γ_c'MPa
 	'Factor defining the effective height of the compression zone -'λ = 0.8'
@@ -76,15 +76,15 @@ l_y = l_y_cl + min(b_y/100;h/100)'m
 	'Mean value of axial tensile strength -'f_ctm = 0.30*f_ck^(2/3)'MPa
 	#show
 	'<p><b>Steel</b></p>
-	'Characteristic yield strength -'f_yk = ?'MPa
+	'Characteristic yield strength -'f_yk = ? {500}'MPa
 	#post
 	'Partial safety factor for steel - 'γ_s = 1.15
 	'Design yield strength - 'f_yd = f_yk/γ_s'MPa
 	'Limit relative compressive zone depth -'ξ_lim = 0.45
 	#show
 	'<p><b>Bar diameters</b></p>
-	'- Bottom parallel to <i>x</i> -'d_bxb = ?'mm, parallel to <i>y</i> -'d_byb = ?'mm
-	'- Top parallel to <i>y</i> -'d_byt = ?'mm
+	'- Bottom parallel to <i>x</i> -'d_bxb = ? {8}'mm, parallel to <i>y</i> -'d_byb = ? {8}'mm
+	'- Top parallel to <i>y</i> -'d_byt = ? {6}'mm
 	#post
 	'<div class="fold">
 	'<h4>Static calculations</h4>
@@ -325,4 +325,4 @@ l_y = l_y_cl + min(b_y/100;h/100)'m
 	'</table>
 #end if
 #show
-'</div>4	6	25	25	14	2	0	0	2.5	2	25	0.85	500	8	8	6	6
+'</div>

--- a/Examples/Structural/Reinforced Concrete - Plates/Simply Supported Slab Panel.cpd
+++ b/Examples/Structural/Reinforced Concrete - Plates/Simply Supported Slab Panel.cpd
@@ -4,11 +4,11 @@
 '<img alt="ss-span-cl.png" style="height:170pt;" class="side" src="../../Images/structures/rc/spans/ss-span-cl.png">
 '<h4>Dimensions</h4>
 'Clear spans (<i>l</i><sub>x</sub> &lt; <i>l</i><sub>y</sub>)
-l_x_cl = ?'m,'l_y_cl = ?'m
-'Beam width along <i>x</i> -'b_y = ?'cm
-'Beam width along <i>y</i> -'b_x = ?'cm
-'Slab thickness -'h = ?'cm
-'Concrete cover -'c = ?'cm
+l_x_cl = ? {4}'m,'l_y_cl = ? {6}'m
+'Beam width along <i>x</i> -'b_y = ? {25}'cm
+'Beam width along <i>y</i> -'b_x = ? {25}'cm
+'Slab thickness -'h = ? {14}'cm
+'Concrete cover -'c = ? {2}'cm
 #post
 'Design span lengths
 l_x = l_x_cl + min(b_x/100;h/100)'m
@@ -24,8 +24,8 @@ l_y = l_y_cl + min(b_y/100;h/100)'m
 	'<h4>Span length</h4>
 	'Design spans lengths and edge moments in adjacent panels
 	'Self weight -'g_sw = 0.25*h'kN/m²
-	'Permanent-'g_k = ?'kN/m²
-	'Variable -'q_k = ?'kN/m²
+	'Permanent-'g_k = ? {2.5}'kN/m²
+	'Variable -'q_k = ? {2}'kN/m²
 	'Partial safety factor -'γ_G = 1.35';'γ_Q = 1.5
 	#post
 	'Design uniform loads
@@ -54,8 +54,8 @@ l_y = l_y_cl + min(b_y/100;h/100)'m
 	#show
 	'<h4>Material properties</h4>
 	'<p><b>Concrete</b> &nbsp;&nbsp;[EN 1992-1-1, Table 3.1]</p>
-	'Characteristic compressive cylinder strength -'f_ck = ?'MPa
-	'Partial safety factors for concrete -'γ_c = 1.5','α_cc = ?
+	'Characteristic compressive cylinder strength -'f_ck = ? {25}'MPa
+	'Partial safety factors for concrete -'γ_c = 1.5','α_cc = ? {0.85}
 	#post
 	'Design compressive cylinder strength -'f_cd = α_cc*f_ck/γ_c'MPa
 	'Factor defining the effective height of the compression zone -'λ = 0.8'
@@ -63,15 +63,15 @@ l_y = l_y_cl + min(b_y/100;h/100)'m
 	'Mean value of axial tensile strength -'f_ctm = 0.30*f_ck^(2/3)'MPa
 	#show
 	'<p><b>Steel</b></p>
-	'Characteristic yield strength -'f_yk = ?'MPa
+	'Characteristic yield strength -'f_yk = ? {500}'MPa
 	#post
 	'Partial safety factor for steel - 'γ_s = 1.15
 	'Design yield strength - 'f_yd = f_yk/γ_s'MPa
 	'Limit relative compressive zone depth -'ξ_lim = 0.45
 	#show
 	'Bar diameters
-	'- Bottom parallel to <i>x</i> -'d_bxb = ?'mm
-	'- Top parallel to <i>y</i> -'d_byb = ?'mm
+	'- Bottom parallel to <i>x</i> -'d_bxb = ? {8}'mm
+	'- Top parallel to <i>y</i> -'d_byb = ? {6}'mm
 	#post
 	'<div class="fold">
 	'<h4>Static calculations</h4>
@@ -238,4 +238,4 @@ l_y = l_y_cl + min(b_y/100;h/100)'m
 	'</table>
 #end if
 #show
-'</div>4	6	25	25	14	2	2.5	2	25	0.85	500	8	6
+'</div>

--- a/Examples/Structural/Reinforced Concrete - Punching/Corner Column.cpd
+++ b/Examples/Structural/Reinforced Concrete - Punching/Corner Column.cpd
@@ -4,20 +4,20 @@
 '<img class="side" style="width:225pt;" src="../../Images/structures/rc/design/punching-corner-column.png" alt="punching-corner-column.png">
 '<h4>Input data</h4>
 '<p><b>Column</b></p>
-'Dimensions - 'c_1 = ?'mm, 'c_2 = ?'mm
+'Dimensions - 'c_1 = ? {600}'mm, 'c_2 = ? {300}'mm
 '<p><b>Design loads</b></p>
-'Support reaction -'V_Ed = ?'kN
+'Support reaction -'V_Ed = ? {125}'kN
 '<p><b>Slab</b></p>
-'Depth -'h = ?'mm
-'Concrete cover -'c = ?'mm
-'Longitudinal bars diameter -'d_bL = ?'mm
-'Links diameter -'d_w = ?'mm
+'Depth -'h = ? {200}'mm
+'Concrete cover -'c = ? {20}'mm
+'Longitudinal bars diameter -'d_bL = ? {10}'mm
+'Links diameter -'d_w = ? {6}'mm
 #post
 'Effective slab depth
 d = h - c - d_bL'mm
 #show
 'Longitudinal reinforcement area
-A_sx = ?'mm²/m, 'A_sy = ?'mm²/m
+A_sx = ? {1200}'mm²/m, 'A_sy = ? {600}'mm²/m
 #post
 'Reinforcement ratio
 ρ_lx = A_sx/(1000*d)
@@ -26,13 +26,13 @@ A_sx = ?'mm²/m, 'A_sy = ?'mm²/m
 #show
 '<p><b>Material properties</b></p>
 '<p><b>Concrete</b> [EN 1992-1-1, Table 3.1]</p>
-'Characteristic compressive cylinder strength -'f_ck = ?'MPa
-'Partial safety factor for concrete -'γ_c = 1.5','α_cc = ?
+'Characteristic compressive cylinder strength -'f_ck = ? {25}'MPa
+'Partial safety factor for concrete -'γ_c = 1.5','α_cc = ? {1}
 #post
 'Design compressive cylinder strength -'f_cd = α_cc*f_ck/γ_c'MPa
 #show
 '<p><b>Steel</b></p>
-'Characteristic yield strength -'f_yk = ?'MPa
+'Characteristic yield strength -'f_yk = ? {500}'MPa
 #post
 'Partial safety factor for steel -'γ_s = 1.15
 'Design yield strength -'f_ywd = f_yk/γ_s'MPa
@@ -138,4 +138,4 @@ v_Ed = β*V_Ed*10^3/(u_1*d)'MPa
 	'<img style="width:195pt;" src="../../Images/structures/rc/design/punching-corner-column-reinf-section.png" alt="punching-corner-column-reinf-section.png">
 #end if
 #show
-'</div>600	300	125	200	20	10	6	1200	600	25	1	500
+'</div>

--- a/Examples/Structural/Reinforced Concrete - Punching/Edge Column.cpd
+++ b/Examples/Structural/Reinforced Concrete - Punching/Edge Column.cpd
@@ -4,20 +4,20 @@
 '<img class="side" style="width:225pt;" src="../../Images/structures/rc/design/punching-edge-column.png" alt="punching-edge-column.png">
 '<h4>Input data</h4>
 '<p><b>Column</b></p>
-'Dimensions - 'c_1 = ?'mm, 'c_2 = ?'mm
+'Dimensions - 'c_1 = ? {600}'mm, 'c_2 = ? {300}'mm
 '<p><b>Design loads</b></p>
-'Support reaction -'V_Ed = ?'kN
+'Support reaction -'V_Ed = ? {200}'kN
 '<p><b>Slab</b></p>
-'Depth -'h = ?'mm
-'Concrete cover -'c = ?'mm
-'Longitudinal bars diameter -'d_bL = ?'mm
-'Links diameter -'d_w = ?'mm
+'Depth -'h = ? {200}'mm
+'Concrete cover -'c = ? {20}'mm
+'Longitudinal bars diameter -'d_bL = ? {10}'mm
+'Links diameter -'d_w = ? {6}'mm
 #post
 'Effective slab depth
 d = h - c - d_bL'mm
 #show
 'Longitudinal reinforcement area
-A_sx = ?'mm²/m, 'A_sy = ?'mm²/m
+A_sx = ? {1200}'mm²/m, 'A_sy = ? {600}'mm²/m
 #post
 'Reinforcement ratio
 ρ_lx = A_sx/(1000*d)
@@ -26,13 +26,13 @@ A_sx = ?'mm²/m, 'A_sy = ?'mm²/m
 #show
 '<p><b>Material properties</b></p>
 '<p><b>Concrete</b> [EN 1992-1-1, Table 3.1]</p>
-'Characteristic compressive cylinder strength -'f_ck = ?'MPa
-'Partial safety factor for concrete -'γ_c = 1.5','α_cc = ?
+'Characteristic compressive cylinder strength -'f_ck = ? {25}'MPa
+'Partial safety factor for concrete -'γ_c = 1.5','α_cc = ? {1}
 #post
 'Design compressive cylinder strength -'f_cd = α_cc*f_ck/γ_c'MPa
 #show
 '<p><b>Steel</b></p>
-'Characteristic yield strength -'f_yk = ?'MPa
+'Characteristic yield strength -'f_yk = ? {500}'MPa
 #post
 'Partial safety factor for steel -'γ_s = 1.15
 'Design yield strength -'f_ywd = f_yk/γ_s'MPa
@@ -138,4 +138,4 @@ v_Ed = β*V_Ed*10^3/(u_1*d)'MPa
 	'<img style="width:195pt;" src="../../Images/structures/rc/design/punching-edge-column-reinf-section.png" alt="punching-edge-column-reinf-section.png">
 #end if
 #show
-'</div>600	300	200	200	20	10	6	1200	600	25	1	500
+'</div>

--- a/Examples/Structural/Reinforced Concrete - Punching/Internal Column.cpd
+++ b/Examples/Structural/Reinforced Concrete - Punching/Internal Column.cpd
@@ -4,22 +4,22 @@
 '<img class="side" style="width:260pt;" src="../../Images/structures/rc/design/punching.png" alt="punching.png">
 '<h4>Input data</h4>
 '<p><b>Column</b></p>
-'Dimensions - 'c_1 = ?'mm, 'c_2 = ?'mm
+'Dimensions - 'c_1 = ? {600}'mm, 'c_2 = ? {300}'mm
 '<p><b>Design loads</b></p>
-'Support reaction -'V_Ed = ?'kN
+'Support reaction -'V_Ed = ? {500}'kN
 'Bending moments
-M_x_Ed = ?'kNm,'M_y_Ed = ?'kNm
+M_x_Ed = ? {0}'kNm,'M_y_Ed = ? {0}'kNm
 '<p><b>Slab</b></p>
-'Depth -'h = ?'mm
-'Concrete cover -'c = ?'mm
-'Longitudinal bars diameter -'d_bL = ?'mm
-'Links diameter -'d_w = ?'mm
+'Depth -'h = ? {200}'mm
+'Concrete cover -'c = ? {20}'mm
+'Longitudinal bars diameter -'d_bL = ? {10}'mm
+'Links diameter -'d_w = ? {6}'mm
 #post
 'Effective slab depth
 d = h - c - d_bL'mm
 #show
 'Longitudinal reinforcement area
-A_sx = ?'mm²/m, 'A_sy = ?'mm²/m
+A_sx = ? {1200}'mm²/m, 'A_sy = ? {1200}'mm²/m
 #post
 'Reinforcement ratio
 ρ_lx = A_sx/(1000*d)
@@ -28,13 +28,13 @@ A_sx = ?'mm²/m, 'A_sy = ?'mm²/m
 #show
 '<p><b>Material properties</b></p>
 '<p><b>Concrete</b> [EN 1992-1-1, Table 3.1]</p>
-'Characteristic compressive cylinder strength -'f_ck = ?'MPa
-'Partial safety factor for concrete -'γ_c = 1.5','α_cc = ?
+'Characteristic compressive cylinder strength -'f_ck = ? {25}'MPa
+'Partial safety factor for concrete -'γ_c = 1.5','α_cc = ? {1}
 #post
 'Design compressive cylinder strength -'f_cd = α_cc*f_ck/γ_c'MPa
 #show
 '<p><b>Steel</b></p>
-'Characteristic yield strength -'f_yk = ?'MPa
+'Characteristic yield strength -'f_yk = ? {500}'MPa
 #post
 'Partial safety factor for steel -'γ_s = 1.15
 'Design yield strength -'f_ywd = f_yk/γ_s'MPa
@@ -193,4 +193,4 @@ v_Ed = β*V_Ed*10^3/(u_1*d)'MPa
 	'<img style="width:260pt;" src="../../Images/structures/rc/design/punching-reinf-section.png" alt="punching-reinf-section.png">
 #end if
 #show
-'</div>600	300	500	0	0	200	20	10	6	1200	1200	25	1	500
+'</div>

--- a/Examples/Structural/Reinforced Concrete/Bending Capacity of Tee Section.cpd
+++ b/Examples/Structural/Reinforced Concrete/Bending Capacity of Tee Section.cpd
@@ -2,21 +2,21 @@
 '<small>According to <strong>Eurocode</strong>: EN 1992-1-1</small>
 '<div style="max-width:180mm">
 '<img style="width:400pt;" src="../../Images/structures/rc/design/tbeam-bending.png" alt="tbeam-bending.png">
-'Design bending moment -'M_Ed = ?'kN·m
+'Design bending moment -'M_Ed = ? {800}'kN·m
 '<h4>Cross section dimensions</h4>
-'Web -'b_w = ?'mm,'h_w = ?'mm
-'Flange -'b_f = ?'mm,'h_f = ?'mm
+'Web -'b_w = ? {300}'mm,'h_w = ? {650}'mm
+'Flange -'b_f = ? {1200}'mm,'h_f = ? {120}'mm
 #post
 'Flange area -'A_f = (b_f - b_w)*h_f'mm²
 'Section area -'A_c = b_w*h_w + A_f'mm²
 #show
 '<p><b>Concrete cover to the center of reinforcement</b></p>
-'Bottom -'d_1 = ?'mm,&nbsp;&nbsp;&nbsp;&nbsp;Top -'d_2 = ?'mm
+'Bottom -'d_1 = ? {50}'mm,&nbsp;&nbsp;&nbsp;&nbsp;Top -'d_2 = ? {50}'mm
 #post
 'Effective cross section depth -'d = h_w - d_1'mm
 #show
 '<p><b>Reinforcement</b></p>
-'Bottom -'A_s1 = ?'mm²,&nbsp;&nbsp;&nbsp;&nbsp;Top -'A_s2 = ?'mm²
+'Bottom -'A_s1 = ? {3700}'mm²,&nbsp;&nbsp;&nbsp;&nbsp;Top -'A_s2 = ? {0}'mm²
 #post
 'Reinforcement ratios
 '- bottom reinforcement -'ρ_1 = (A_s1)/(b_w*d)
@@ -25,8 +25,8 @@
 '<h4>Material properties</h4>
 '<p class="ref" style="float:right">[EN 1992-1-1, Table 3.1]</p>
 '<p><b>Concrete</b></p>
-'Characteristic compressive cylinder strength -'f_ck = ?'MPa
-'Partial safety factor for concrete -'γ_c = 1.5','α_cc = ?
+'Characteristic compressive cylinder strength -'f_ck = ? {20}'MPa
+'Partial safety factor for concrete -'γ_c = 1.5','α_cc = ? {0.85}
 #post
 'Design compressive cylinder strength -'f_cd = α_cc*f_ck/γ_c'MPa
 'Ultimate compressive strain -'ε_cu2 = 0.0035
@@ -34,7 +34,7 @@
 'Mean value of axial tensile strength -'f_ctm = 0.30*f_ck^(2/3)'MPa
 #show
 '<p><b>Steel</b></p>
-'Characteristic yield strength -'f_yk = ?'MPa
+'Characteristic yield strength -'f_yk = ? {500}'MPa
 #post
 'Partial safety factor for steel -'γ_s = 1.15
 'Design yield strength -'f_yd = f_yk/γ_s'MPa
@@ -112,4 +112,4 @@ M_Rd = (A_s1*σ_s(ε_s1(x))*(z_c - d_1) + A_s2*σ_s(ε_s2(x))*(z_c - h_w + d_2))
 	'Design checks are satisfied.
 #end if
 #show
-'</div>800	300	650	1200	120	50	50	3700	0	20	0.85	500
+'</div>

--- a/Examples/Structural/Reinforced Concrete/Bending Design of Tee Section.cpd
+++ b/Examples/Structural/Reinforced Concrete/Bending Design of Tee Section.cpd
@@ -2,11 +2,11 @@
 '<small>According to <strong>Eurocode</strong>: EN 1992-1-1</small>
 '<div style="max-width:180mm;">
 '<img style="width:400pt;" src="../../Images/structures/rc/design/tbeam-bending.png" alt="tbeam-bending.png">
-'Design bending moment -'M_Ed = ?'kN·m
+'Design bending moment -'M_Ed = ? {800}'kN·m
 '<h4>Cross section dimensions</h4>
-'Web -'b_w = ?'mm,'h_w = ?'mm
-'Flange -'b_f = ?'mm,'h_f = ?'mm
-'Concrete cover to the center of reinforcement -'d_1 = ?'mm
+'Web -'b_w = ? {250}'mm,'h_w = ? {600}'mm
+'Flange -'b_f = ? {1200}'mm,'h_f = ? {120}'mm
+'Concrete cover to the center of reinforcement -'d_1 = ? {50}'mm
 #post
 'Effective cross section depth -'d = h_w - d_1'mm
 'Flange area -'A_f = (b_f - b_w)*h_f'mm<sup>2</sup>
@@ -15,8 +15,8 @@
 '<h4>Material properties</h4>
 '<p class="ref" style="float:right">[EN 1992-1-1, Table 3.1]</p>
 '<p><b>Concrete</b></p>
-'Characteristic compressive cylinder strength -'f_ck = ?'MPa
-'Partial safety factor for concrete -'γ_c = 1.5','α_cc = ?
+'Characteristic compressive cylinder strength -'f_ck = ? {20}'MPa
+'Partial safety factor for concrete -'γ_c = 1.5','α_cc = ? {0.85}
 #post
 'Design compressive cylinder strength -'f_cd = α_cc*f_ck/γ_c'MPa
 'Factor for effective compression zone depth -'λ = 0.8
@@ -25,7 +25,7 @@
 'Mean value of axial tensile strength -'f_ctm = 0.30*f_ck^(2/3)'MPa
 #show
 '<p><b>Steel</b></p>
-'Characteristic yield strength -'f_yk = ?'MPa
+'Characteristic yield strength -'f_yk = ? {500}'MPa
 #post
 'Partial safety factor for steel -'γ_s = 1.15
 'Design yield strength -'f_yd = f_yk/γ_s'MPa
@@ -43,7 +43,7 @@ M_f = b_f*h_f*η*f_cd*(d - h_f/2)*10^-6'kN·m
 	'Relative depth of compression zone corresponding to design yield strain
 	ξ_yd = ε_cu3/(ε_cu3 + ε_yd)
 	#show
-	'Limit compression zone depth -'ξ_lim = ?
+	'Limit compression zone depth -'ξ_lim = ? {0.62}
 	'(enter <i>ξ</i><sub>yd</sub> for elastic or 0.45 for plastic analysis)
 	#post
 	#if ξ ≤ ξ_lim
@@ -93,4 +93,4 @@ M_f = b_f*h_f*η*f_cd*(d - h_f/2)*10^-6'kN·m
 	'<p class="err">Reinforcement ratio is greater than the maximum:'ρ_1'>'ρ_max'mm<sup>2</sup></p>'
 #end if
 #show
-'</div>800	250	600	1200	120	50	20	0.85	500	0.62
+'</div>

--- a/Examples/Structural/Reinforced Concrete/Column Design for Biaxial Bending and Axial Force (with Units).cpd
+++ b/Examples/Structural/Reinforced Concrete/Column Design for Biaxial Bending and Axial Force (with Units).cpd
@@ -3,28 +3,28 @@
 '<div style="max-width:180mm">
 '<img class="side" style="width:150pt;" src="../../Images/structures/rc/design/column-design.png" alt="Column_Design.png">
 '<h4>Cross section dimensions</h4>
-'Width -'b = ?mm', Height - 'h = ?mm
+'Width -'b = ?{300}mm', Height - 'h = ?{700}mm
 #post
 'Cross section area -'A_c = b*h|cm^2
 #show
 '<p><b>Reinforcement</b></p>
-'Left -'A_s1 = ?*cm^2', Right -'A_s2 = ?*cm^2
+'Left -'A_s1 = ?{8}*cm^2', Right -'A_s2 = ?{8}*cm^2
 #post
 'Reinforcement ratio -'ρ = (A_s1 + A_s2)/A_c
 #show
 '<p><b>Concrete cover to the center of reinforcement</b></p>
-'Left -'d_1 = ?mm', Right -'d_2 = ?mm
+'Left -'d_1 = ?{50}mm', Right -'d_2 = ?{50}mm
 #post
 'Effective cross section depth -'d = h - d_1
 #show
 '<p><b>Section design loads</b></p>
-'Axial force -'N_Ed = ?kN' (positive for compression)
-'Bending moment -'M_Ed = ?kNm
+'Axial force -'N_Ed = ?{1200}kN' (positive for compression)
+'Bending moment -'M_Ed = ?{200}kNm
 '<h4>Material properties</h4>
 '<p class="ref" style="float:right">[EN 1992-1-1, Table 3.1]</p>
 '<p><b>Concrete</b></p>
-'Characteristic compressive cylinder strength -'f_ck = ?MPa
-'Partial safety factor for concrete -'γ_c = 1.5','α_cc = ?
+'Characteristic compressive cylinder strength -'f_ck = ?{20}MPa
+'Partial safety factor for concrete -'γ_c = 1.5','α_cc = ? {0.85}
 #post
 'Design compressive cylinder strength -'f_cd = α_cc*f_ck/γ_c
 'Mean value of cylinder compressive strength -'f_cm = f_ck + 8MPa
@@ -33,7 +33,7 @@
 'Strain  at the end of parabolic part of the diagram -'ε_c2 = 0.002
 #show
 '<p><b>Steel</b></p>
-'Characteristic yield strength -'f_yk = ?MPa
+'Characteristic yield strength -'f_yk = ?{500}MPa
 #post
 'Partial safety factor for steel -'γ_s = 1.15
 'Design yield strength -'f_yd = f_yk/γ_s
@@ -55,19 +55,19 @@ $Plot{σ_s(ε/1000) @ ε = -10 : 10}
 #show
 max(-f_yd;min(0.01*E_s;f_yd))
 '<h4>Imperfections and second order effects</h4>
-'Ratio of quasi-permanent bending moment: M<sub>0Eqp</sub>/M<sub>0Ed</sub> ='K_G = ?
+'Ratio of quasi-permanent bending moment: M<sub>0Eqp</sub>/M<sub>0Ed</sub> ='K_G = ? {0.75}
 #post
 'M<sub>0Eqp</sub> is the first order bending moment in quasi-permanent load combination (SLS)
 'M<sub>0Ed</sub> is the first order bending moment in design load combination (ULS)
 #show
-'Long term creep factor - φ(∞,t<sub>0</sub>) ='φ = ?
-'Column height -'L = ?m
-'Effective column height -'L_o = ?*L
+'Long term creep factor - φ(∞,t<sub>0</sub>) ='φ = ? {2.5}
+'Column height -'L = ?{4}m
+'Effective column height -'L_o = ?{1}*L
 #post
 '<div class="fold">
 #show
 '<p><b>Geometric imperfections and accidental eccentricity</b></p>
-'Number of vertical members contributing to the total effect -'m = ?
+'Number of vertical members contributing to the total effect -'m = ? {1}
 #post
 'Reduction factor for height:
 α_h_ = 2/sqr(L/1m)
@@ -191,9 +191,9 @@ N_Rd_max = A_c*f_cd + σ_s(ε)*(A_s1 + A_s2)|kN
 		'<img class="side" style="width:190pt;" src="../../Images/structures/rc/design/column-biaxial.png" alt="Column_Biaxial.png">
 		'<h4>Biaxial bending design</h4>
 		'For the other direction:
-		'Design moment -'M_Edy = ?kNm
-		'Bending resistance -'M_Rdy = ?kNm
-		'Effective length -'L_oy = ?*L
+		'Design moment -'M_Edy = ?{50}kNm
+		'Bending resistance -'M_Rdy = ?{100}kNm
+		'Effective length -'L_oy = ?{1}*L
 		#post
 		#if M_Edy > 0kNm
 			'<img class="side" style="width:190pt;" src="../../Images/structures/rc/design/column-biaxial.png" alt="Column_Biaxial.png">
@@ -251,4 +251,4 @@ N_Rd_max = A_c*f_cd + σ_s(ε)*(A_s1 + A_s2)|kN
 	#end if
 #end if
 #show
-'</div>300	700	8	8	50	50	1200	200	20	0.85	500	0.75	2.5	4	1	1	50	100	1
+'</div>

--- a/Examples/Structural/Reinforced Concrete/Column Design for Biaxial Bending and Axial Force.cpd
+++ b/Examples/Structural/Reinforced Concrete/Column Design for Biaxial Bending and Axial Force.cpd
@@ -3,28 +3,28 @@
 '<div style="max-width:180mm">
 '<img class="side" style="width:150pt;" src="../../Images/structures/rc/design/column-design.png" alt="column-design.png">
 '<h4>Cross section dimensions</h4>
-'Width -'b = ?'mm, Height -'h = ?'mm
+'Width -'b = ? {300}'mm, Height -'h = ? {700}'mm
 #post
 'Cross section area -'A_c = b*h'mm²
 #show
 '<p><b>Reinforcement</b></p>
-'Left -'A_s1 = ?'mm², Right -'A_s2 = ?'mm²
+'Left -'A_s1 = ? {800}'mm², Right -'A_s2 = ? {800}'mm²
 #post
 'Reinforcement ratio -'ρ = (A_s1 + A_s2)/A_c
 #show
 '<p><b>Concrete cover to the center of reinforcement</b></p>
-'Left -'d_1 = ?'mm, Right -'d_2 = ?'mm
+'Left -'d_1 = ? {50}'mm, Right -'d_2 = ? {50}'mm
 #post
 'Effective cross section depth -'d = h - d_1'mm
 #show
 '<p><b>Section design loads</b></p>
-'Axial force -'N_Ed = ?'kN (positive for compression)
-'Bending moment -'M_Ed = ?'kN·m
+'Axial force -'N_Ed = ? {1200}'kN (positive for compression)
+'Bending moment -'M_Ed = ? {200}'kN·m
 '<h4>Material properties</h4>
 '<p class="ref" style="float:right">[EN 1992-1-1, Table 3.1]</p>
 '<p><b>Concrete</b></p>
-'Characteristic compressive cylinder strength -'f_ck = ?'MPa
-'Partial safety factor for concrete -'γ_c = 1.5','α_cc = ?
+'Characteristic compressive cylinder strength -'f_ck = ? {20}'MPa
+'Partial safety factor for concrete -'γ_c = 1.5','α_cc = ? {0.85}
 #post
 'Design compressive cylinder strength -'f_cd = α_cc*f_ck/γ_c'MPa
 'Mean value of cylinder compressive strength -'f_cm = f_ck + 8'MPa
@@ -33,7 +33,7 @@
 'Strain  at the end of parabolic part of the diagram -'ε_c2 = 0.002
 #show
 '<p><b>Steel</b></p>
-'Characteristic yield strength -'f_yk = ?'MPa
+'Characteristic yield strength -'f_yk = ? {500}'MPa
 #post
 'Partial safety factor for steel -'γ_s = 1.15
 'Design yield strength -'f_yd = f_yk/γ_s'MPa
@@ -54,19 +54,19 @@ $Plot{σ_s(ε/1000) @ ε = -10 : 10}
 '</td></tr></table>
 #show
 '<h4>Imperfections and second order effects</h4>
-'Ratio of quasi-permanent bending moment: M<sub>0Eqp</sub>/M<sub>0Ed</sub> ='K_G = ?
+'Ratio of quasi-permanent bending moment: M<sub>0Eqp</sub>/M<sub>0Ed</sub> ='K_G = ? {0.75}
 #post
 'M<sub>0Eqp</sub> is the first order bending moment in quasi-permanent load combination (SLS)
 'M<sub>0Ed</sub> is the first order bending moment in design load combination (ULS)
 #show
-'Long term creep factor - φ(∞,t<sub>0</sub>) ='φ = ?
-'Column height -'L = ?'mm
-'Effective column height -'L_o = ?*L'mm
+'Long term creep factor - φ(∞,t<sub>0</sub>) ='φ = ? {2.5}
+'Column height -'L = ? {4000}'mm
+'Effective column height -'L_o = ?{1}*L'mm
 #post
 '<div class="fold">
 #show
 '<p><b>Geometric imperfections and accidental eccentricity</b></p>
-'Number of vertical members contributing to the total effect -'m = ?
+'Number of vertical members contributing to the total effect -'m = ? {1}
 #post
 'Reduction factor for height:
 α_h_ = 2/sqr(L*10^-3)
@@ -189,9 +189,9 @@ N_Rd_max = A_c*f_cd*10^-3 + σ_s(ε)*(A_s1 + A_s2)*10^-3'kN
 		'<img class="side" style="width:190pt;" src="../../Images/structures/rc/design/column-biaxial.png" alt="column-biaxial.png">
 		'<h4>Biaxial bending design</h4>
 		'For the other direction:
-		'Design moment -'M_Edy = ?'kN·m
-		'Bending resistance -'M_Rdy = ?'kN·m
-		'Effective length -'L_oy = ?*L'mm
+		'Design moment -'M_Edy = ? {50}'kN·m
+		'Bending resistance -'M_Rdy = ? {100}'kN·m
+		'Effective length -'L_oy = ?{1}*L'mm
 		#post
 		#if M_Edy > 0
 			'<img class="side" style="width:190pt;" src="../../Images/structures/rc/design/column-biaxial.png" alt="column-biaxial.png">
@@ -249,4 +249,4 @@ N_Rd_max = A_c*f_cd*10^-3 + σ_s(ε)*(A_s1 + A_s2)*10^-3'kN
 	#end if
 #end if
 #show
-'</div>300	700	800	800	50	50	1200	200	20	0.85	500	0.75	2.5	4000	1	1	50	100	1
+'</div>

--- a/Examples/Structural/Reinforced Concrete/Interaction Diagram of RC Section.cpd
+++ b/Examples/Structural/Reinforced Concrete/Interaction Diagram of RC Section.cpd
@@ -3,25 +3,25 @@
 '<div style="max-width:180mm">
 '<img class="side" style="width:150pt;" src="../../Images/structures/rc/design/column-design.png" alt="column-design.png">
 '<h4>Cross section dimensions</h4>
-'Width -'b = ?'mm, Height -'h = ?'mm
+'Width -'b = ? {300}'mm, Height -'h = ? {700}'mm
 #post
 'Cross section area -'A_c = b*h'mm²
 #show
 '<p><b>Reinforcement</b></p>
-'Left -'A_s1 = ?'mm², Right -'A_s2 = A_s1'mm²
+'Left -'A_s1 = ? {800}'mm², Right -'A_s2 = A_s1'mm²
 #post
 'Reinforcement ratio -'ρ = (A_s1 + A_s2)/A_c
 #show
 '<p><b>Concrete cover</b> (to the center of the reinforcement)</p>
-'Left -'d_1 = ?'mm, Right -'d_2 = d_1'mm
+'Left -'d_1 = ? {80}'mm, Right -'d_2 = d_1'mm
 #post
 'Effective cross section depth -'d = h - d_1'mm
 #show
 '<h4>Material properties</h4>
 '<!--'PlotWidth = 250','PlotHeight = 125'-->
 '<p><b>Concrete</b> [EN 1992-1-1, Table 3.1]</p>
-'Characteristic compressive cylinder strength -'f_ck = ?'MPa
-'Partial safety factors for concrete -'γ_c = 1.5','α_cc = ?
+'Characteristic compressive cylinder strength -'f_ck = ? {20}'MPa
+'Partial safety factors for concrete -'γ_c = 1.5','α_cc = ? {0.85}
 #post
 'Mean value of cylinder compressive strength -'f_cm = f_ck + 8'MPa
 'Design compressive cylinder strength -'f_cd = α_cc*f_ck/γ_c'MPa
@@ -29,7 +29,7 @@
 'Secant modulus of elasticity -'E_cm = 22*(f_cm/10)^0.3'GPa
 #show
 '<p><b>Steel</b></p>
-'Characteristic yield strength -'f_yk = ?'MPa
+'Characteristic yield strength -'f_yk = ? {500}'MPa
 #post
 'Partial safety factor for steel -'γ_s = 1.15
 'Design yield strength -'f_yd = f_yk/γ_s'MPa
@@ -88,4 +88,4 @@ PlotHeight = 600
 $Plot{M_Rd(ε)|N_Rd(ε) @ ε = ε_max : -ε_c2}
 '<p style=float:right><i>M</i><sub>Rd</sub></p>
 #show
-'</div>300	700	800	80	20	0.85	500
+'</div>

--- a/Examples/Structural/Reinforced Concrete/SLS Design of Beam with Rectangular Section.cpd
+++ b/Examples/Structural/Reinforced Concrete/SLS Design of Beam with Rectangular Section.cpd
@@ -5,7 +5,7 @@
 '<small>According to <strong>Eurocode</strong>: EN 1992-1-1</small>
 '<div style="max-width:180mm">
 '<h4>Static scheme</h4>
-'<p id="type" class="flip_base" style="display:none">'type = ?'</p>
+'<p id="type" class="flip_base" style="display:none">'type = ? {0}'</p>
 #pre
 '<p><select data-target="type" class="flip_trigger">
 '<option value="1">Cantilever with concentrated load</option>
@@ -40,9 +40,9 @@
 	#hide
 #end if
 #show
-'Beam length -'L = ?'m
+'Beam length -'L = ? {7}'m
 'Exposure class:
-'<p id="w_max" style="display:none">'w_max = ?'</p>
+'<p id="w_max" style="display:none">'w_max = ? {0.4}'</p>
 #pre
 '<p><select data-target="w_max">
 '<option value="0.4">X0 or XC1</option>
@@ -57,40 +57,40 @@
 #show
 ''
 '<h4>Bending moments</h4>
-'Characteristic combination (<i>g</i> + <i>q</i>) -'M_k = ?'kNm
-'Quasi-permanent combination (<i>g</i> + <i>ψ</i><sub>2</sub><i>q</i>) -'M_qp = ?'kNm
+'Characteristic combination (<i>g</i> + <i>q</i>) -'M_k = ? {200}'kNm
+'Quasi-permanent combination (<i>g</i> + <i>ψ</i><sub>2</sub><i>q</i>) -'M_qp = ? {150}'kNm
 '
 '<img class="side" src="../../Images/structures/rc/design/beam-section.png" alt="beam-section.png" style="width:120pt;">
 '<h4>Cross section dimensions</h4>
-'Width -'b = ?'mm, Height -'h = ?'mm
-'Concrete cover -'c = ?'mm (to bars surface)
+'Width -'b = ? {300}'mm, Height -'h = ? {650}'mm
+'Concrete cover -'c = ? {30}'mm (to bars surface)
 '<p><b>Tension reinforcement</b></p>
-'Bar count -'n_1 = ?'with diameter -'Φ_1 = ?'mm
+'Bar count -'n_1 = ? {4}'with diameter -'Φ_1 = ? {20}'mm
 #post
 'Reinforcement area -'A_s1 = n_1*π*Φ_1^2/4'mm²
 #show
-'Concrete cover to the center of reinforcement -'d_1 = ?'mm
+'Concrete cover to the center of reinforcement -'d_1 = ? {45}'mm
 #post
 'Effective cross section depth -'d = h - d_1'mm
 #show
-'Spacing between bar centers -'s = ?'mm
+'Spacing between bar centers -'s = ? {74}'mm
 '<p><b>Compression reinforcement</b></p>
-'Bar count -'n_2 = ?'with diameter -'Φ_2 = ?'mm
+'Bar count -'n_2 = ? {2}'with diameter -'Φ_2 = ? {14}'mm
 #post
 'Reinforcement area -'A_s2 = n_2*π*Φ_2^2/4'mm²
 #show
-'Concrete cover to the center of reinforcement -'d_2 = ?'mm
+'Concrete cover to the center of reinforcement -'d_2 = ? {45}'mm
 '
 '<h4>Material properties</h4>
 '<p><b>Concrete</b> [EN 1992-1-1, Table 3.1]</p>
-'Characteristic compressive cylinder strength -'f_ck = ?'MPa
+'Characteristic compressive cylinder strength -'f_ck = ? {20}'MPa
 #post
 'Mean value of cylinder compressive strength -'f_cm = f_ck + 8'MPa
 'Mean value of axial tensile strength -'f_ctm = 0.30*f_ck^(2/3)'MPa
 'Secant modulus of elasticity -'E_cm = 22*(f_cm/10)^0.3'GPa
 #show
 '<p><b>Steel</b></p>
-'Characteristic yield strength -'f_yk = ?'MPa
+'Characteristic yield strength -'f_yk = ? {500}'MPa
 #post
 'Modulus of elasticity -'E_s = 200'GPa
 'Ratio of steel to conrete moduli of elasticity -'α = E_s/E_cm
@@ -100,7 +100,7 @@
 '<h4>Concrete creep and shrinkage</h4>
 '<p class = "ref">[EN 1992-1-1 B.1(1)]</p>
 '<p><b>Creep</b></p>
-'Relative humidity of the environment -'RH = ?'%
+'Relative humidity of the environment -'RH = ? {50}'%
 #post
 'Perimeter of cross section in contact with the atmosphere
 u = 2*(b + h)'mm
@@ -383,4 +383,4 @@ S = A_s1*(d - x) - A_s2*(x - d_2)'mm<sup>3</sup>
 #show
 '</div>
 #pre
-'<script>if(window.jQuery){$(".flip_trigger").change(function(){$(".flip").hide();$(".flip_"+$(this).val()).show();});$(".flip").hide();$(".flip_"+$(".flip_base input").val()).show();}</script>0	7	0.4	200	150	300	650	30	4	20	45	74	2	14	45	20	500	50
+'<script>if(window.jQuery){$(".flip_trigger").change(function(){$(".flip").hide();$(".flip_"+$(this).val()).show();});$(".flip").hide();$(".flip_"+$(".flip_base input").val()).show();}</script>

--- a/Examples/Structural/Reinforced Concrete/SLS Design of Beam with Tee Section.cpd
+++ b/Examples/Structural/Reinforced Concrete/SLS Design of Beam with Tee Section.cpd
@@ -5,7 +5,7 @@
 '<small>According to <strong>Eurocode</strong>: EN 1992-1-1</small>
 '<div style="max-width:180mm">
 '<h4>Static scheme</h4>
-'<p id="type" class="flip_base" style="display:none">'type = ?'</p>
+'<p id="type" class="flip_base" style="display:none">'type = ? {0}'</p>
 #pre
 '<p><select data-target="type" class="flip_trigger">
 '<option value="1">Cantilever with concentrated load</option>
@@ -40,9 +40,9 @@
 	#hide
 #end if
 #show
-'Beam length -'L = ?'m
+'Beam length -'L = ? {5.75}'m
 'Exposure class:
-'<p id="w_max" style="display:none">'w_max = ?'</p>
+'<p id="w_max" style="display:none">'w_max = ? {0.4}'</p>
 #pre
 '<p><select data-target="w_max">
 '<option value="0.4">X0 or XC1</option>
@@ -57,41 +57,41 @@
 #show
 '
 '<h4>Bending moments</h4>
-'Characteristic combination (<i>g</i> + <i>q</i>) -'M_k = ?'kNm
-'Quasi-permanent combination (<i>g</i> + <i>ψ</i><sub>2</sub><i>q</i>) -'M_qp = ?'kNm
+'Characteristic combination (<i>g</i> + <i>q</i>) -'M_k = ? {200}'kNm
+'Quasi-permanent combination (<i>g</i> + <i>ψ</i><sub>2</sub><i>q</i>) -'M_qp = ? {157}'kNm
 '
 '<img class="side" src="../../Images/structures/rc/design/beam-tsection.png" alt="beam-tsection.png" style="width:150pt;">
 '<h4>Cross section dimensions</h4>
-'Stem:'b = ?'mm,'h = ?'mm
-'Flange:'b_f = ?'mm,'h_f = ?'mm
-'Concrete cover -'c = ?'mm (to bars surface)
+'Stem:'b = ? {250}'mm,'h = ? {550}'mm
+'Flange:'b_f = ? {2400}'mm,'h_f = ? {140}'mm
+'Concrete cover -'c = ? {30}'mm (to bars surface)
 '<p><b>Tension reinforcement</b></p>
-'Bar count -'n_1 = ?'with diameter -'Φ_1 = ?'mm
+'Bar count -'n_1 = ? {4}'with diameter -'Φ_1 = ? {20}'mm
 #post
 'Reinforcement area -'A_s1 = n_1*π*Φ_1^2/4'mm²
 #show
-'Concrete cover to the center of reinforcement -'d_1 = ?'mm
+'Concrete cover to the center of reinforcement -'d_1 = ? {45}'mm
 #post
 'Effective cross section depth -'d = h - d_1'mm
 #show
-'Spacing between bar centers -'s = ?'mm
+'Spacing between bar centers -'s = ? {50}'mm
 '<p><b>Compression reinforcement</b></p>
-'Bar count -'n_2 = ?'with diameter -'Φ_2 = ?'mm
+'Bar count -'n_2 = ? {2}'with diameter -'Φ_2 = ? {8}'mm
 #post
 'Reinforcement area -'A_s2 = n_2*π*Φ_2^2/4'mm²
 #show
-'Concrete cover to the center of reinforcement -'d_2 = ?'mm
+'Concrete cover to the center of reinforcement -'d_2 = ? {45}'mm
 '
 '<h4>Material properties</h4>
 '<p><b>Concrete</b> [EN 1992-1-1, Table 3.1]</p>
-'Characteristic compressive cylinder strength -'f_ck = ?'MPa
+'Characteristic compressive cylinder strength -'f_ck = ? {25}'MPa
 #post
 'Mean value of cylinder compressive strength -'f_cm = f_ck + 8'MPa
 'Mean value of axial tensile strength -'f_ctm = 0.30*f_ck^(2/3)'MPa
 'Secant modulus of elasticity -'E_cm = 22*(f_cm/10)^0.3'GPa
 #show
 '<p><b>Steel</b></p>
-'Characteristic yield strength -'f_yk = ?'MPa
+'Characteristic yield strength -'f_yk = ? {500}'MPa
 #post
 'Modulus of elasticity -'E_s = 200'GPa
 'Ratio of steel to concrete moduli of elasticity -'α = E_s/E_cm
@@ -101,7 +101,7 @@
 '<h4>Concrete creep and shrinkage</h4>
 '<p class = "ref">[EN 1992-1-1 B.1(1)]</p>
 '<p><b>Creep</b></p>
-'Relative humidity of the environment -'RH = ?'%
+'Relative humidity of the environment -'RH = ? {60}'%
 #post
 'Perimeter of cross section in contact with the atmosphere
 u = 2*(b + h)'mm
@@ -394,4 +394,4 @@ S = A_s1*(d - x) - A_s2*(x - d_2)'mm<sup>3</sup>
 #show
 '</div>
 #pre
-'<script>if(window.jQuery){$(".flip_trigger").change(function(){$(".flip").hide();$(".flip_"+$(this).val()).show();});$(".flip").hide();$(".flip_"+$(".flip_base input").val()).show();}</script>0	5.75	0.4	200	157	250	550	2400	140	30	4	20	45	50	2	8	45	25	500	60
+'<script>if(window.jQuery){$(".flip_trigger").change(function(){$(".flip").hide();$(".flip_"+$(this).val()).show();});$(".flip").hide();$(".flip_"+$(".flip_base input").val()).show();}</script>

--- a/Examples/Structural/Reinforced Concrete/Shear Design of Rectangular Section.cpd
+++ b/Examples/Structural/Reinforced Concrete/Shear Design of Rectangular Section.cpd
@@ -3,29 +3,29 @@
 '<div style="max-width:180mm;">
 '<img class="side" style="width:270pt;" src="../../Images/structures/rc/design/beam-shear.png" alt="beam-shear.png">
 '<h4>Cross section dimensions</h4>
-'Width -'b = ?'mm, Height'h = ?'mm
+'Width -'b = ? {300}'mm, Height'h = ? {800}'mm
 #post
 'Cross section area -'A_c = b*h'mm²
 #show
-'Tensile reinforcement area -'A_sl = ?'mm²
-'Effective depth -'d = h - ?'mm
+'Tensile reinforcement area -'A_sl = ? {1200}'mm²
+'Effective depth -'d = h - ? {50}'mm
 #post
 'Reinforcement ratio -'ρ_l = min(A_sl/(b*d); 0.02)
 #show
-'Shear links diameter -'d_w = ?'mm
-'Number of legs for one link -'n_w = ?
+'Shear links diameter -'d_w = ? {8}'mm
+'Number of legs for one link -'n_w = ? {2}
 '<p><b>Section design loads</b></p>
-'Shear force -'V_Ed = ?'kN&nbsp;&emsp;Axial force -'N_Ed = ?'kN
+'Shear force -'V_Ed = ? {600}'kN&nbsp;&emsp;Axial force -'N_Ed = ? {0}'kN
 '<h4>Material properties</h4>
 '<p class="ref">[EN 1992-1-1, Table 3.1]</p>
 '<p><b>Concrete</b></p>
-'Characteristic compressive cylinder strength -'f_ck = ?'MPa
-'Partial safety factor for concrete -'γ_c = 1.5','α_cc = ?
+'Characteristic compressive cylinder strength -'f_ck = ? {20}'MPa
+'Partial safety factor for concrete -'γ_c = 1.5','α_cc = ? {1}
 #post
 'Design compressive cylinder strength -'f_cd = α_cc*f_ck/γ_c'MPa
 #show
 '<p><b>Steel for shear reinforcement</b></p>
-'Characteristic yield strength -'f_yk = ?'MPa
+'Characteristic yield strength -'f_yk = ? {500}'MPa
 #post
 'Partial safety factor for steel -'γ_s = 1.15
 'Design yield strength -'f_ywd = f_yk/γ_s'MPa
@@ -117,4 +117,4 @@ V_Rd_c = max(V_Rd_c_min;V_Rd_c_)'kN
 	#end if
 #end if
 #show
-'</div>300	800	1200	50	8	2	600	0	20	1	500
+'</div>

--- a/Examples/Structural/Simply Supported Beams/Concentrated Force.cpd
+++ b/Examples/Structural/Simply Supported Beams/Concentrated Force.cpd
@@ -2,9 +2,9 @@
 '<div style = "max-width:180mm;">
 '<img style="width:190pt;" alt = "simply-supported-beam-concentrated-force.png" class="side" src = "../../Images/mechanics/beams/simply-supported-beam-concentrated-force.png">
 '<p><b>Input data</b></p>
-'Beam length -'l = ?'m
-'Load -'F = ?'kN
-'Distance -'a = ?'m
+'Beam length -'l = ? {5}'m
+'Load -'F = ? {10}'kN
+'Distance -'a = ? {2}'m
 #post
 '<p><b>Internal forces</b></p>
 'Bending
@@ -17,7 +17,7 @@ V_B = -F*a/l'kN
 PlotWidth = 600
 PlotHeight = 150
 #show
-'Calculate internal forces at'x_1 = ?'m
+'Calculate internal forces at'x_1 = ? {1}'m
 #pre
 
 #post
@@ -30,4 +30,4 @@ V(x) = V_A - F*(x > a)
 $Plot{V(x) @ x = 0 : l}
 V(x_1)'kN
 #show
-'</div>5	10	2	1
+'</div>

--- a/Examples/Structural/Simply Supported Beams/Concentrated Forces.cpd
+++ b/Examples/Structural/Simply Supported Beams/Concentrated Forces.cpd
@@ -2,9 +2,9 @@
 '<div style = "max-width:180mm;">
 '<img style="width:190pt;" alt = "simply-supported-beam-forces.png" class="side" src = "../../Images/mechanics/beams/simply-supported-beam-forces.png">
 '<p><b>Input data</b></p>
-'Beam length -'l = ?'m
-'Load -'F = ?'kN
-'Number of forces -'n = ?
+'Beam length -'l = ? {5}'m
+'Load -'F = ? {10}'kN
+'Number of forces -'n = ? {2}
 #post
 'Number of spacings -'n_1 = n + 1
 '<p><b>Internal forces</b></p>
@@ -19,7 +19,7 @@
 PlotWidth = 600
 PlotHeight = 150
 #show
-'Calculate internal forces at'x_1 = ?'m
+'Calculate internal forces at'x_1 = ? {1}'m
 #pre
 
 #post
@@ -35,4 +35,4 @@ V(x) = V_max - F*n(x)
 $Plot{V(x) @ x = 0 : l}
 V(x_1)'kN
 #show
-'</div>5	10	2	1
+'</div>

--- a/Examples/Structural/Simply Supported Beams/Concentrated Moment.cpd
+++ b/Examples/Structural/Simply Supported Beams/Concentrated Moment.cpd
@@ -2,9 +2,9 @@
 '<div style = "max-width:180mm;">
 '<img style="width:190pt;" alt = "simply-supported-beam-concentrated-moment.png" class="side" src = "../../Images/mechanics/beams/simply-supported-beam-concentrated-moment.png">
 '<p><b>Input data</b></p>
-'Beam length -'l = ?'m
-'Load -'M = ?'kN·m
-'Distance -'a = ?'m
+'Beam length -'l = ? {5}'m
+'Load -'M = ? {10}'kN·m
+'Distance -'a = ? {2}'m
 #post
 '<p><b>Internal forces</b></p>
 'Bending
@@ -17,7 +17,7 @@ V = M/l'kN
 PlotWidth = 600
 PlotHeight = 150
 #show
-'Calculate internal forces at'x_1 = ?'m
+'Calculate internal forces at'x_1 = ? {1}'m
 #pre
 
 #post
@@ -30,4 +30,4 @@ V(x) = V
 $Plot{V(x) @ x = 0 : l}
 V(x_1)'kN
 #show
-'</div>5	10	2	1
+'</div>

--- a/Examples/Structural/Simply Supported Beams/Linearly Distributed Load.cpd
+++ b/Examples/Structural/Simply Supported Beams/Linearly Distributed Load.cpd
@@ -2,8 +2,8 @@
 '<div style = "max-width:180mm;">
 '<img style="width:190pt;" alt = "simply-supported-beam-distributed-load-linear.png" class="side" src = "../../Images/mechanics/beams/simply-supported-beam-distributed-load-linear.png">
 '<p><b>Input data</b></p>
-'Beam length -'l = ?'m
-'Load -'q_1 = ?'kN/m,'q_2 = ?'kN/m
+'Beam length -'l = ? {5}'m
+'Load -'q_1 = ? {5}'kN/m,'q_2 = ? {15}'kN/m
 #post
 Δq = q_2 - q_1'kN/m
 '<p><b>Internal forces</b></p>
@@ -28,7 +28,7 @@ V_B = l*(q_1/2 + Δq/3)'kN
 PlotWidth = 600
 PlotHeight = 150
 #show
-'Calculate internal forces at'x_1 = ?'m
+'Calculate internal forces at'x_1 = ? {1}'m
 #pre
 
 
@@ -43,4 +43,4 @@ V(x) = q_1*(l/2 - x) + Δq*(l/6 - x^2/(2*l))
 $Plot{V(x) @ x = 0 : l}
 V(x_1)'kN
 #show
-'</div>5	5	15	1
+'</div>

--- a/Examples/Structural/Simply Supported Beams/Partially Distributed Load.cpd
+++ b/Examples/Structural/Simply Supported Beams/Partially Distributed Load.cpd
@@ -2,9 +2,9 @@
 '<div style = "max-width:180mm;">
 '<img style="width:190pt;" alt = "simply-supported-beam-distributed-load-partial.png" class="side" src = "../../Images/mechanics/beams/simply-supported-beam-distributed-load-partial.png">
 '<p><b>Input data</b></p>
-'Beam length -'l = ?'m
-'Load -'q = ?'kN/m
-'Distances -'a = ?'m,'b = ?'m
+'Beam length -'l = ? {5}'m
+'Load -'q = ? {10}'kN/m
+'Distances -'a = ? {1}'m,'b = ? {2}'m
 #post
 c = l - (a + b)'m
 #if '<!--'c < 0'-->
@@ -22,7 +22,7 @@ c = l - (a + b)'m
 	PlotWidth = 600
 	PlotHeight = 150
 	#show
-	'Calculate internal forces at'x_1 = ?'m
+	'Calculate internal forces at'x_1 = ? {1.5}'m
 	#pre
 
 	#post
@@ -36,4 +36,4 @@ c = l - (a + b)'m
 	V(x_1)'kN
 #end if
 #show
-'</div>5	10	1	2	1.5
+'</div>

--- a/Examples/Structural/Simply Supported Beams/Uniformly Distributed Load.cpd
+++ b/Examples/Structural/Simply Supported Beams/Uniformly Distributed Load.cpd
@@ -2,8 +2,8 @@
 '<div style = "max-width:180mm;">
 '<img style="width:190pt;" alt = simply-supported-beam-distributed-load-uniform.png" class="side" src = "../../Images/mechanics/beams/simply-supported-beam-distributed-load-uniform.png">
 '<p><b>Input data</b></p>
-'Beam length -'l = ?'m
-'Load -'q = ?'kN/m
+'Beam length -'l = ? {5}'m
+'Load -'q = ? {10}'kN/m
 #post
 '<p><b>Internal forces</b></p>
 'Bending -'M_max = q*l^2/8'kN·m
@@ -13,7 +13,7 @@
 PlotWidth = 600
 PlotHeight = 150
 #show
-'Calculate internal forces at'x_1 = ?'m
+'Calculate internal forces at'x_1 = ? {1}'m
 #pre
 
 #post
@@ -26,4 +26,4 @@ V(x) = q*(l/2 - x)
 $Plot{V(x) @ x = 0 : l}
 V(x_1)'kN
 #show
-'</div>5	10	1
+'</div>


### PR DESCRIPTION
Updating a few places to explicitly include jquery where it was used in the examples, updating macro in Examples/Engineering/Others/Bitwise Operations.cpd to use $ in macro param per Calcpad.Web spec, updating Examples to remove legacy UI vertical tab method that Calcpad.Web doesn't support. The newer inline method was used and they will still work the same way in the CLI and WPF.