### PR TITLE
Various Updates to Calcpad.Web and Calcpad.Highlighter

### DIFF
--- a/Calcpad.Highlighter/HtmlComment/HtmlCommentParser.cs
+++ b/Calcpad.Highlighter/HtmlComment/HtmlCommentParser.cs
@@ -36,17 +36,10 @@ namespace Calcpad.Highlighter.HtmlComment
     /// <summary>
     /// Extracts and parses JSON payloads embedded in Calcpad HTML comment syntax.
     ///
-    /// Supported forms (all produce the same result):
-    ///   '&lt;!--{json: "hello"}--&gt;
-    ///   '&lt;!--{json: "hello"}--&gt;'
-    ///   '&lt;!--{          (multi-line, no inner closing quotes)
-    ///   'json: "hello"
-    ///   '}
-    ///   '--&gt;
-    ///   '&lt;!--{'         (multi-line, inner closing quotes per line)
-    ///   'json: "hello"'
-    ///   '}'
-    ///   '--&gt;'
+    /// Supported forms:
+    ///   '&lt;!--{"json": "hello"}--&gt;                single line (optional trailing quote)
+    ///   '&lt;!--{"json": "hello", _                    multi line via " _" continuation
+    ///   "more": "world"}--&gt;
     ///
     /// Requires that the tokenizer has been run with <see cref="CalcpadTokenizer._inHtmlComment"/>
     /// state tracking enabled, so all lines of a multi-line block are typed as HtmlComment.
@@ -75,7 +68,7 @@ namespace Calcpad.Highlighter.HtmlComment
                 if (token.Type != TokenType.HtmlComment)
                     continue;
 
-                var content = StripCommentQuotes(token.Text);
+                var content = token.Text;
 
                 if (state == ParseState.Normal)
                 {
@@ -155,26 +148,6 @@ namespace Calcpad.Highlighter.HtmlComment
 
             // Any open block at end of stream is silently discarded (unterminated)
             return results;
-        }
-
-        /// <summary>
-        /// Strips the leading comment-quote character (<c>'</c> or <c>"</c>) and,
-        /// if the remainder ends with the same character, the trailing one too.
-        /// </summary>
-        private static string StripCommentQuotes(string text)
-        {
-            if (text.Length == 0)
-                return text;
-
-            char first = text[0];
-            if (first != '\'' && first != '"')
-                return text;
-
-            var inner = text[1..];
-            if (inner.Length > 0 && inner[^1] == first)
-                inner = inner[..^1];
-
-            return inner;
         }
 
         private static HtmlCommentBlock? BuildBlock(int startLine, int endLine, string rawJson)

--- a/Calcpad.Highlighter/Linter/Constants/ErrorCodes.cs
+++ b/Calcpad.Highlighter/Linter/Constants/ErrorCodes.cs
@@ -59,6 +59,7 @@ namespace Calcpad.Highlighter.Linter.Constants
             ["CPD-3311"] = "Empty parameter in function call",
             ["CPD-3312"] = "Unused variable",
             ["CPD-3313"] = "Unused function",
+            ["CPD-3314"] = "Redefinition of existing function",
 
             // Stage 3: Semantic (CPD-34xx)
             ["CPD-3401"] = "Invalid operator usage",

--- a/Calcpad.Highlighter/Linter/Validators/Stage3/NamingValidator.cs
+++ b/Calcpad.Highlighter/Linter/Validators/Stage3/NamingValidator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Calcpad.Highlighter.Linter.Constants;
 using Calcpad.Highlighter.Linter.Helpers;
 using Calcpad.Highlighter.Linter.Models;
@@ -42,6 +43,7 @@ namespace Calcpad.Highlighter.Linter.Validators.Stage3
 
         private void ValidateFunctionNaming(Stage3Context stage3, LinterResult result, TokenizedLineProvider tokenProvider)
         {
+            var definedNames = new HashSet<string>(StringComparer.Ordinal);
             for (int i = 0; i < stage3.Lines.Count; i++)
             {
                 if (!tokenProvider.IsCpdMode(i)) continue;
@@ -62,6 +64,17 @@ namespace Calcpad.Highlighter.Linter.Validators.Stage3
                 {
                     var funcName = funcMatch.Groups[1].Value;
                     var paramsStr = funcMatch.Groups[2].Value.Trim();
+
+                    // Redefining a user-defined function is allowed - inform rather than error.
+                    // Built-in conflicts (CPD-3204) and macros ($) are handled separately.
+                    if (!funcName.EndsWith("$") && !CalcpadBuiltIns.Functions.Contains(funcName)
+                        && !definedNames.Add(funcName))
+                    {
+                        var startPos = line.IndexOf(funcName, StringComparison.Ordinal);
+                        var col = startPos >= 0 ? startPos : 0;
+                        result.AddInformation(i, col, col + funcName.Length, "CPD-3314",
+                            "Function '" + funcName + "' redefines an existing function");
+                    }
 
                     // Functions must have at least one parameter
                     if (string.IsNullOrWhiteSpace(paramsStr))
@@ -145,10 +158,10 @@ namespace Calcpad.Highlighter.Linter.Validators.Stage3
                 return;
             }
 
-            // Check for conflict with built-in constants (ERROR)
+            // Check for conflict with built-in constants (WARNING - redefinition is allowed)
             if (CalcpadBuiltIns.CommonConstants.Contains(identifier))
             {
-                result.AddError(stage3Line, col, endPos, "CPD-3207",
+                result.AddWarning(stage3Line, col, endPos, "CPD-3207",
                     "Variable name '" + identifier + "' conflicts with built-in constant");
                 return; // Don't report additional conflicts
             }

--- a/Calcpad.Highlighter/Linter/Validators/Stage3/UsageValidator.cs
+++ b/Calcpad.Highlighter/Linter/Validators/Stage3/UsageValidator.cs
@@ -472,6 +472,10 @@ namespace Calcpad.Highlighter.Linter.Validators.Stage3
 
         private void ValidateFunctionCalls(Stage3Context stage3, LinterResult result, TokenizedLineProvider tokenProvider)
         {
+            // When a function is redefined, the latest definition wins (matching Calcpad.Core),
+            // so calls are checked against the last definition's parameter count.
+            var lastDefParamCount = BuildLastDefinitionParamCounts(stage3, tokenProvider);
+
             for (int i = 0; i < stage3.Lines.Count; i++)
             {
                 if (!tokenProvider.IsCpdMode(i)) continue;
@@ -486,6 +490,12 @@ namespace Calcpad.Highlighter.Linter.Validators.Stage3
                 if (LineParser.IsDirectiveLine(trimmed))
                     continue;
 
+                // The name on the left of a function definition is a (re)definition, not a call.
+                // Redefining an existing function is allowed, so don't check it against a param count.
+                var defMatch = CalcpadPatterns.FunctionDefinition.Match(line);
+                var defName = defMatch.Success ? defMatch.Groups[1].Value : null;
+                var defNameCol = defMatch.Success ? defMatch.Groups[1].Index : -1;
+
                 var tokens = tokenProvider.GetTokensForLine(i);
 
                 foreach (var token in tokens)
@@ -495,6 +505,9 @@ namespace Calcpad.Highlighter.Linter.Validators.Stage3
                         continue;
 
                     var funcName = token.Text;
+
+                    if (funcName == defName && token.Column == defNameCol)
+                        continue;
 
                     // Skip built-in functions (they have variable param counts)
                     if (CalcpadBuiltIns.Functions.Contains(funcName))
@@ -511,13 +524,15 @@ namespace Calcpad.Highlighter.Linter.Validators.Stage3
                             if (argList.Count == 1 && argList[0].Length == 0)
                                 argList.Clear();
 
+                            var expected = lastDefParamCount.TryGetValue(funcName, out var pc)
+                                ? pc : funcInfo.ParamCount;
                             int totalActual = argList.Count;
-                            if (totalActual != funcInfo.ParamCount)
+                            if (totalActual != expected)
                             {
                                 var endCol = ParsingHelpers.FindClosingParen(line, token.Column + token.Length);
                                 if (endCol <= token.Column + token.Length) endCol = token.Column + token.Length;
                                 result.AddError(i, token.Column, endCol, "CPD-3302",
-                                    "'" + funcName + "' expects " + funcInfo.ParamCount + " parameter(s) but got " + totalActual);
+                                    "'" + funcName + "' expects " + expected + " parameter(s) but got " + totalActual);
                             }
                         }
                     }
@@ -529,6 +544,35 @@ namespace Calcpad.Highlighter.Linter.Validators.Stage3
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Maps each user-defined function name to the parameter count of its last textual
+        /// definition. The tokenizer only registers the first definition's arity, but Calcpad
+        /// resolves redefinitions to the latest one, so call checks must use the last count.
+        /// </summary>
+        private static Dictionary<string, int> BuildLastDefinitionParamCounts(Stage3Context stage3, TokenizedLineProvider tokenProvider)
+        {
+            var counts = new Dictionary<string, int>(StringComparer.Ordinal);
+            for (int i = 0; i < stage3.Lines.Count; i++)
+            {
+                if (!tokenProvider.IsCpdMode(i)) continue;
+
+                var line = stage3.Lines[i];
+                if (LineParser.ShouldSkipLine(line))
+                    continue;
+
+                var defMatch = CalcpadPatterns.FunctionDefinition.Match(line);
+                if (!defMatch.Success)
+                    continue;
+
+                var paramList = ParameterParser.ParseParameters(defMatch.Groups[2].Value);
+                if (paramList.Count == 1 && paramList[0].Trim().Length == 0)
+                    paramList.Clear();
+
+                counts[defMatch.Groups[1].Value] = paramList.Count;
+            }
+            return counts;
         }
 
         private void ValidateMacroCalls(Stage3Context stage3, LinterResult result, TokenizedLineProvider tokenProvider)

--- a/Calcpad.Highlighter/Tokenizer/CalcpadTokenizer.Parsing.cs
+++ b/Calcpad.Highlighter/Tokenizer/CalcpadTokenizer.Parsing.cs
@@ -322,7 +322,17 @@ namespace Calcpad.Highlighter.Tokenizer
 
                 if (_builder.Length > 0)
                 {
-                    Append(_state.CurrentTypeOrPrevious);
+                    var appendType = _state.CurrentTypeOrPrevious;
+                    // Detect HTML comment markers before emitting, so a <!-- opener
+                    // on a line ending in " _" is typed as HtmlComment and _inHtmlComment
+                    // carries the open block into the continuation line.
+                    if (appendType == TokenType.Comment || _inHtmlComment)
+                    {
+                        _state.CurrentType = appendType;
+                        CheckHtmlComment();
+                        appendType = _state.CurrentType;
+                    }
+                    Append(appendType);
                 }
             }
 

--- a/Calcpad.Tests/HighlighterTests/ComprehensiveErrorTests.cs
+++ b/Calcpad.Tests/HighlighterTests/ComprehensiveErrorTests.cs
@@ -62,7 +62,7 @@ namespace Calcpad.Tests.HighlighterTests
 
                 // Naming errors (CPD-32xx)
                 { "naming_errors.cpd", "CPD-3205" },
-                { "naming_errors.cpd", "CPD-3207" },
+                { "naming_errors.cpd", "CPD-3207" }, // Warning: conflict with built-in constant is allowed
                 { "naming_errors.cpd", "CPD-3208" },
 
                 // Usage errors (CPD-33xx)

--- a/Calcpad.Tests/HighlighterTests/HTMLCommentTests.cs
+++ b/Calcpad.Tests/HighlighterTests/HTMLCommentTests.cs
@@ -59,6 +59,30 @@ namespace Calcpad.Tests.HighlighterTests
             Assert.DoesNotContain("6.12345", html);
         }
 
+        [Fact]
+        public void LineContinuation_MetadataCommentParsesAsSingleJsonBlock()
+        {
+            // A metadata comment split across lines with an explicit " _" continuation
+            // must be recognized as one HtmlComment block with intact JSON. Regression:
+            // the opener line was typed as plain Comment and the continuation line's
+            // leading JSON quote was stripped as if it were a comment delimiter.
+            var source =
+                "'<!--{\"desc\":\"k\",\"paramTypes\":[\"value\"], _\n" +
+                "\"paramDesc\":[\"ndfdf\"]}-->";
+
+            var tokens = new CalcpadTokenizer().Tokenize(source);
+            var blocks = new HtmlCommentParser().Parse(tokens);
+
+            var block = Assert.Single(blocks);
+            Assert.Equal(HtmlCommentParseStatus.Success, block.Status);
+            Assert.True(block.Data.HasValue);
+
+            var data = block.Data.Value;
+            Assert.Equal("k", data.GetProperty("desc").GetString());
+            Assert.Equal("value", data.GetProperty("paramTypes")[0].GetString());
+            Assert.Equal("ndfdf", data.GetProperty("paramDesc")[0].GetString());
+        }
+
         private static void ApplyHtmlCommentSettings(string source, Settings settings)
         {
             var tokens = new CalcpadTokenizer().Tokenize(source);

--- a/Calcpad.Tests/HighlighterTests/valid/functions.cpd
+++ b/Calcpad.Tests/HighlighterTests/valid/functions.cpd
@@ -95,3 +95,8 @@ noUnits = clrunits(length)
 hpConv = hp([1; 2; 3])
 isHpRes = ishp(hpConv)
 deepNest = sqr(abs(sin(45) + cos(45)))
+
+' Function redefinition is allowed (reports CPD-3314 Information, not an error)
+redef(a) = a + 1
+redef(a; b) = a + b
+redefUse = redef(2; 3)

--- a/Calcpad.Web/frontend/calcpad-desktop/build-desktop.ps1
+++ b/Calcpad.Web/frontend/calcpad-desktop/build-desktop.ps1
@@ -1,4 +1,4 @@
-# Build the CalcPadCE Web desktop app (Tauri + embedded ASP.NET Core sidecar)
+# Build the CalcpadCE desktop app (Tauri + embedded ASP.NET Core sidecar)
 # on Windows.
 #
 # Publishes Calcpad.Server via sync-bundled-server.mjs, renames the apphost

--- a/Calcpad.Web/frontend/calcpad-desktop/build-desktop.sh
+++ b/Calcpad.Web/frontend/calcpad-desktop/build-desktop.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Build the CalcPadCE Web desktop app (Tauri + embedded ASP.NET Core sidecar).
+# Build the CalcpadCE desktop app (Tauri + embedded ASP.NET Core sidecar).
 #
 # Steps:
 #   1. Publish Calcpad.Server for the target RID via sync-bundled-server.mjs.

--- a/Calcpad.Web/frontend/calcpad-desktop/build-portable.ps1
+++ b/Calcpad.Web/frontend/calcpad-desktop/build-portable.ps1
@@ -1,4 +1,4 @@
-# Build a portable (no-installer) Windows build of CalcPadCE Web.
+# Build a portable (no-installer) Windows build of CalcpadCE.
 #
 # Publishes Calcpad.Server via sync-bundled-server.mjs, runs `tauri build
 # --no-bundle` (Tauri copies bundle.resources next to the exe at compile time
@@ -19,8 +19,8 @@ $SyncScript  = Join-Path $RepoRoot 'Calcpad.Web\frontend\vscode-calcpad\scripts\
 $BinariesDir = Join-Path $ScriptDir 'src-tauri\binaries'
 $ReleaseDir  = Join-Path $ScriptDir "src-tauri\target\$Target\release"
 $OutputDir   = Join-Path $ScriptDir 'src-tauri\target\portable'
-$StageDir    = Join-Path $OutputDir 'CalcPadCE-Web-portable-win64'
-$ZipPath     = Join-Path $OutputDir 'CalcPadCE-Web-portable-win64.zip'
+$StageDir    = Join-Path $OutputDir 'CalcpadCE-portable-win64'
+$ZipPath     = Join-Path $OutputDir 'CalcpadCE-portable-win64.zip'
 
 Write-Host ">> Cargo target: $Target"
 Write-Host ">> .NET RID:     $Rid"
@@ -56,7 +56,7 @@ foreach ($sub in 'bg', 'zh', 'Fonts') {
 }
 
 $exeSrc = Join-Path $StageDir 'calcpad-desktop.exe'
-$exeDst = Join-Path $StageDir 'CalcPadCE Web.exe'
+$exeDst = Join-Path $StageDir 'CalcpadCE.exe'
 if (Test-Path $exeSrc) {
     Move-Item -Force -Path $exeSrc -Destination $exeDst
 }

--- a/Calcpad.Web/frontend/calcpad-desktop/package.json
+++ b/Calcpad.Web/frontend/calcpad-desktop/package.json
@@ -2,7 +2,7 @@
   "name": "calcpad-desktop",
   "version": "0.3.0",
   "private": true,
-  "description": "CalcPad Desktop — Tauri shell with an embedded ASP.NET Core server",
+  "description": "CalcpadCE Desktop — Tauri shell with an embedded ASP.NET Core server",
   "scripts": {
     "tauri": "tauri",
     "dev": "tauri dev --config src-tauri/tauri.linux.conf.json",

--- a/Calcpad.Web/frontend/calcpad-desktop/src-tauri/Cargo.toml
+++ b/Calcpad.Web/frontend/calcpad-desktop/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "calcpad-desktop"
 version = "0.3.0"
-description = "CalcPadCE Web desktop shell"
+description = "CalcpadCE desktop shell"
 authors = ["Isaiah Martin"]
 edition = "2021"
 rust-version = "1.77"

--- a/Calcpad.Web/frontend/calcpad-desktop/src-tauri/capabilities/default.json
+++ b/Calcpad.Web/frontend/calcpad-desktop/src-tauri/capabilities/default.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "Default capabilities for the CalcPadCE Web desktop app.",
+  "description": "Default capabilities for the CalcpadCE desktop app.",
   "windows": ["main"],
   "permissions": [
     "core:default",

--- a/Calcpad.Web/frontend/calcpad-desktop/src-tauri/src/lib.rs
+++ b/Calcpad.Web/frontend/calcpad-desktop/src-tauri/src/lib.rs
@@ -165,7 +165,7 @@ fn install_panic_hook() {
             .and_then(|m| m.lock().ok().map(|g| g.clone()))
             .unwrap_or_default();
         let body = format!(
-            "=== CalcPad Desktop panic ===\n\
+            "=== CalcpadCE Desktop panic ===\n\
              Time (unix ms): {ms}\n\
              Thread: {thread}\n\
              Location: {location}\n\
@@ -842,6 +842,8 @@ fn build_menu(app: &AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
             &MenuItem::with_id(app, "close-tab", "Close Tab", true, Some("CmdOrCtrl+W"))?,
             &sep()?,
             &MenuItem::with_id(app, "export-pdf", "Export PDF...", true, None::<&str>)?,
+            &MenuItem::with_id(app, "export-html", "Export HTML...", true, None::<&str>)?,
+            &MenuItem::with_id(app, "export-docx", "Export Word...", true, None::<&str>)?,
             &sep()?,
             &MenuItem::with_id(app, "quit", "Quit", true, Some("CmdOrCtrl+Q"))?,
         ],

--- a/Calcpad.Web/frontend/calcpad-desktop/src-tauri/tauri.conf.json
+++ b/Calcpad.Web/frontend/calcpad-desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
-  "productName": "CalcPadCE Web",
+  "productName": "CalcpadCE",
   "version": "0.3.0",
-  "identifier": "com.calcpad.desktop",
+  "identifier": "com.calcpadce.desktop",
   "build": {
     "frontendDist": "../../calcpad-web/dist"
   },
@@ -9,7 +9,7 @@
     "windows": [
       {
         "label": "main",
-        "title": "CalcPadCE Web",
+        "title": "CalcpadCE",
         "width": 1400,
         "height": 900,
         "minWidth": 800,
@@ -45,16 +45,16 @@
         "ext": [
           "cpd"
         ],
-        "name": "Calcpad Document",
-        "description": "Calcpad calculation document",
-        "mimeType": "application/x-calcpad",
+        "name": "CalcpadCE Document",
+        "description": "CalcpadCE calculation document",
+        "mimeType": "application/x-calcpadce",
         "role": "Editor",
         "rank": "Default"
       }
     ],
     "category": "DeveloperTool",
-    "shortDescription": "CalcPadCE Web desktop editor",
-    "longDescription": "CalcPadCE Web is a Vue-based editor for Calcpad calculation files, backed by an embedded ASP.NET Core server.",
+    "shortDescription": "CalcpadCE desktop editor",
+    "longDescription": "CalcpadCE is a Vue-based editor for CalcpadCE calculation files, backed by an embedded ASP.NET Core server.",
     "macOS": {
       "minimumSystemVersion": "11.0"
     }

--- a/Calcpad.Web/frontend/calcpad-frontend/package.json
+++ b/Calcpad.Web/frontend/calcpad-frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "calcpad-frontend",
   "version": "0.3.0",
-  "description": "Shared CalcPad frontend logic for VS Code extension and Electron desktop app",
+  "description": "Shared CalcpadCE frontend logic for VS Code extension, Tauri desktop app, and web browser app",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/Calcpad.Web/frontend/calcpad-frontend/src/services/message-bridge/base.ts
+++ b/Calcpad.Web/frontend/calcpad-frontend/src/services/message-bridge/base.ts
@@ -236,7 +236,8 @@ export abstract class BaseMessageBridge {
     protected async saveImageToImagesFolder(_img: PickedImage): Promise<string | null> { return null; }
     /** Prompt for a save location; return the src (relative to the document) to reference it by. */
     protected async saveImageToCustomPath(_img: PickedImage): Promise<string | null> { return null; }
-    protected abstract saveExportedFile(req: ExportRequest): Promise<void>;
+    /** Persist an export; returns the saved path when the platform has one, else null. */
+    protected abstract saveExportedFile(req: ExportRequest): Promise<string | null>;
     protected abstract buildFileContext(content: string): Promise<{ sourceFilePath?: string }>;
     protected abstract getVariablesOrigin(): string;
 
@@ -261,6 +262,8 @@ export abstract class BaseMessageBridge {
     protected buildSettingsResponseExtras(): Record<string, unknown> | Promise<Record<string, unknown>> { return {}; }
     protected async runPdfPreflight(): Promise<boolean> { return true; }
     protected async onPdfError(_err: unknown): Promise<void> { /* default no-op */ }
+    /** Called after a PDF is successfully written, with the saved path (platforms that have one). */
+    protected async onPdfSaved(_filePath: string): Promise<void> { /* default no-op */ }
     protected handlePlatformMessage(_message: any): boolean { return false; }
     protected onOpenLogsFolder(): void {
         console.warn('Open Logs Folder is only available in the desktop build — server logs live on the host running CalcPad.');
@@ -538,13 +541,14 @@ export abstract class BaseMessageBridge {
         try {
             const pdfBytes = await this.generatePdfBytes(content, apiSettings, sourceFilePath);
             if (!pdfBytes) return;
-            await this.saveExportedFile({
+            const savedPath = await this.saveExportedFile({
                 defaultName: 'calcpad-output.pdf',
                 data: pdfBytes,
                 mime: 'application/pdf',
                 extensions: ['pdf'],
                 dialogTitle: 'Export PDF',
             });
+            if (savedPath) await this.onPdfSaved(savedPath);
         } catch (err) {
             await this.onPdfError(err);
         }

--- a/Calcpad.Web/frontend/calcpad-frontend/src/vue/components/CalcpadApp.vue
+++ b/Calcpad.Web/frontend/calcpad-frontend/src/vue/components/CalcpadApp.vue
@@ -185,7 +185,7 @@ const FOLDER_ICON = '<svg width="20" height="20" viewBox="0 0 16 16" fill="curre
 const CALCPAD_ICON = '<svg width="20" height="20" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"><defs><linearGradient id="cp-icon-gradient" x1="0%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#23A9F2"/><stop offset="100%" stop-color="#006DB0"/></linearGradient><mask id="cp-icon-hole"><rect width="100" height="100" fill="white"/><circle cx="50" cy="50" r="9" fill="black"/></mask></defs><path d="M 50 20 L 80 50" stroke="#FFC107" stroke-width="12" stroke-linecap="round" stroke-linejoin="round"/><path d="M 17 17 Q 50 42 83 17 Q 58 50 83 83 Q 50 58 17 83 Q 42 50 17 17 Z" mask="url(#cp-icon-hole)" fill="url(#cp-icon-gradient)" stroke="url(#cp-icon-gradient)" stroke-width="3" stroke-linejoin="round"/><path d="M 80 50 L 50 80" stroke="#FFC107" stroke-width="12" stroke-linecap="round" stroke-linejoin="round"/></svg>'
 const views: ViewDef[] = [
   { id: 'files', label: 'Files', icon: FOLDER_ICON },
-  { id: 'calcpad', label: 'Calcpad', icon: CALCPAD_ICON }
+  { id: 'calcpad', label: 'CalcpadCE', icon: CALCPAD_ICON }
 ]
 const activeView = ref<string>('calcpad')
 

--- a/Calcpad.Web/frontend/calcpad-frontend/src/vue/components/CalcpadSettingsTab.vue
+++ b/Calcpad.Web/frontend/calcpad-frontend/src/vue/components/CalcpadSettingsTab.vue
@@ -97,6 +97,7 @@
             @change="updateSettings"
           />
           Adaptive Plotting
+          <span class="setting-info" title="Concentrates sample points where the curve bends sharply instead of spacing them evenly. Produces smoother plots of curved functions at a lower point count; disable for a fixed dense sampling.">ⓘ</span>
         </label>
       </div>
 
@@ -131,6 +132,7 @@
             @change="updateSettings"
           />
           Vector Graphics
+          <span class="setting-info" title="Renders plots as SVG (scalable, sharp at any zoom) instead of raster PNG images.">ⓘ</span>
         </label>
       </div>
 

--- a/Calcpad.Web/frontend/calcpad-frontend/src/vue/components/CalcpadVariablesTab.vue
+++ b/Calcpad.Web/frontend/calcpad-frontend/src/vue/components/CalcpadVariablesTab.vue
@@ -13,7 +13,7 @@
         Loading variables...
       </div>
       <div v-else-if="!hasVariables" class="no-variables">
-        No variables found. Open a CalcPad document to see variables, macros, and functions.
+        No variables found. Open a CalcpadCE document to see variables, macros, and functions.
       </div>
       <div v-else-if="searchTerm && !hasFilteredResults" class="no-variables">
         No results found for "{{ searchTerm }}"

--- a/Calcpad.Web/frontend/calcpad-web/index.html
+++ b/Calcpad.Web/frontend/calcpad-web/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" href="/icon.png" />
-    <title>CalcPad Web</title>
+    <title>CalcpadCE</title>
   </head>
   <body>
     <div id="app"></div>

--- a/Calcpad.Web/frontend/calcpad-web/package.json
+++ b/Calcpad.Web/frontend/calcpad-web/package.json
@@ -2,7 +2,7 @@
   "name": "calcpad-web",
   "version": "0.3.0",
   "private": true,
-  "description": "CalcPad web editor — Monaco + Vue sidebar powered by calcpad-frontend",
+  "description": "CalcpadCE web editor — Monaco + Vue sidebar powered by calcpad-frontend",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/Calcpad.Web/frontend/calcpad-web/src/App.vue
+++ b/Calcpad.Web/frontend/calcpad-web/src/App.vue
@@ -927,7 +927,7 @@ export interface OutputLine {
 }
 
 const OUTPUT_CHANNEL_LABELS: Record<OutputChannel, string> = {
-  app: 'CalcPad',
+  app: 'CalcpadCE',
   preview: 'Preview Console',
   server: 'Server',
 }
@@ -1287,7 +1287,7 @@ function injectPreviewConsole(html: string, groupId: string): string {
     '    var r = e.reason; var d = r && (r.stack || r.message) || String(r);',
     "    post('error', ['[Unhandled Rejection] ' + d]);",
     '  });',
-    "  console.log('CalcPad preview console interception initialized');",
+    "  console.log('CalcpadCE preview console interception initialized');",
     '})();',
   ].join('\n')
   const open = '<' + 'script>'

--- a/Calcpad.Web/frontend/calcpad-web/src/editor/formatting-commands.ts
+++ b/Calcpad.Web/frontend/calcpad-web/src/editor/formatting-commands.ts
@@ -39,31 +39,31 @@ export function registerFormattingCommands(
     const KC = monaco.KeyCode;
 
     // Inline formatting
-    add('calcpad.formatBold',         'CalcPad: Bold',         [KM.CtrlCmd | KC.KeyB], () => wrapInline(editor, bridge, 'bold'));
-    add('calcpad.formatItalic',       'CalcPad: Italic',       [KM.CtrlCmd | KC.KeyI], () => wrapInline(editor, bridge, 'italic'));
-    add('calcpad.formatUnderline',    'CalcPad: Underline',    [KM.CtrlCmd | KC.KeyU], () => wrapInline(editor, bridge, 'underline'));
-    add('calcpad.formatSubscript',    'CalcPad: Subscript',    [KM.CtrlCmd | KC.Equal], () => wrapInline(editor, bridge, 'subscript'));
-    add('calcpad.formatSuperscript',  'CalcPad: Superscript',  [KM.CtrlCmd | KM.Shift | KC.Equal], () => wrapInline(editor, bridge, 'superscript'));
+    add('calcpad.formatBold',         'CalcpadCE: Bold',         [KM.CtrlCmd | KC.KeyB], () => wrapInline(editor, bridge, 'bold'));
+    add('calcpad.formatItalic',       'CalcpadCE: Italic',       [KM.CtrlCmd | KC.KeyI], () => wrapInline(editor, bridge, 'italic'));
+    add('calcpad.formatUnderline',    'CalcpadCE: Underline',    [KM.CtrlCmd | KC.KeyU], () => wrapInline(editor, bridge, 'underline'));
+    add('calcpad.formatSubscript',    'CalcpadCE: Subscript',    [KM.CtrlCmd | KC.Equal], () => wrapInline(editor, bridge, 'subscript'));
+    add('calcpad.formatSuperscript',  'CalcpadCE: Superscript',  [KM.CtrlCmd | KM.Shift | KC.Equal], () => wrapInline(editor, bridge, 'superscript'));
 
     // Headings (Ctrl+1..Ctrl+6)
     const digitKeys = [KC.Digit1, KC.Digit2, KC.Digit3, KC.Digit4, KC.Digit5, KC.Digit6];
     for (let i = 0; i < 6; i++) {
         const level = i + 1;
-        add(`calcpad.formatHeading${level}`, `CalcPad: Heading ${level}`,
+        add(`calcpad.formatHeading${level}`, `CalcpadCE: Heading ${level}`,
             [KM.CtrlCmd | digitKeys[i]],
             () => insertHeading(editor, bridge, level));
     }
 
     // Block elements
-    add('calcpad.formatParagraph',    'CalcPad: Paragraph',     [KM.CtrlCmd | KC.KeyL], () => insertParagraph(editor));
-    add('calcpad.formatLineBreak',    'CalcPad: Line Break',    [KM.CtrlCmd | KC.KeyR], () => insertLineBreak(editor));
-    add('calcpad.formatBulletedList', 'CalcPad: Bulleted List', [KM.CtrlCmd | KM.Shift | KC.KeyL], () => insertBulletedList(editor, bridge));
-    add('calcpad.formatNumberedList', 'CalcPad: Numbered List', [KM.CtrlCmd | KM.Shift | KC.KeyN], () => insertNumberedList(editor, bridge));
+    add('calcpad.formatParagraph',    'CalcpadCE: Paragraph',     [KM.CtrlCmd | KC.KeyL], () => insertParagraph(editor));
+    add('calcpad.formatLineBreak',    'CalcpadCE: Line Break',    [KM.CtrlCmd | KC.KeyR], () => insertLineBreak(editor));
+    add('calcpad.formatBulletedList', 'CalcpadCE: Bulleted List', [KM.CtrlCmd | KM.Shift | KC.KeyL], () => insertBulletedList(editor, bridge));
+    add('calcpad.formatNumberedList', 'CalcpadCE: Numbered List', [KM.CtrlCmd | KM.Shift | KC.KeyN], () => insertNumberedList(editor, bridge));
 
     // Comments
-    add('calcpad.toggleComment',  'CalcPad: Toggle Comment',   [KM.CtrlCmd | KC.KeyQ], () => toggleComment(editor));
-    add('calcpad.uncomment',      'CalcPad: Uncomment',        [KM.CtrlCmd | KM.Shift | KC.KeyQ], () => uncomment(editor));
-    add('calcpad.pasteAsComment', 'CalcPad: Paste as Comment', [KM.CtrlCmd | KM.Shift | KC.KeyV], () => pasteAsComment(editor));
+    add('calcpad.toggleComment',  'CalcpadCE: Toggle Comment',   [KM.CtrlCmd | KC.KeyQ], () => toggleComment(editor));
+    add('calcpad.uncomment',      'CalcpadCE: Uncomment',        [KM.CtrlCmd | KM.Shift | KC.KeyQ], () => uncomment(editor));
+    add('calcpad.pasteAsComment', 'CalcpadCE: Paste as Comment', [KM.CtrlCmd | KM.Shift | KC.KeyV], () => pasteAsComment(editor));
 
     return { dispose() { for (const d of disposables) d.dispose(); } };
 }

--- a/Calcpad.Web/frontend/calcpad-web/src/main.ts
+++ b/Calcpad.Web/frontend/calcpad-web/src/main.ts
@@ -63,7 +63,7 @@ function getEmptyPreviewHtml(theme: 'light' | 'dark'): string {
 <html>
 <head>
     <meta charset="UTF-8">
-    <title>CalcPad Preview</title>
+    <title>CalcpadCE Preview</title>
     <style>
         body { color: ${c.fg}; background: ${c.bg}; padding: 20px; font-family: var(--vscode-font-family, system-ui, sans-serif); }
         h3 { text-align: center; }
@@ -78,7 +78,7 @@ function getEmptyPreviewHtml(theme: 'light' | 'dark'): string {
 </head>
 <body>
     <h3>Empty Document</h3>
-    <p>Start typing CalcPad code to see the preview.</p>
+    <p>Start typing CalcpadCE code to see the preview.</p>
     <h4>Formatting Hotkeys</h4>
     <table>
         <tr><th>Bold</th><td>Ctrl+B</td></tr>
@@ -102,7 +102,7 @@ function getEmptyPreviewHtml(theme: 'light' | 'dark'): string {
 }
 
 function getSampleContent(): string {
-    return `'CalcPad Web Editor
+    return `'CalcpadCE Web Editor
 'Enter your calculations below
 
 a = 3
@@ -136,13 +136,13 @@ async function rgbaToPng(rgba: Uint8Array, width: number, height: number): Promi
 async function showServerBlockedDialog(details: string): Promise<void> {
     const { message: dialogMessage } = await import('@tauri-apps/plugin-dialog');
     const body =
-        "CalcPad's calculation server started but never became ready.\n\n"
+        "CalcpadCE's calculation server started but never became ready.\n\n"
         + 'The editor still works, but preview, linting, and PDF/Word export '
         + 'need the server. Choose Server → Restart Server to try again.\n\n'
         + `Details: ${details}`;
     try {
         await dialogMessage(body, {
-            title: 'CalcPad server unavailable',
+            title: 'CalcpadCE server unavailable',
             kind: 'warning',
             okLabel: 'OK',
         });
@@ -885,7 +885,7 @@ async function bootstrap(): Promise<void> {
         }
     });
 
-    appInstance.appendOutput('info', `CalcPad Web started — server: ${serverUrl}`);
+    appInstance.appendOutput('info', `CalcpadCE Web started — server: ${serverUrl}`);
 
     // Flush any server-manager log lines buffered before the Output panel mounted,
     // then redirect future ones straight into the panel.
@@ -908,7 +908,7 @@ async function bootstrap(): Promise<void> {
         };
         serverManager.onCrashExhausted = (crashOutput: string) => {
             appInstance.appendOutput('error',
-                'CalcPad server crashed repeatedly — auto-restart disabled. ' +
+                'CalcpadCE server crashed repeatedly — auto-restart disabled. ' +
                 'Use Server → Restart Server to try again.');
             if (crashOutput) appInstance.appendOutput('error', crashOutput);
         };
@@ -1136,7 +1136,7 @@ async function bootstrap(): Promise<void> {
             const choice = await appInstance.showConfirm({
                 title: 'Recover unsaved changes?',
                 message:
-                    `CalcPad found ${drafts.length} unsaved draft${drafts.length === 1 ? '' : 's'} `
+                    `CalcpadCE found ${drafts.length} unsaved draft${drafts.length === 1 ? '' : 's'} `
                     + `from a previous session:\n\n${summary}\n\n`
                     + `Restore them into new tabs? Choose "Don't Restore" to discard.`,
                 yesLabel: 'Restore',
@@ -1577,6 +1577,14 @@ async function bootstrap(): Promise<void> {
 
                 case 'export-pdf':
                     tauriBridge.handleMessage({ type: 'generatePdf' });
+                    break;
+
+                case 'export-html':
+                    tauriBridge.handleMessage({ type: 'saveSourceHtml' });
+                    break;
+
+                case 'export-docx':
+                    tauriBridge.handleMessage({ type: 'saveDocx' });
                     break;
 
                 case 'toggle-sidebar':

--- a/Calcpad.Web/frontend/calcpad-web/src/services/message-bridge.ts
+++ b/Calcpad.Web/frontend/calcpad-web/src/services/message-bridge.ts
@@ -96,11 +96,12 @@ export class MessageBridge extends BaseMessageBridge {
         return `data:${mimeType};base64,${bytesToBase64(data)}`;
     }
 
-    protected async saveExportedFile(req: ExportRequest): Promise<void> {
+    protected async saveExportedFile(req: ExportRequest): Promise<string | null> {
         const part: BlobPart = req.data instanceof Uint8Array
             ? new Uint8Array(req.data)
             : req.data;
         triggerBlobDownload(new Blob([part], { type: req.mime }), req.defaultName);
+        return null;
     }
 
     protected async buildFileContext(_content: string): Promise<{ sourceFilePath?: string }> {

--- a/Calcpad.Web/frontend/calcpad-web/src/services/tauri-bridge.ts
+++ b/Calcpad.Web/frontend/calcpad-web/src/services/tauri-bridge.ts
@@ -11,7 +11,7 @@ import {
     mkdir,
     exists,
 } from '@tauri-apps/plugin-fs';
-import { open as dialogOpen, save as dialogSave, message as dialogMessage } from '@tauri-apps/plugin-dialog';
+import { open as dialogOpen, save as dialogSave, message as dialogMessage, ask as dialogAsk } from '@tauri-apps/plugin-dialog';
 import { openPath } from '@tauri-apps/plugin-opener';
 import { Store } from '@tauri-apps/plugin-store';
 import { platform } from '@tauri-apps/plugin-os';
@@ -57,6 +57,11 @@ const MAX_RECENT_FILES = 10;
 function pathDirname(p: string): string {
     const idx = Math.max(p.lastIndexOf('/'), p.lastIndexOf('\\'));
     return idx > 0 ? p.slice(0, idx) : '';
+}
+
+function pathBasename(p: string): string {
+    const idx = Math.max(p.lastIndexOf('/'), p.lastIndexOf('\\'));
+    return idx >= 0 ? p.slice(idx + 1) : p;
 }
 
 /** POSIX-style relative path from `from` to `to`, using forward slashes. */
@@ -313,13 +318,13 @@ export class TauriMessageBridge extends BaseMessageBridge {
         return candidate;
     }
 
-    protected async saveExportedFile(req: ExportRequest): Promise<void> {
+    protected async saveExportedFile(req: ExportRequest): Promise<string | null> {
         const filePath = await dialogSave({
             title: req.dialogTitle,
-            defaultPath: this.getDialogDefaultPath(),
+            defaultPath: this.getExportDefaultPath(req),
             filters: [{ name: `${req.dialogTitle} Files`, extensions: req.extensions }],
         });
-        if (!filePath) return;
+        if (!filePath) return null;
         this.rememberDialogDir(filePath);
         if (typeof req.data === 'string') {
             await writeTextFile(filePath, req.data);
@@ -329,6 +334,17 @@ export class TauriMessageBridge extends BaseMessageBridge {
                 : new Uint8Array(req.data as ArrayBuffer);
             await fsWriteFile(filePath, bytes);
         }
+        return filePath;
+    }
+
+    protected async onPdfSaved(filePath: string): Promise<void> {
+        const open = await dialogAsk(`PDF saved to ${filePath}`, {
+            title: 'PDF export complete',
+            kind: 'info',
+            okLabel: 'Open PDF',
+            cancelLabel: 'Close',
+        });
+        if (open) await this.openPathSafe(filePath);
     }
 
     protected async buildFileContext(_content: string): Promise<{ sourceFilePath?: string }> {
@@ -394,6 +410,12 @@ export class TauriMessageBridge extends BaseMessageBridge {
         this.handleGetServerLog();
         if (await this.browserMissing()) {
             await this.warnBrowserMissing();
+            return;
+        }
+        try {
+            await dialogMessage(msg, { title: 'Failed to generate PDF', kind: 'error', okLabel: 'OK' });
+        } catch {
+            /* output panel already carries the error */
         }
     }
 
@@ -475,6 +497,22 @@ export class TauriMessageBridge extends BaseMessageBridge {
         return this._lastDialogDir ?? undefined;
     }
 
+    /**
+     * Default path for an export Save dialog: the active document's name with the
+     * export's extension swapped in (e.g. `report.cpd` → `report.html`), placed in
+     * the document's folder — mirroring how Save As prefills the `.cpd` name.
+     */
+    private getExportDefaultPath(req: ExportRequest): string | undefined {
+        const ext = req.extensions[0];
+        const activePath = this.activeTabFilePath();
+        const source = activePath || this.activeTabTitle();
+        if (!source) return this.getDialogDefaultPath();
+        const base = pathBasename(source).replace(/\.[^./\\]+$/, '') || 'calcpad-output';
+        const name = ext ? `${base}.${ext}` : base;
+        const dir = activePath ? pathDirname(activePath) : this._lastDialogDir;
+        return dir ? pathResolve(dir, name) : name;
+    }
+
     private getSaveDialogDefaultPath(): string | undefined {
         const activePath = this.activeTabFilePath();
         if (activePath) return activePath;
@@ -497,7 +535,7 @@ export class TauriMessageBridge extends BaseMessageBridge {
             multiple: false,
             defaultPath: this.getDialogDefaultPath(),
             filters: [
-                { name: 'CalcPad Files', extensions: ['cpd'] },
+                { name: 'CalcpadCE Files', extensions: ['cpd'] },
                 { name: 'All Files', extensions: ['*'] },
             ],
         });
@@ -548,7 +586,7 @@ export class TauriMessageBridge extends BaseMessageBridge {
             title: 'Save File',
             defaultPath: this.getSaveDialogDefaultPath(),
             filters: [
-                { name: 'CalcPad Files', extensions: ['cpd'] },
+                { name: 'CalcpadCE Files', extensions: ['cpd'] },
                 { name: 'All Files', extensions: ['*'] },
             ],
         });
@@ -861,7 +899,7 @@ export class TauriMessageBridge extends BaseMessageBridge {
         const message =
             'PDF export needs a Chromium-family browser, but none was found on PATH.\n\n'
             + advice
-            + '\n\nAfter installing, restart CalcPad (Server → Restart App) and try again.';
+            + '\n\nAfter installing, restart CalcpadCE (Server → Restart App) and try again.';
         try {
             await dialogMessage(message, {
                 title: 'Chromium browser required for PDF export',

--- a/Calcpad.Web/frontend/vscode-calcpad/calcpad-settings-schema.json
+++ b/Calcpad.Web/frontend/vscode-calcpad/calcpad-settings-schema.json
@@ -94,11 +94,11 @@
     },
     "server": {
       "type": "object",
-      "description": "CalcPad server configuration",
+      "description": "CalcpadCE server configuration",
       "properties": {
         "url": {
           "type": "string",
-          "description": "Server URL for CalcPad API",
+          "description": "Server URL for CalcpadCE API",
           "default": ""
         }
       }

--- a/Calcpad.Web/frontend/vscode-calcpad/package.json
+++ b/Calcpad.Web/frontend/vscode-calcpad/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-calcpad",
-  "displayName": "VS Code CalcPad",
+  "displayName": "VS Code CalcpadCE",
   "description": "Calculator extension for VS Code",
   "version": "0.3.0",
   "publisher": "imartincei",
@@ -19,7 +19,7 @@
       {
         "id": "calcpad",
         "aliases": [
-          "CalcPad",
+          "CalcpadCE",
           "calcpad"
         ],
         "extensions": [
@@ -216,55 +216,55 @@
     "commands": [
       {
         "command": "vscode-calcpad.activate",
-        "title": "Activate CalcPad"
+        "title": "Activate CalcpadCE"
       },
       {
         "command": "vscode-calcpad.previewHtml",
-        "title": "CalcPad Preview",
+        "title": "CalcpadCE Preview",
         "icon": "$(preview)"
       },
       {
         "command": "vscode-calcpad.showInsert",
-        "title": "Show CalcPad Insert Panel",
+        "title": "Show CalcpadCE Insert Panel",
         "icon": "$(add)"
       },
       {
         "command": "vscode-calcpad.editMetadataProperties",
-        "title": "CalcPad: Add / Edit Metadata Properties",
-        "category": "Calcpad"
+        "title": "CalcpadCE: Add / Edit Metadata Properties",
+        "category": "CalcpadCE"
       },
       {
         "command": "vscode-calcpad.exportToPdf",
-        "title": "Export CalcPad to PDF",
+        "title": "Export CalcpadCE to PDF",
         "icon": "$(file-pdf)"
       },
       {
         "command": "vscode-calcpad.previewUnwrapped",
-        "title": "CalcPad Preview Unwrapped",
+        "title": "CalcpadCE Preview Unwrapped",
         "icon": "$(eye)"
       },
       {
         "command": "vscode-calcpad.focusPreviewToLine",
-        "title": "CalcPad: Focus Preview to Line",
+        "title": "CalcpadCE: Focus Preview to Line",
         "icon": "$(target)"
       },
       {
         "command": "vscode-calcpad.viewWebviewSource",
-        "title": "CalcPad: View Webview Source HTML"
+        "title": "CalcpadCE: View Webview Source HTML"
       },
       {
         "command": "vscode-calcpad.printToPdf",
-        "title": "Print CalcPad Preview to PDF",
+        "title": "Print CalcpadCE Preview to PDF",
         "icon": "$(file-pdf)"
       },
       {
         "command": "vscode-calcpad.saveSourceHtml",
-        "title": "CalcPad: Save Source HTML…",
+        "title": "CalcpadCE: Save Source HTML…",
         "icon": "$(file-code)"
       },
       {
         "command": "vscode-calcpad.saveDocx",
-        "title": "CalcPad: Save as Word Document…",
+        "title": "CalcpadCE: Save as Word Document…",
         "icon": "$(file)"
       },
       {
@@ -274,94 +274,94 @@
       },
       {
         "command": "vscode-calcpad.formatBold",
-        "title": "CalcPad: Bold"
+        "title": "CalcpadCE: Bold"
       },
       {
         "command": "vscode-calcpad.formatItalic",
-        "title": "CalcPad: Italic"
+        "title": "CalcpadCE: Italic"
       },
       {
         "command": "vscode-calcpad.formatUnderline",
-        "title": "CalcPad: Underline"
+        "title": "CalcpadCE: Underline"
       },
       {
         "command": "vscode-calcpad.formatSubscript",
-        "title": "CalcPad: Subscript"
+        "title": "CalcpadCE: Subscript"
       },
       {
         "command": "vscode-calcpad.formatSuperscript",
-        "title": "CalcPad: Superscript"
+        "title": "CalcpadCE: Superscript"
       },
       {
         "command": "vscode-calcpad.formatHeading1",
-        "title": "CalcPad: Heading 1"
+        "title": "CalcpadCE: Heading 1"
       },
       {
         "command": "vscode-calcpad.formatHeading2",
-        "title": "CalcPad: Heading 2"
+        "title": "CalcpadCE: Heading 2"
       },
       {
         "command": "vscode-calcpad.formatHeading3",
-        "title": "CalcPad: Heading 3"
+        "title": "CalcpadCE: Heading 3"
       },
       {
         "command": "vscode-calcpad.formatHeading4",
-        "title": "CalcPad: Heading 4"
+        "title": "CalcpadCE: Heading 4"
       },
       {
         "command": "vscode-calcpad.formatHeading5",
-        "title": "CalcPad: Heading 5"
+        "title": "CalcpadCE: Heading 5"
       },
       {
         "command": "vscode-calcpad.formatHeading6",
-        "title": "CalcPad: Heading 6"
+        "title": "CalcpadCE: Heading 6"
       },
       {
         "command": "vscode-calcpad.formatParagraph",
-        "title": "CalcPad: Paragraph"
+        "title": "CalcpadCE: Paragraph"
       },
       {
         "command": "vscode-calcpad.formatLineBreak",
-        "title": "CalcPad: Line Break"
+        "title": "CalcpadCE: Line Break"
       },
       {
         "command": "vscode-calcpad.formatBulletedList",
-        "title": "CalcPad: Bulleted List"
+        "title": "CalcpadCE: Bulleted List"
       },
       {
         "command": "vscode-calcpad.formatNumberedList",
-        "title": "CalcPad: Numbered List"
+        "title": "CalcpadCE: Numbered List"
       },
       {
         "command": "vscode-calcpad.toggleComment",
-        "title": "CalcPad: Toggle Comment"
+        "title": "CalcpadCE: Toggle Comment"
       },
       {
         "command": "vscode-calcpad.uncomment",
-        "title": "CalcPad: Uncomment"
+        "title": "CalcpadCE: Uncomment"
       },
       {
         "command": "vscode-calcpad.pasteAsComment",
-        "title": "CalcPad: Paste as Comment"
+        "title": "CalcpadCE: Paste as Comment"
       },
       {
         "command": "vscode-calcpad.prettifyDocument",
-        "title": "CalcPad: Prettify Document",
+        "title": "CalcpadCE: Prettify Document",
         "icon": "$(symbol-ruler)"
       },
       {
         "command": "calcpad.refreshDocument",
-        "title": "CalcPad: Run Preview",
+        "title": "CalcpadCE: Run Preview",
         "icon": "$(refresh)"
       },
       {
         "command": "calcpad.stopServer",
-        "title": "Stop CalcPad Server",
+        "title": "Stop CalcpadCE Server",
         "icon": "$(debug-stop)"
       },
       {
         "command": "vscode-calcpad.installJuliaMono",
-        "title": "CalcPad: Install JuliaMono Font"
+        "title": "CalcpadCE: Install JuliaMono Font"
       }
     ],
     "menus": {
@@ -568,12 +568,12 @@
       }
     ],
     "configuration": {
-      "title": "CalcPad",
+      "title": "CalcpadCE",
       "properties": {
         "calcpad.enableFormattingHotkeys": {
           "type": "boolean",
           "default": true,
-          "description": "Enable formatting hotkeys (Ctrl+B, Ctrl+I, Ctrl+1-6, etc.) for CalcPad files. Mirrored from the active CalcPad settings config on activation — edit via the CalcPad sidebar, not here (this key exists only so keybinding `when` clauses can reference it)."
+          "description": "Enable formatting hotkeys (Ctrl+B, Ctrl+I, Ctrl+1-6, etc.) for CalcpadCE files. Mirrored from the active CalcpadCE settings config on activation — edit via the CalcpadCE sidebar, not here (this key exists only so keybinding `when` clauses can reference it)."
         }
       }
     },
@@ -581,7 +581,7 @@
       "calcpad-ui": [
         {
           "id": "calcpadVueUI",
-          "name": "CalcPad",
+          "name": "CalcpadCE",
           "type": "webview"
         }
       ]
@@ -590,7 +590,7 @@
       "activitybar": [
         {
           "id": "calcpad-ui",
-          "title": "CalcPad",
+          "title": "CalcpadCE",
           "icon": "./calcpad-icon.png"
         }
       ]

--- a/Calcpad.Web/frontend/vscode-calcpad/src/baseServerManager.ts
+++ b/Calcpad.Web/frontend/vscode-calcpad/src/baseServerManager.ts
@@ -346,7 +346,7 @@ export class BaseServerManager {
                 detail +=
                     `\nWindows blocked the executable (Defender / SmartScreen / AppLocker). ` +
                     `Right-click ${useAppHost ? path.basename(exePath) : path.basename(this.dotnetPath)} ` +
-                    `in Windows Explorer → Properties → check "Unblock", then click the CalcPad refresh button to retry.`;
+                    `in Windows Explorer → Properties → check "Unblock", then click the CalcpadCE refresh button to retry.`;
             }
             this._lastCrashOutput.push(detail);
             this._processClosed = true; // make waitForReady fast-fail

--- a/Calcpad.Web/frontend/vscode-calcpad/src/calcpad-settings-schema.json
+++ b/Calcpad.Web/frontend/vscode-calcpad/src/calcpad-settings-schema.json
@@ -94,11 +94,11 @@
     },
     "server": {
       "type": "object",
-      "description": "CalcPad server configuration",
+      "description": "CalcpadCE server configuration",
       "properties": {
         "url": {
           "type": "string",
-          "description": "Server URL for CalcPad API",
+          "description": "Server URL for CalcpadCE API",
           "default": ""
         }
       }

--- a/Calcpad.Web/frontend/vscode-calcpad/src/calcpadServerManager.ts
+++ b/Calcpad.Web/frontend/vscode-calcpad/src/calcpadServerManager.ts
@@ -168,7 +168,7 @@ export class CalcpadServerManager extends BaseServerManager implements vscode.Di
 
         await vscode.window.withProgress({
             location: vscode.ProgressLocation.Notification,
-            title: 'CalcPad: Downloading server libraries...',
+            title: 'CalcpadCE: Downloading server libraries...',
             cancellable: false
         }, async (progress) => {
             for (let i = 0; i < missing.length; i++) {
@@ -337,7 +337,7 @@ export class CalcpadServerManager extends BaseServerManager implements vscode.Di
 
         await vscode.window.withProgress({
             location: vscode.ProgressLocation.Notification,
-            title: 'CalcPad: Downloading native libraries...',
+            title: 'CalcpadCE: Downloading native libraries...',
             cancellable: false
         }, async (progress) => {
             await this.downloadNativeLib(info, binDir, progress);

--- a/Calcpad.Web/frontend/vscode-calcpad/src/calcpadSettings.ts
+++ b/Calcpad.Web/frontend/vscode-calcpad/src/calcpadSettings.ts
@@ -36,7 +36,7 @@ let _outputChannel: vscode.OutputChannel | undefined;
 
 function getOutputChannel(): vscode.OutputChannel {
     if (!_outputChannel) {
-        _outputChannel = vscode.window.createOutputChannel('CalcPad Settings');
+        _outputChannel = vscode.window.createOutputChannel('CalcpadCE Settings');
     }
     return _outputChannel;
 }

--- a/Calcpad.Web/frontend/vscode-calcpad/src/calcpadVueUIProvider.ts
+++ b/Calcpad.Web/frontend/vscode-calcpad/src/calcpadVueUIProvider.ts
@@ -30,7 +30,7 @@ export class CalcpadVueUIProvider implements vscode.WebviewViewProvider {
         private readonly _settingsManager: CalcpadSettingsManager,
         private readonly _insertManager: CalcpadInsertManager
     ) {
-        this._outputChannel = vscode.window.createOutputChannel('CalcPad Vue');
+        this._outputChannel = vscode.window.createOutputChannel('CalcpadCE Vue');
         this._outputChannel.appendLine('CalcPad Vue UI Provider initialized');
 
         // Register callback to refresh UI when snippets are loaded from server
@@ -579,12 +579,12 @@ export class CalcpadVueUIProvider implements vscode.WebviewViewProvider {
     <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src ${webview.cspSource} data:; style-src ${webview.cspSource} 'unsafe-inline'; script-src 'nonce-${nonce}';">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="${styleUri}" rel="stylesheet">
-    <title>CalcPad Vue UI</title>
+    <title>CalcpadCE Vue UI</title>
 </head>
 <body>
     <div id="app">
         <div style="padding: 20px; text-align: center; color: #666; font-size: 12px;">
-            Loading Vue.js CalcPad UI...
+            Loading Vue.js CalcpadCE UI...
             <br><small>If this message persists, check the developer console for errors</small>
         </div>
     </div>

--- a/Calcpad.Web/frontend/vscode-calcpad/src/dotnetRuntimeManager.ts
+++ b/Calcpad.Web/frontend/vscode-calcpad/src/dotnetRuntimeManager.ts
@@ -89,8 +89,8 @@ export class DotnetRuntimeManager {
      */
     public async promptUserForInstallation(status: DotnetStatus): Promise<'install-local' | 'download' | 'cancel'> {
         const message = status === 'not-found'
-            ? `CalcPad requires the .NET ${DOTNET_MAJOR_VERSION}.0 runtime to run calculations locally. It was not found on your system.`
-            : `CalcPad requires the ASP.NET Core ${DOTNET_MAJOR_VERSION}.0 runtime, but only older versions were found on your system.`;
+            ? `CalcpadCE requires the .NET ${DOTNET_MAJOR_VERSION}.0 runtime to run calculations locally. It was not found on your system.`
+            : `CalcpadCE requires the ASP.NET Core ${DOTNET_MAJOR_VERSION}.0 runtime, but only older versions were found on your system.`;
 
         const choice = await vscode.window.showWarningMessage(
             message,
@@ -133,7 +133,7 @@ export class DotnetRuntimeManager {
 
         await vscode.window.withProgress({
             location: vscode.ProgressLocation.Notification,
-            title: 'CalcPad: Installing .NET runtime...',
+            title: 'CalcpadCE: Installing .NET runtime...',
             cancellable: false
         }, async (progress) => {
             progress.report({ message: 'Downloading runtime...' });
@@ -232,14 +232,14 @@ export class DotnetRuntimeManager {
             } catch (err) {
                 const message = err instanceof Error ? err.message : String(err);
                 this.log(`Failed to install runtime locally: ${message}`);
-                vscode.window.showErrorMessage(`CalcPad: Failed to install .NET runtime: ${message}`);
+                vscode.window.showErrorMessage(`CalcpadCE: Failed to install .NET runtime: ${message}`);
                 return null;
             }
         } else if (choice === 'download') {
             this.openDownloadPage();
             if (serverMode === 'local') {
                 vscode.window.showInformationMessage(
-                    'CalcPad: Please restart VS Code after installing the .NET runtime.'
+                    'CalcpadCE: Please restart VS Code after installing the .NET runtime.'
                 );
             }
             return null;

--- a/Calcpad.Web/frontend/vscode-calcpad/src/extension.ts
+++ b/Calcpad.Web/frontend/vscode-calcpad/src/extension.ts
@@ -146,7 +146,7 @@ function getPdfSettings(): FullPdfSettings {
 
     const fileName = activeEditor
         ? path.basename(activeEditor.document.fileName, path.extname(activeEditor.document.fileName))
-        : 'CalcPad Document';
+        : 'CalcpadCE Document';
 
     return {
         // User-configurable settings (defaults from shared module)
@@ -610,8 +610,8 @@ async function updatePreviewContent(panel: vscode.WebviewPanel, content: string,
     // Update panel title with current file name
     const activeEditor = vscode.window.activeTextEditor;
     if (activeEditor) {
-        const fileName = activeEditor.document.fileName.split('/').pop() || 'CalcPad';
-        panel.title = unwrapped ? `CalcPad Preview Unwrapped - ${fileName}` : `CalcPad Preview - ${fileName}`;
+        const fileName = activeEditor.document.fileName.split('/').pop() || 'CalcpadCE';
+        panel.title = unwrapped ? `CalcpadCE Preview Unwrapped - ${fileName}` : `CalcpadCE Preview - ${fileName}`;
     }
 
     // Check if content is empty
@@ -626,7 +626,7 @@ async function updatePreviewContent(panel: vscode.WebviewPanel, content: string,
             <html>
             <head>
                 <meta charset="UTF-8">
-                <title>CalcPad Preview${unwrapped ? ' Unwrapped' : ''}</title>
+                <title>CalcpadCE Preview${unwrapped ? ' Unwrapped' : ''}</title>
                 <style>
                     body { color: ${c.fg}; background: ${c.bg}; padding: 20px; font-family: var(--vscode-font-family); }
                     h3 { text-align: center; }
@@ -641,7 +641,7 @@ async function updatePreviewContent(panel: vscode.WebviewPanel, content: string,
             </head>
             <body>
                 <h3>Empty Document</h3>
-                <p>Start typing CalcPad code to see the preview.</p>
+                <p>Start typing CalcpadCE code to see the preview.</p>
                 <h4>Formatting Hotkeys</h4>
                 <table>
                     <tr><th>Bold</th><td>Ctrl+B</td></tr>
@@ -760,7 +760,7 @@ async function updatePreviewContent(panel: vscode.WebviewPanel, content: string,
             <html>
             <head>
                 <meta charset="UTF-8">
-                <title>CalcPad Preview Error</title>
+                <title>CalcpadCE Preview Error</title>
             </head>
             <body>
                 <div style="color: #d32f2f; background: #ffebee; padding: 15px; border-radius: 4px; margin: 20px;">
@@ -795,7 +795,7 @@ async function generatePdfToFile(
     if (!apiBaseUrl) throw new Error('Server URL not configured');
 
     if (!documentContent || documentContent.trim().length === 0) {
-        throw new Error('Document is empty. Please add some CalcPad content first.');
+        throw new Error('Document is empty. Please add some CalcpadCE content first.');
     }
 
     const settings = await settingsManager.getApiSettings();
@@ -858,7 +858,7 @@ async function generatePdfToFile(
 async function runPdfExportCommand(): Promise<void> {
     const activeEditor = vscode.window.activeTextEditor;
     if (!activeEditor) {
-        vscode.window.showErrorMessage('No active CalcPad document found');
+        vscode.window.showErrorMessage('No active CalcpadCE document found');
         return;
     }
 
@@ -910,7 +910,7 @@ async function runPdfExportCommand(): Promise<void> {
 async function saveSourceHtml() {
     const activeEditor = vscode.window.activeTextEditor;
     if (!activeEditor) {
-        vscode.window.showErrorMessage('No active CalcPad document found');
+        vscode.window.showErrorMessage('No active CalcpadCE document found');
         return;
     }
     try {
@@ -977,7 +977,7 @@ async function saveSourceHtml() {
 async function saveDocx() {
     const activeEditor = vscode.window.activeTextEditor;
     if (!activeEditor) {
-        vscode.window.showErrorMessage('No active CalcPad document found');
+        vscode.window.showErrorMessage('No active CalcpadCE document found');
         return;
     }
     try {
@@ -1129,7 +1129,7 @@ async function showPreview(kind: 'regular' | 'unwrapped', scrollToLine?: number)
 
     const panel = vscode.window.createWebviewPanel(
         unwrapped ? 'htmlPreviewUnwrapped' : 'htmlPreview',
-        unwrapped ? 'CalcPad Preview Unwrapped' : 'CalcPad Preview',
+        unwrapped ? 'CalcpadCE Preview Unwrapped' : 'CalcpadCE Preview',
         unwrapped && wrappedPanel ? vscode.ViewColumn.Active : vscode.ViewColumn.Beside,
         {
             enableScripts: true,
@@ -1199,15 +1199,15 @@ export async function activate(context: vscode.ExtensionContext) {
         extensionContext = context;
         
         // Create output channel for debugging
-        outputChannel = vscode.window.createOutputChannel('CalcPad Extension');
+        outputChannel = vscode.window.createOutputChannel('CalcpadCE Extension');
         outputChannel.appendLine('CalcPad extension activated');
 
         // Create dedicated output channels for HTML
-        calcpadOutputHtmlChannel = vscode.window.createOutputChannel('Calcpad Output HTML');
-        calcpadWebviewConsoleChannel = vscode.window.createOutputChannel('Calcpad Webview Console');
+        calcpadOutputHtmlChannel = vscode.window.createOutputChannel('CalcpadCE Output HTML');
+        calcpadWebviewConsoleChannel = vscode.window.createOutputChannel('CalcpadCE Webview Console');
 
         // Create debug channel for linter/highlighter
-        const serverDebugChannel = vscode.window.createOutputChannel('CalcPad Server Debug');
+        const serverDebugChannel = vscode.window.createOutputChannel('CalcpadCE Server Debug');
 
         outputChannel.appendLine('Initializing settings manager...');
         const settingsManager = CalcpadSettingsManager.getInstance(context);
@@ -1267,7 +1267,7 @@ export async function activate(context: vscode.ExtensionContext) {
                         serverDebugChannel.appendLine('[ServerManager] Server crashed 3 times — stopping auto-restart');
                         serverDebugChannel.appendLine('[ServerManager] Last crash output:\n' + crashOutput);
                         vscode.window.showErrorMessage(
-                            'CalcPad server crashed repeatedly (possibly due to your file). Use the refresh button to restart.',
+                            'CalcpadCE server crashed repeatedly (possibly due to your file). Use the refresh button to restart.',
                             'Show Debug Output'
                         ).then(choice => {
                             if (choice === 'Show Debug Output') {
@@ -1296,9 +1296,9 @@ export async function activate(context: vscode.ExtensionContext) {
 
                         if (blocked) {
                             vscode.window.showErrorMessage(
-                                'CalcPad: Windows blocked Calcpad.Server.exe. ' +
+                                'CalcpadCE: Windows blocked Calcpad.Server.exe. ' +
                                 'Unblock the file (right-click → Properties → Unblock) ' +
-                                'then click the CalcPad refresh button to retry.',
+                                'then click the CalcpadCE refresh button to retry.',
                                 'Show Output'
                             ).then(choice => {
                                 if (choice === 'Show Output') {
@@ -1306,7 +1306,7 @@ export async function activate(context: vscode.ExtensionContext) {
                                 }
                             });
                         } else if (serverMode === 'local') {
-                            vscode.window.showErrorMessage(`CalcPad: Failed to start local server: ${message}`);
+                            vscode.window.showErrorMessage(`CalcpadCE: Failed to start local server: ${message}`);
                         } else {
                             // Auto mode. Falling back to remote only makes
                             // sense if the user actually configured a remote
@@ -1316,7 +1316,7 @@ export async function activate(context: vscode.ExtensionContext) {
                             const remoteUrl = settingsManager.getRemoteServerUrl();
                             if (!remoteUrl || remoteUrl.length === 0) {
                                 vscode.window.showErrorMessage(
-                                    `CalcPad: Bundled server failed to start and no remote URL is configured (${message}).`,
+                                    `CalcpadCE: Bundled server failed to start and no remote URL is configured (${message}).`,
                                     'Show Output',
                                 ).then(choice => {
                                     if (choice === 'Show Output') serverDebugChannel.show();
@@ -1331,7 +1331,7 @@ export async function activate(context: vscode.ExtensionContext) {
                     outputChannel.appendLine(`Dotnet resolution failed: ${message}`);
                 });
             } else if (serverMode === 'local') {
-                vscode.window.showErrorMessage('CalcPad: Server mode is "local" but CalcpadServer.dll was not found in the extension.');
+                vscode.window.showErrorMessage('CalcpadCE: Server mode is "local" but CalcpadServer.dll was not found in the extension.');
             } else {
                 outputChannel.appendLine('No bundled DLL found, using remote API');
             }
@@ -1550,7 +1550,7 @@ export async function activate(context: vscode.ExtensionContext) {
     );
 
     const disposable = vscode.commands.registerCommand('vscode-calcpad.activate', () => {
-        vscode.window.showInformationMessage('CalcPad activated!');
+        vscode.window.showInformationMessage('CalcpadCE activated!');
     });
 
     const previewCommand = vscode.commands.registerCommand('vscode-calcpad.previewHtml', () => {
@@ -1662,7 +1662,7 @@ export async function activate(context: vscode.ExtensionContext) {
     const viewWebviewSourceCommand = vscode.commands.registerCommand('vscode-calcpad.viewWebviewSource', async () => {
         const inspectPanel = (unwrappedPanel && unwrappedPanel.active ? unwrappedPanel : wrappedPanel) ?? unwrappedPanel;
         if (!inspectPanel) {
-            vscode.window.showWarningMessage('No active CalcPad preview to inspect.');
+            vscode.window.showWarningMessage('No active CalcpadCE preview to inspect.');
             return;
         }
         webviewSourceHtml = inspectPanel.webview.html;
@@ -1690,7 +1690,7 @@ export async function activate(context: vscode.ExtensionContext) {
         outputChannel.appendLine('[Stop] Manual server stop triggered');
         if (!serverManager) {
             outputChannel.appendLine('[Stop] No serverManager available');
-            vscode.window.showInformationMessage('CalcPad server is not configured.');
+            vscode.window.showInformationMessage('CalcpadCE server is not configured.');
             return;
         }
         // Don't gate on `isRunning` — that flag only reflects whether *this*
@@ -1707,13 +1707,13 @@ export async function activate(context: vscode.ExtensionContext) {
             outputChannel.appendLine(`[Stop] Server stopped successfully (wasRunning=${wasRunning})`);
             vscode.window.showInformationMessage(
                 wasRunning
-                    ? 'CalcPad server stopped. Use the refresh button to restart.'
-                    : 'CalcPad server stopped via lock file. Use the refresh button to restart.',
+                    ? 'CalcpadCE server stopped. Use the refresh button to restart.'
+                    : 'CalcpadCE server stopped via lock file. Use the refresh button to restart.',
             );
         } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
             outputChannel.appendLine(`[Stop] Server stop failed: ${msg}`);
-            vscode.window.showErrorMessage(`CalcPad: Failed to stop server: ${msg}`);
+            vscode.window.showErrorMessage(`CalcpadCE: Failed to stop server: ${msg}`);
         }
     });
 
@@ -1741,7 +1741,7 @@ export async function activate(context: vscode.ExtensionContext) {
                         'then click refresh again.'
                     );
                 } else {
-                    vscode.window.showErrorMessage(`CalcPad: Server restart failed: ${msg}`);
+                    vscode.window.showErrorMessage(`CalcpadCE: Server restart failed: ${msg}`);
                 }
                 return;
             }
@@ -1759,7 +1759,7 @@ export async function activate(context: vscode.ExtensionContext) {
                 } catch (err) {
                     const msg = err instanceof Error ? err.message : String(err);
                     outputChannel.appendLine(`[Refresh] Server restart failed: ${msg}`);
-                    vscode.window.showErrorMessage(`CalcPad: Server restart failed: ${msg}`);
+                    vscode.window.showErrorMessage(`CalcpadCE: Server restart failed: ${msg}`);
                     return;
                 }
             }
@@ -1781,11 +1781,11 @@ export async function activate(context: vscode.ExtensionContext) {
     const prettifyDocumentCommand = vscode.commands.registerCommand('vscode-calcpad.prettifyDocument', async () => {
         const editor = vscode.window.activeTextEditor;
         if (!editor) {
-            vscode.window.showInformationMessage('CalcPad: open a .cpd file to prettify.');
+            vscode.window.showInformationMessage('CalcpadCE: open a .cpd file to prettify.');
             return;
         }
         if (editor.document.languageId !== 'calcpad' && editor.document.languageId !== 'plaintext') {
-            vscode.window.showInformationMessage('CalcPad: prettify is only available for CalcPad documents.');
+            vscode.window.showInformationMessage('CalcpadCE: prettify is only available for CalcpadCE documents.');
             return;
         }
 
@@ -1798,7 +1798,7 @@ export async function activate(context: vscode.ExtensionContext) {
         try {
             const response = await apiClient.prettify(editor.document.getText(), indentUnit, trim);
             if (!response) {
-                vscode.window.showErrorMessage('CalcPad: prettify request failed (no response from server).');
+                vscode.window.showErrorMessage('CalcpadCE: prettify request failed (no response from server).');
                 return;
             }
             const fullRange = new vscode.Range(
@@ -1807,12 +1807,12 @@ export async function activate(context: vscode.ExtensionContext) {
             );
             const ok = await editor.edit(eb => eb.replace(fullRange, response.content));
             if (!ok) {
-                vscode.window.showErrorMessage('CalcPad: prettify edit was rejected by the editor.');
+                vscode.window.showErrorMessage('CalcpadCE: prettify edit was rejected by the editor.');
             }
         } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
             outputChannel.appendLine('[Prettify] Error: ' + msg);
-            vscode.window.showErrorMessage('CalcPad: prettify failed — ' + msg);
+            vscode.window.showErrorMessage('CalcpadCE: prettify failed — ' + msg);
         }
     });
 
@@ -1947,7 +1947,7 @@ export async function activate(context: vscode.ExtensionContext) {
             outputChannel.appendLine(`FATAL ERROR during activation: ${error}`);
         }
         // Still try to show the error to user
-        vscode.window.showErrorMessage(`CalcPad extension failed to activate: ${error instanceof Error ? error.message : 'Unknown error'}`);
+        vscode.window.showErrorMessage(`CalcpadCE extension failed to activate: ${error instanceof Error ? error.message : 'Unknown error'}`);
         throw error; // Re-throw to mark extension as failed
     }
 }

--- a/Calcpad.Web/frontend/vscode-calcpad/src/installFont.ts
+++ b/Calcpad.Web/frontend/vscode-calcpad/src/installFont.ts
@@ -89,7 +89,7 @@ export async function maybePromptInstall(context: vscode.ExtensionContext): Prom
     }
 
     const choice = await vscode.window.showInformationMessage(
-        'CalcPad recommends the JuliaMono font for better math symbol rendering in .cpd files. Install now?',
+        'CalcpadCE recommends the JuliaMono font for better math symbol rendering in .cpd files. Install now?',
         'Install',
         'Not Now',
         "Don't Ask Again"


### PR DESCRIPTION
Updating user-facing naming consistancy to CalcpadCE, causing PDF message to appear in calcpad-desktop and cleaning up HTML/docx export extension in save dialog, adding tooltips in settings, and fixing some highlighter bugs that were discovered by reviewing Examples folder. Also included writing tests for fixed highligther behavior.