### PR TITLE
Add .csproj.lscache to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -386,3 +386,6 @@ wkhtmltopdf.exe
 
 # Claude
 **.claude/settings.local.json
+
+# VSCode C# Plugin
+*.csproj.lscache


### PR DESCRIPTION
Seems like this entry got lost during some .gitignore merge conflicts.