### PR TITLE
Add #UI directive, portable path roots, and cpdz bundling support to Core

### DIFF
--- a/Calcpad.Api/PyCalcpad/Parser.cs
+++ b/Calcpad.Api/PyCalcpad/Parser.cs
@@ -41,7 +41,8 @@ namespace PyCalcpad
             var code = Reader.Read(inputFileName);
             var macroParser = new MacroParser
             {
-                Include = Reader.Include
+                Include = Reader.Include,
+                SourceFilePath = inputFileName
             };
             var hasMacroErrors = macroParser.Parse(code, out var unwrappedCode, null, 0, true);
             string htmlResult;
@@ -54,7 +55,9 @@ namespace PyCalcpad
             }
             ExpressionParser parser = new()
             {
-                Settings = ConvertSettings(Settings)
+                Settings = ConvertSettings(Settings),
+                SourceFilePath = inputFileName,
+                PathRoots = macroParser.PathRoots
             };
             parser.Parse(unwrappedCode, true, ext == ".docx");
             htmlResult = parser.HtmlResult;

--- a/Calcpad.Cli/Program.cs
+++ b/Calcpad.Cli/Program.cs
@@ -374,7 +374,8 @@ namespace Calcpad.Cli
                 var code = CalcpadReader.Read(fileName);
                 var macroParser = new MacroParser
                 {
-                    Include = CalcpadReader.Include
+                    Include = CalcpadReader.Include,
+                    SourceFilePath = fileName
                 };
                 var hasMacroErrors = macroParser.Parse(code, out var unwrappedCode, null, 0, true);
                 string htmlResult;
@@ -387,7 +388,9 @@ namespace Calcpad.Cli
                 }
                 ExpressionParser parser = new()
                 {
-                    Settings = settings
+                    Settings = settings,
+                    SourceFilePath = fileName,
+                    PathRoots = macroParser.PathRoots
                 };
                 parser.Parse(unwrappedCode, true, ext == ".docx");
                 htmlResult = parser.HtmlResult;

--- a/Calcpad.Core/BaseTypes/Unit.cs
+++ b/Calcpad.Core/BaseTypes/Unit.cs
@@ -22,12 +22,11 @@ namespace Calcpad.Core
         private readonly double[] _factors;
         private int Length => _powers.Length;
 
-        private static bool _isUs;
         private static readonly string CompositeUnitChars = Calculator.NegChar + "∕^";
         private static readonly string[] Names = ["g", "m", "s", "A", "°C", "mol", "cd", "rad", ""];
         private static readonly Unit[] ForceUnits = new Unit[9], ForceUnits_US = new Unit[9];
         private static readonly FrozenDictionary<Unit, Unit> ElectricalUnits;
-        private static FrozenDictionary<string, Unit> Units;
+        private static readonly FrozenDictionary<string, Unit> Units;
         private static readonly string[] UnitNames =
         [
             "therm",
@@ -43,23 +42,18 @@ namespace Calcpad.Core
             "bu",
             "tonf"
         ];
+        // These 12 names (plus the "ton_f" alias) are the only ones that differ between the US
+        // and UK unit systems — resolved per-lookup from isUs rather than baked into Units, so
+        // the table itself can stay immutable and safe for concurrent readers.
+        private static readonly HashSet<string> AmbiguousUnitNames = new(UnitNames, StringComparer.Ordinal) { "ton_f" };
 
-        internal static bool IsUs
+        private static string ResolveKey(string text, bool isUs)
         {
-            get => _isUs;
-            set
-            {
-                _isUs = value;
-                var suffix = value ? "_US" : "_UK";
-                var units = new Dictionary<string, Unit>(Units);
-                for (var i = 0; i < UnitNames.Length; ++i)
-                {
-                    ref var s = ref UnitNames[i];
-                    units[s] = new(Units[s + suffix], s);
-                }
-                units["ton_f"] = new(Units["tonf"], "ton_f");
-                Units = units.ToFrozenDictionary();
-            }
+            if (!AmbiguousUnitNames.Contains(text))
+                return text;
+
+            var baseName = text == "ton_f" ? "tonf" : text;
+            return baseName + (isUs ? "_US" : "_UK");
         }
 
         internal Field GetField()
@@ -307,10 +301,10 @@ namespace Calcpad.Core
             _factors = u._factors;
         }
 
-        internal static Unit Get(string text) => Units[text];
+        internal static Unit Get(string text, bool isUs) => Units[ResolveKey(text, isUs)];
 
-        internal static bool TryGet(string text, out Unit u) =>
-            Units.TryGetValue(text, out u);
+        internal static bool TryGet(string text, bool isUs, out Unit u) =>
+            Units.TryGetValue(ResolveKey(text, isUs), out u);
 
         private static string TemperatureToDelta(string s)
         {

--- a/Calcpad.Core/Calculator/Calculator.cs
+++ b/Calcpad.Core/Calculator/Calculator.cs
@@ -32,11 +32,13 @@ namespace Calcpad.Core
             Math.PI / 200.0
         ];
 
+        // Angle units never differ between US/UK, and this table is built at type-load,
+        // before any request's setting exists, so the isUs argument is irrelevant here.
         protected static readonly Unit[] AngleUnits =
         [
-            Unit.Get("deg"),
-            Unit.Get("rad"),
-            Unit.Get("grad")
+            Unit.Get("deg", false),
+            Unit.Get("rad", false),
+            Unit.Get("grad", false)
         ];
 
         protected Function3[] Functions3 =

--- a/Calcpad.Core/Calculator/ComplexCalculator.cs
+++ b/Calcpad.Core/Calculator/ComplexCalculator.cs
@@ -163,7 +163,7 @@ namespace Calcpad.Core
         {
             CheckTrigFunctionUnits("phasor", b.Units);
             var u = b.Units;
-            var d = u is null ? 1d : u.ConvertTo(Unit.Get("rad"));
+            var d = u is null ? 1d : u.ConvertTo(Unit.Get("rad", false));
             var phi = b.A * d;
             var c = a.A * (Math.Cos(phi) + Complex.ImaginaryOne * Math.Sin(phi));
             return new ComplexValue(c, a.Units, a.IsUnit);
@@ -530,7 +530,7 @@ namespace Calcpad.Core
             new(value * FromRad[_degrees], AngleUnits[_degrees]) :
             new(value * FromRad[_degrees]);
 
-        protected static ComplexValue Timer(in ComplexValue _) => new(Timer(), Unit.Get("s"));
+        protected static ComplexValue Timer(in ComplexValue _) => new(Timer(), Unit.Get("s", false));
 
     }
 }

--- a/Calcpad.Core/Calculator/RealCalculator.cs
+++ b/Calcpad.Core/Calculator/RealCalculator.cs
@@ -518,6 +518,6 @@ namespace Calcpad.Core
             new(value * FromRad[_degrees], AngleUnits[_degrees]) :
             new(value * FromRad[_degrees]);
 
-        protected static RealValue Timer(in RealValue _) => new(Timer(), Unit.Get("s"));
+        protected static RealValue Timer(in RealValue _) => new(Timer(), Unit.Get("s", false));
     }
 }

--- a/Calcpad.Core/DirectiveDto.cs
+++ b/Calcpad.Core/DirectiveDto.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace Calcpad.Core
+{
+    /// <summary>A value the directive supplied that its own rules reject.</summary>
+    public readonly record struct DirectiveError<TKey>(TKey Key, string Message) where TKey : struct, Enum;
+
+    public abstract class DirectiveDto<TSelf, TKey>
+        where TSelf : DirectiveDto<TSelf, TKey>
+        where TKey : struct, Enum
+    {
+        private static readonly JsonSerializerOptions Options = new() { PropertyNameCaseInsensitive = true };
+
+        /// <summary>Recognized keys, derived from <typeparamref name="TKey"/> (case-insensitive).</summary>
+        public static readonly IReadOnlySet<string> KnownKeys =
+            new HashSet<string>(Enum.GetNames<TKey>(), StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>Deserializes the payload. Throws <see cref="JsonException"/> on malformed JSON or a wrong value type.</summary>
+        public static TSelf Parse(string json) => JsonSerializer.Deserialize<TSelf>(json, Options);
+
+        /// <summary>An entry for every supplied value that the directive rejects.</summary>
+        public IReadOnlyList<DirectiveError<TKey>> Validate()
+        {
+            var errors = new List<DirectiveError<TKey>>();
+            Validate(errors);
+            return errors;
+        }
+
+        protected abstract void Validate(List<DirectiveError<TKey>> errors);
+
+        protected static void CheckRange<T>(List<DirectiveError<TKey>> errors, TKey key, string name, T? value, double min, double? max) where T : struct, IConvertible
+        {
+            if (value is null)
+                return;
+
+            var d = value.Value.ToDouble(null);
+            if (d < min || max.HasValue && d > max.Value)
+                errors.Add(new(key, max.HasValue
+                    ? $"'{name}' must be between {min} and {max.Value}"
+                    : $"'{name}' must be at least {min}"));
+        }
+    }
+}

--- a/Calcpad.Core/ImageReferences.cs
+++ b/Calcpad.Core/ImageReferences.cs
@@ -1,0 +1,93 @@
+using System;
+using System.IO;
+using System.Text.RegularExpressions;
+
+namespace Calcpad.Core
+{
+    public static class ImageReferences
+    {
+        public static readonly Regex Source =
+            new(@"(<img\s[^>]*?src\s*=\s*[""'])([^""']+)([""'])",
+                RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        /// <summary>
+        /// A source that resolves on its own, wherever the document ends up: already absolute,
+        /// inline data, or fetched over the network.
+        /// </summary>
+        public static bool IsExternal(string src) =>
+            Path.IsPathRooted(src)
+            || src.StartsWith("data:", StringComparison.OrdinalIgnoreCase)
+            || src.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
+            || src.StartsWith("https://", StringComparison.OrdinalIgnoreCase)
+            || src.StartsWith("file:", StringComparison.OrdinalIgnoreCase);
+
+        internal static string ExpandSources(
+            string html,
+            PathRoots roots,
+            string documentDirectory,
+            Action<string> reportError)
+        {
+            var matches = Source.Matches(html);
+            if (matches.Count == 0)
+                return html;
+
+            for (var i = matches.Count - 1; i >= 0; --i)
+            {
+                var group = matches[i].Groups[2];
+                var expanded = Expand(group.Value, roots, documentDirectory, reportError);
+                if (expanded is not null)
+                    html = string.Concat(
+                        html.AsSpan(0, group.Index),
+                        expanded,
+                        html.AsSpan(group.Index + group.Length));
+            }
+            return html;
+        }
+
+        // Markdig percent-encodes a link destination, so an image written as Markdown
+        // (![alt]({library}/logo.png)) reaches us with its leading token escaped.
+        private static string DecodeLeadingToken(string src)
+        {
+            if (!src.StartsWith("%7B", StringComparison.OrdinalIgnoreCase))
+                return src;
+
+            var close = src.IndexOf("%7D", StringComparison.OrdinalIgnoreCase);
+            return close < 0
+                ? src
+                : string.Concat("{", src.AsSpan(3, close - 3), "}", src.AsSpan(close + 3));
+        }
+
+        private static string Expand(
+            string src,
+            PathRoots roots,
+            string documentDirectory,
+            Action<string> reportError)
+        {
+            if (IsExternal(src))
+                return null;
+
+            src = DecodeLeadingToken(src);
+            var hasToken = PathRoots.HasToken(src.AsSpan()) || PathRoots.IsUserToken(src.AsSpan());
+            if (!roots.TryExpand(src, out var expanded, out var error))
+            {
+                reportError(error);
+                return null;
+            }
+            try
+            {
+                expanded = Environment.ExpandEnvironmentVariables(expanded);
+                if (!hasToken && !Path.IsPathRooted(expanded))
+                    return expanded == src ? null : expanded;
+
+                var full = string.IsNullOrEmpty(documentDirectory)
+                    ? Path.GetFullPath(expanded)
+                    : Path.GetFullPath(expanded, documentDirectory);
+                return full.Replace('\\', '/');
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/Calcpad.Core/Messages.Designer.cs
+++ b/Calcpad.Core/Messages.Designer.cs
@@ -439,6 +439,15 @@ namespace Calcpad.Core {
         }
 
         // / <summary>
+        // /   Looks up a localized string similar to Error in &quot;{0}&quot;: {1}.
+        // / </summary>
+        public static string Error_in_0_1 {
+            get {
+                return ResourceManager.GetString("Error_in_0_1", resourceCulture);
+            }
+        }
+
+        // / <summary>
         // /   Looks up a localized string similar to Error parsing &quot;{0}&quot; as number..
         // / </summary>
         public static string Error_parsing_0_as_number {
@@ -709,11 +718,11 @@ namespace Calcpad.Core {
         }
 
         // / <summary>
-        // /   Looks up a localized string similar to Invalid settings JSON: {0}..
+        // /   Looks up a localized string similar to Invalid JSON in {0}..
         // / </summary>
-        public static string Invalid_settings_0 {
+        public static string Invalid_JSON_in_0 {
             get {
-                return ResourceManager.GetString("Invalid_settings_0", resourceCulture);
+                return ResourceManager.GetString("Invalid_JSON_in_0", resourceCulture);
             }
         }
 
@@ -1632,6 +1641,132 @@ namespace Calcpad.Core {
         public static string Vectors_and_matrices_are_not_supported_in_complex_mode {
             get {
                 return ResourceManager.GetString("Vectors_and_matrices_are_not_supported_in_complex_mode", resourceCulture);
+            }
+        }
+
+        // / <summary>
+        // /   Looks up a localized string similar to Improper format for #UI keyword. Missing closing brace &apos;}&apos;..
+        // / </summary>
+        public static string Improper_format_for_UI_keyword_Missing_closing_brace {
+            get {
+                return ResourceManager.GetString("Improper_format_for_UI_keyword_Missing_closing_brace", resourceCulture);
+            }
+        }
+
+        // / <summary>
+        // /   Looks up a localized string similar to The #UI keyword requires a variable assignment..
+        // / </summary>
+        public static string The_UI_keyword_requires_a_variable_assignment {
+            get {
+                return ResourceManager.GetString("The_UI_keyword_requires_a_variable_assignment", resourceCulture);
+            }
+        }
+
+        // / <summary>
+        // /   Looks up a localized string similar to #UI directives do not support expressions..
+        // / </summary>
+        public static string UI_directives_do_not_support_expressions {
+            get {
+                return ResourceManager.GetString("UI_directives_do_not_support_expressions", resourceCulture);
+            }
+        }
+
+        // / <summary>
+        // /   Looks up a localized string similar to Only numbers are supported by the #UI keyword..
+        // / </summary>
+        public static string Only_numbers_are_supported_by_the_UI_keyword {
+            get {
+                return ResourceManager.GetString("Only_numbers_are_supported_by_the_UI_keyword", resourceCulture);
+            }
+        }
+
+        // / <summary>
+        // /   Looks up a localized string similar to #UI {0} requires both &apos;keys&apos; and &apos;values&apos; arrays..
+        // / </summary>
+        public static string The_UI_0_requires_both_keys_and_values_arrays {
+            get {
+                return ResourceManager.GetString("The_UI_0_requires_both_keys_and_values_arrays", resourceCulture);
+            }
+        }
+
+        // / <summary>
+        // /   Looks up a localized string similar to #UI {0} has {1} keys but {2} values, the &apos;keys&apos; and &apos;values&apos; arrays must have the same length..
+        // / </summary>
+        public static string The_UI_0_keys_and_values_arrays_must_have_the_same_length {
+            get {
+                return ResourceManager.GetString("The_UI_0_keys_and_values_arrays_must_have_the_same_length", resourceCulture);
+            }
+        }
+
+        // / <summary>
+        // /   Looks up a localized string similar to &apos;{0}&apos; is not a recognized #UI type, expected one of {1}..
+        // / </summary>
+        public static string The_UI_type_0_is_not_recognized_expected_one_of_1 {
+            get {
+                return ResourceManager.GetString("The_UI_type_0_is_not_recognized_expected_one_of_1", resourceCulture);
+            }
+        }
+
+        // / <summary>
+        // /   Looks up a localized string similar to #UI &apos;{0}&apos; must not be negative..
+        // / </summary>
+        public static string The_UI_0_must_not_be_negative {
+            get {
+                return ResourceManager.GetString("The_UI_0_must_not_be_negative", resourceCulture);
+            }
+        }
+
+        // / <summary>
+        // /   Looks up a localized string similar to #UI &apos;{0}&apos; has {1} entries but the grid has {2} {3}..
+        // / </summary>
+        public static string The_UI_0_has_1_entries_but_the_grid_has_2_3 {
+            get {
+                return ResourceManager.GetString("The_UI_0_has_1_entries_but_the_grid_has_2_3", resourceCulture);
+            }
+        }
+
+        // / <summary>
+        // /   Looks up a localized string similar to A #UI value has the wrong type..
+        // / </summary>
+        public static string A_UI_value_has_the_wrong_type {
+            get {
+                return ResourceManager.GetString("A_UI_value_has_the_wrong_type", resourceCulture);
+            }
+        }
+
+        // / <summary>
+        // /   Looks up a localized string similar to {0} requires a path..
+        // / </summary>
+        public static string Missing_path_value_0 {
+            get {
+                return ResourceManager.GetString("Missing_path_value_0", resourceCulture);
+            }
+        }
+
+        // / <summary>
+        // /   Looks up a localized string similar to {0} is already declared in this document..
+        // / </summary>
+        public static string Duplicate_path_declaration_0 {
+            get {
+                return ResourceManager.GetString("Duplicate_path_declaration_0", resourceCulture);
+            }
+        }
+
+        // / <summary>
+        // /   Looks up a localized string similar to {0} is not declared. Add {1} before this line..
+        // / </summary>
+        public static string Path_root_not_declared_0_1 {
+            get {
+                return ResourceManager.GetString("Path_root_not_declared_0_1", resourceCulture);
+            }
+        }
+
+        // / <summary>
+        // /   Looks up a localized string similar to {0} folder not found: {1}..
+        // / </summary>
+        public static string Path_root_folder_not_found_0_1 {
+            get {
+                return ResourceManager.GetString("Path_root_folder_not_found_0_1", resourceCulture);
             }
         }
     }

--- a/Calcpad.Core/Messages.resx
+++ b/Calcpad.Core/Messages.resx
@@ -331,6 +331,9 @@
   <data name="Error_in_0_on_line_1_2" xml:space="preserve">
         <value>Error in "{0}" on line {1}: {2}</value>
     </data>
+  <data name="Error_in_0_1" xml:space="preserve">
+        <value>Error in "{0}": {1}</value>
+    </data>
   <data name="Number_of_iterations_exceeds_the_maximum_0" xml:space="preserve">
         <value>Number of iterations exceeds the maximum {0}.&lt;/p&gt;</value>
     </data>
@@ -526,8 +529,8 @@
   <data name="Invalid_keyword_0" xml:space="preserve">
     <value>Invalid keyword: {0}.</value>
   </data>
-  <data name="Invalid_settings_0" xml:space="preserve">
-    <value>Invalid settings JSON: {0}.</value>
+  <data name="Invalid_JSON_in_0" xml:space="preserve">
+    <value>Invalid JSON in {0}.</value>
   </data>
   <data name="_must_be_matrix" xml:space="preserve">
     <value> must be matrix.</value>
@@ -582,5 +585,47 @@
   </data>
   <data name="CannotModifyConstant" xml:space="preserve">
     <value>Cannot modify constant "{0}".</value>
+  </data>
+  <data name="Improper_format_for_UI_keyword_Missing_closing_brace" xml:space="preserve">
+    <value>Improper format for #UI keyword. Missing closing brace '}'.</value>
+  </data>
+  <data name="The_UI_keyword_requires_a_variable_assignment" xml:space="preserve">
+    <value>The #UI keyword requires a variable assignment.</value>
+  </data>
+  <data name="UI_directives_do_not_support_expressions" xml:space="preserve">
+    <value>#UI directives do not support expressions.</value>
+  </data>
+  <data name="Only_numbers_are_supported_by_the_UI_keyword" xml:space="preserve">
+    <value>Only numbers are supported by the #UI keyword.</value>
+  </data>
+  <data name="The_UI_0_requires_both_keys_and_values_arrays" xml:space="preserve">
+    <value>#UI {0} requires both 'keys' and 'values' arrays.</value>
+  </data>
+  <data name="The_UI_0_keys_and_values_arrays_must_have_the_same_length" xml:space="preserve">
+    <value>#UI {0} has {1} keys but {2} values, the 'keys' and 'values' arrays must have the same length.</value>
+  </data>
+  <data name="The_UI_type_0_is_not_recognized_expected_one_of_1" xml:space="preserve">
+    <value>'{0}' is not a recognized #UI type, expected one of {1}.</value>
+  </data>
+  <data name="The_UI_0_must_not_be_negative" xml:space="preserve">
+    <value>#UI '{0}' must not be negative.</value>
+  </data>
+  <data name="The_UI_0_has_1_entries_but_the_grid_has_2_3" xml:space="preserve">
+    <value>#UI '{0}' has {1} entries but the grid has {2} {3}.</value>
+  </data>
+  <data name="A_UI_value_has_the_wrong_type" xml:space="preserve">
+    <value>A #UI value has the wrong type.</value>
+  </data>
+  <data name="Missing_path_value_0" xml:space="preserve">
+    <value>{0} requires a path.</value>
+  </data>
+  <data name="Duplicate_path_declaration_0" xml:space="preserve">
+    <value>{0} is already declared in this document.</value>
+  </data>
+  <data name="Path_root_not_declared_0_1" xml:space="preserve">
+    <value>{0} is not declared. Add {1} before this line.</value>
+  </data>
+  <data name="Path_root_folder_not_found_0_1" xml:space="preserve">
+    <value>{0} folder not found: {1}.</value>
   </data>
 </root>

--- a/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.Condition.cs
+++ b/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.Condition.cs
@@ -84,8 +84,8 @@ namespace Calcpad.Core
                 }
 
                 var type = (Types)(index + 1);
-                _keywordLength = GetKeywordLength(type);
                 _keyword = GetConditinalKeyword(type);
+                _keywordLength = _keyword.AsSpan().TrimEnd().Length;
                 IsUnchecked = type == Types.If || type == Types.ElseIf;
                 if (type > Types.If && type < Types.While && _count == 0)
                     throw Exceptions.ConditionNotInitialized();
@@ -121,6 +121,15 @@ namespace Calcpad.Core
 
             internal void Check(Complex value)
             {
+                var result = IsTrue(value);
+                if (result)
+                    IsFound = true;
+                Change(result, Type);
+                IsUnchecked = false;
+            }
+
+            internal static bool IsTrue(Complex value)
+            {
                 if (!value.IsReal)
                     throw Exceptions.ConditionComplex();
 
@@ -128,11 +137,7 @@ namespace Calcpad.Core
                 if (double.IsNaN(d) || double.IsInfinity(d))
                     throw Exceptions.ConditionResultInvalid(d.ToString());
 
-                var result = Math.Abs(d) > 1e-12;
-                if (result)
-                    IsFound = true;
-                Change(result, Type);
-                IsUnchecked = false;
+                return Math.Abs(d) > 1e-12;
             }
 
             internal void Check() => IsUnchecked = false;
@@ -144,19 +149,6 @@ namespace Calcpad.Core
                 if (string.IsNullOrEmpty(_keyword))
                     return _keyword;
                 return $"<span class=\"cond\">{_keyword}</span>";
-            }
-
-            private static int GetKeywordLength(Types type)
-            {
-                return type switch
-                {
-                    Types.If => 3,
-                    Types.Else => 5,
-                    Types.While => 6,
-                    Types.EndIf => 7,
-                    Types.ElseIf => 8,
-                    _ => 0,
-                };
             }
 
             private static string GetConditinalKeyword(Types type)

--- a/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.Keywords.cs
+++ b/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.Keywords.cs
@@ -16,9 +16,16 @@ namespace Calcpad.Core
             Show,
             Pre,
             Post,
+            End_Hide,
+            End_Show,
+            End_Pre,
+            End_Post,
             Val,
             Equ,
             Noc,
+            End_Val,
+            End_Equ,
+            End_Noc,
             NoSub,
             NoVar,
             VarSub,
@@ -51,6 +58,9 @@ namespace Calcpad.Core
             Phasor,
             Complex,
             Settings,
+            Ui,
+            ProjectPath,
+            LibraryPath,
             SkipLine
         }
         private enum KeywordResult
@@ -110,6 +120,12 @@ namespace Calcpad.Core
             return Keyword.None;
         }
 
+        /// <summary>
+        /// The number of characters a keyword occupies in the source line, including the leading '#'.
+        /// </summary>
+        private static int KeywordLength(Keyword keyword) =>
+            KeywordNames[(int)keyword - 1].Length + 1;
+
         KeywordResult ParseKeyword(ReadOnlySpan<char> s, ref Keyword keyword)
         {
             if (_isPausedByUser)
@@ -122,30 +138,27 @@ namespace Calcpad.Core
 
             switch (keyword)
             {
-                case Keyword.Hide:
-                    _isVisible = false;
-                    break;
-                case Keyword.Show:
-                    _isVisible = true;
-                    break;
-                case Keyword.Pre:
-                    _isVisible = !_calculate;
-                    break;
-                case Keyword.Post:
-                    _isVisible = _calculate;
+                case Keyword.Hide: SetVisibility(s, keyword, Settings.Math.ShowHiddenOutput && _isVisible); break;
+                case Keyword.Show: SetVisibility(s, keyword, true); break;
+                case Keyword.Pre: SetVisibility(s, keyword, !ForPrint); break;
+                case Keyword.Post: SetVisibility(s, keyword, !EnableUi); break;
+                case Keyword.End_Hide:
+                case Keyword.End_Show:
+                case Keyword.End_Pre:
+                case Keyword.End_Post:
+                    _isVisible = _visibilityStack.Count > 0 ? _visibilityStack.Pop() : true;
                     break;
                 case Keyword.Input:
                     return ParseKeywordInput();
                 case Keyword.Pause:
                     return ParseKeywordPause();
-                case Keyword.Val:
-                    _isVal = 1;
-                    break;
-                case Keyword.Equ:
-                    _isVal = 0;
-                    break;
-                case Keyword.Noc:
-                    _isVal = -1;
+                case Keyword.Val: SetOutputMode(s, keyword, 1); break;
+                case Keyword.Equ: SetOutputMode(s, keyword, 0); break;
+                case Keyword.Noc: SetOutputMode(s, keyword, -1); break;
+                case Keyword.End_Val:
+                case Keyword.End_Equ:
+                case Keyword.End_Noc:
+                    _isVal = _outputModeStack.Count > 0 ? _outputModeStack.Pop() : 0;
                     break;
                 case Keyword.NoSub:
                     _parser.VariableSubstitution = MathParser.VariableSubstitutionOptions.VariablesOnly;
@@ -218,12 +231,61 @@ namespace Calcpad.Core
                 case Keyword.Settings:
                     ParseKeywordSettings(s);
                     break;
+                case Keyword.Ui:
+                    return ParseKeywordUi(s);
+                case Keyword.ProjectPath:
+                case Keyword.LibraryPath:
+                    ParseKeywordPathRoot(s);
+                    break;
                 default:
                     if (keyword != Keyword.Global && keyword != Keyword.Local)
                         return KeywordResult.None;
                     break;
             }
             return KeywordResult.Continue;
+        }
+
+        private void SetVisibility(ReadOnlySpan<char> s, Keyword keyword, bool value)
+        {
+            _visibilityStack.Push(_isVisible);
+            if (IsDirectiveConditionMet(s, keyword))
+                _isVisible = value;
+        }
+
+        private void SetOutputMode(ReadOnlySpan<char> s, Keyword keyword, int value)
+        {
+            _outputModeStack.Push(_isVal);
+            if (IsDirectiveConditionMet(s, keyword))
+                _isVal = value;
+        }
+
+        private bool IsDirectiveConditionMet(ReadOnlySpan<char> s, Keyword keyword)
+        {
+            if (!_condition.IsSatisfied)
+                return false;
+
+            var kwdLength = KeywordLength(keyword);
+            if (s.Length <= kwdLength)
+                return true;
+
+            var expr = s[kwdLength..].Trim();
+            if (expr.IsWhiteSpace())
+                return true;
+
+            if (!_calculate)
+                return false;
+
+            try
+            {
+                _parser.Parse(expr);
+                _parser.Calculate();
+                return Condition.IsTrue(_parser.Result);
+            }
+            catch (MathParserException ex)
+            {
+                AppendError(s.ToString(), ex.Message, _currentLine);
+                return false;
+            }
         }
 
         KeywordResult ParseKeywordInput()
@@ -270,9 +332,10 @@ namespace Calcpad.Core
 
         private void ParseKeywordRound(ReadOnlySpan<char> s)
         {
-            if (s.Length > 6)
+            var kwdLength = KeywordLength(Keyword.Round);
+            if (s.Length > kwdLength)
             {
-                var expr = s[6..].Trim();
+                var expr = s[kwdLength..].Trim();
                 if (expr.SequenceEqual("default"))
                     Settings.Math.Decimals = _decimals;
                 else if (int.TryParse(expr, out int n))
@@ -297,8 +360,9 @@ namespace Calcpad.Core
 
         private void ParseKeywordRepeat(ReadOnlySpan<char> s)
         {
-            ReadOnlySpan<char> expression = s.Length > 7 ? // #repeat - 7
-                s[7..].Trim() :
+            var kwdLength = KeywordLength(Keyword.Repeat);
+            ReadOnlySpan<char> expression = s.Length > kwdLength ?
+                s[kwdLength..].Trim() :
                 [];
 
             if (_calculate)
@@ -349,8 +413,9 @@ namespace Calcpad.Core
 
         private void ParseKeywordFor(ReadOnlySpan<char> s)
         {
-            ReadOnlySpan<char> expression = s.Length > 4 ? // #for - 4
-                s[4..].Trim() :
+            var kwdLength = KeywordLength(Keyword.For);
+            ReadOnlySpan<char> expression = s.Length > kwdLength ?
+                s[kwdLength..].Trim() :
                 [];
 
             if (expression.IsWhiteSpace())
@@ -428,8 +493,9 @@ namespace Calcpad.Core
 
         private void ParseKeywordWhile(ReadOnlySpan<char> s)
         {
-            ReadOnlySpan<char> expression = s.Length > 6 ? // #while - 6
-                s[7..].Trim() :
+            var kwdLength = KeywordLength(Keyword.While);
+            ReadOnlySpan<char> expression = s.Length > kwdLength ?
+                s[kwdLength..].Trim() :
                 [];
 
             if (expression.IsWhiteSpace())
@@ -599,9 +665,10 @@ namespace Calcpad.Core
 
         private void ParseKeywordFormat(ReadOnlySpan<char> s)
         {
-            if (s.Length > 7)
+            var kwdLength = KeywordLength(Keyword.Format);
+            if (s.Length > kwdLength)
             {
-                var expr = s[7..].Trim();
+                var expr = s[kwdLength..].Trim();
                 if (expr.SequenceEqual("default"))
                     Settings.Math.FormatString = null;
                 else
@@ -616,6 +683,28 @@ namespace Calcpad.Core
             else
                 Settings.Math.FormatString = null;
         }
+        private void ParseKeywordPathRoot(ReadOnlySpan<char> s)
+        {
+            // MacroParser already declared and validated this line against the folder of the file
+            // that wrote it — which this flattened text no longer identifies — so its answer wins.
+            if (_hasInheritedPathRoots)
+                return;
+
+            PathRoots.IsDeclaration(s, out var isProject, out var start, out var length);
+            if (length == 0)
+            {
+                AppendError(s.ToString(), string.Format(Messages.Missing_path_value_0,
+                    isProject ? "#ProjectPath" : "#LibraryPath"), _currentLine);
+                return;
+            }
+
+            var rawValue = s.Slice(start, length).ToString();
+            var declaringDir = !string.IsNullOrEmpty(SourceFilePath)
+                ? System.IO.Path.GetDirectoryName(SourceFilePath) : null;
+            if (!_pathRoots.TryDeclare(isProject, rawValue, declaringDir, out var error))
+                AppendError(s.ToString(), error, _currentLine);
+        }
+
         private const string SettingsKeyword = "#settings";
 
         private void ParseKeywordSettings(ReadOnlySpan<char> s)
@@ -623,7 +712,7 @@ namespace Calcpad.Core
             var json = s[SettingsKeyword.Length..].Trim();
             if (json.IsEmpty)
             {
-                AppendError(s.ToString(), string.Format(Messages.Invalid_settings_0, json.ToString()), _currentLine);
+                AppendError(s.ToString(), string.Format(Messages.Invalid_JSON_in_0, SettingsKeyword), _currentLine);
                 return;
             }
             try
@@ -645,7 +734,7 @@ namespace Calcpad.Core
             }
             catch (JsonException)
             {
-                AppendError(s.ToString(), string.Format(Messages.Invalid_settings_0, json.ToString()), _currentLine);
+                AppendError(s.ToString(), string.Format(Messages.Invalid_JSON_in_0, SettingsKeyword), _currentLine);
             }
         }
 
@@ -680,6 +769,10 @@ namespace Calcpad.Core
                     if (dto.ZeroSmallMatrixElements.HasValue)
                         Settings.Math.ZeroSmallMatrixElements = dto.ZeroSmallMatrixElements.Value;
                     break;
+                case SettingKey.ShowHiddenOutput:
+                    if (dto.ShowHiddenOutput.HasValue)
+                        Settings.Math.ShowHiddenOutput = dto.ShowHiddenOutput.Value;
+                    break;
                 case SettingKey.MaxOutputCount:
                     if (dto.MaxOutputCount.HasValue)
                         Settings.Math.MaxOutputCount = dto.MaxOutputCount.Value;
@@ -695,7 +788,7 @@ namespace Calcpad.Core
                     if (dto.IsUs.HasValue)
                     {
                         Settings.IsUs = dto.IsUs.Value;
-                        Unit.IsUs = dto.IsUs.Value;
+                        _parser.IsUs = dto.IsUs.Value;
                     }
                     break;
                 case SettingKey.VectorGraphics:
@@ -774,9 +867,10 @@ namespace Calcpad.Core
 
         private void ParseKeywordMd(ReadOnlySpan<char> s)
         {
-            if (s.Length > 3)
+            var kwdLength = KeywordLength(Keyword.Md);
+            if (s.Length > kwdLength)
             {
-                var expr = s[3..].Trim();
+                var expr = s[kwdLength..].Trim();
                 if (expr.Equals("on", StringComparison.OrdinalIgnoreCase))
                     _isMarkdownOn = true;
                 else if (expr.Equals("off", StringComparison.OrdinalIgnoreCase))
@@ -796,7 +890,7 @@ namespace Calcpad.Core
                 {
                     var sourceDir = !string.IsNullOrEmpty(SourceFilePath)
                         ? System.IO.Path.GetDirectoryName(SourceFilePath) : null;
-                    var options = new ReadWriteOptions(s, 0, sourceDir);
+                    var options = new ReadWriteOptions(s, 0, sourceDir, _pathRoots);
                     if (options.Name.IsEmpty)
                         return;
 
@@ -811,7 +905,7 @@ namespace Calcpad.Core
                 }
             }
             else if (_isVisible)
-                _sb.Append($"<p><span{HtmlId} class=\"cond\">#read</span> {s[5..]}</p>");
+                _sb.Append($"<p><span{HtmlId} class=\"cond\">#read</span> {s[KeywordLength(Keyword.Read)..]}</p>");
         }
 
         private void ParseKeywordWrite(ReadOnlySpan<char> s, Keyword keyword)
@@ -822,7 +916,7 @@ namespace Calcpad.Core
                 {
                     var sourceDir = !string.IsNullOrEmpty(SourceFilePath)
                         ? System.IO.Path.GetDirectoryName(SourceFilePath) : null;
-                    var options = new ReadWriteOptions(s, keyword - Keyword.Read, sourceDir);
+                    var options = new ReadWriteOptions(s, keyword - Keyword.Read, sourceDir, _pathRoots);
                     if (options.Name.IsEmpty)
                         return;
 
@@ -833,7 +927,10 @@ namespace Calcpad.Core
                 }
             }
             else if (_isVisible)
-                _sb.Append($"<p><span{HtmlId} class=\"cond\">#write</span> {s[6..]}</p>");
+            {
+                var kwdLength = KeywordLength(keyword);
+                _sb.Append($"<p><span{HtmlId} class=\"cond\">{s[..kwdLength]}</span> {s[kwdLength..]}</p>");
+            }
         }
 
         private void ReportDataExchageResult(ReadWriteOptions options, string command)

--- a/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.Loops.cs
+++ b/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.Loops.cs
@@ -15,6 +15,8 @@ namespace Calcpad.Core
             internal int Iteration => _iteration;
             internal int InitialCount { get; }
             internal bool IsFirstPass => _iteration == InitialCount;
+            /// <summary>1 based pass number. _iteration counts down, so this counts up.</summary>
+            internal int Pass => InitialCount - _iteration + 1;
             private protected Loop(int startLine, double count, int id)
             {
                 _startLine = startLine;

--- a/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.Portable.cs
+++ b/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.Portable.cs
@@ -1,0 +1,171 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Calcpad.Core
+{
+    public partial class ExpressionParser
+    {
+        public static string InlineReadDirective(ReadOnlySpan<char> line, string sourceFilePath, PathRoots pathRoots = null)
+        {
+            var sourceDir = string.IsNullOrEmpty(sourceFilePath)
+                ? null
+                : System.IO.Path.GetDirectoryName(sourceFilePath);
+            var options = new ReadWriteOptions(line.Trim(), 0, sourceDir, pathRoots);
+            if (options.Name.IsEmpty)
+                return null;
+
+            var literal = DataLiteral(DataExchange.Read(options), options.Type);
+            return literal is null ? null : $"{options.Name} = {literal}";
+        }
+
+        public static bool TryGetDataPath(ReadOnlySpan<char> line, out int start, out int length)
+        {
+            start = 0;
+            length = 0;
+            var connector = line.StartsWith("#read", StringComparison.OrdinalIgnoreCase) ? "from"
+                : line.StartsWith("#write", StringComparison.OrdinalIgnoreCase)
+                    || line.StartsWith("#append", StringComparison.OrdinalIgnoreCase) ? "to"
+                : null;
+            if (connector is null)
+                return false;
+
+            // The keyword, the variable name and the connector: one space-delimited token each,
+            // consumed exactly as ReadWriteOptions consumes them.
+            var len = line.Length;
+            var i = 0;
+            for (var token = 0; token < 3; ++token)
+            {
+                var from = i;
+                while (i < len) { if (line[i++] == ' ') break; }
+                if (i == len)
+                    return false;
+
+                if (token == 2 && !line[from..(i - 1)].Equals(connector, StringComparison.OrdinalIgnoreCase))
+                    return false;
+            }
+
+            var dot = line.LastIndexOf('.');
+            if (dot < i)
+                return false;
+
+            var end = len;
+            for (var j = dot + 1; j < len; ++j)
+            {
+                var c = line[j];
+                if (c is '@' or '!' or ':' or ' ')
+                {
+                    end = j;
+                    break;
+                }
+            }
+            start = i;
+            length = end - i;
+            return length > 0;
+        }
+
+        private static string DataLiteral(string[][] data, char type)
+        {
+            var rows = data?.Length ?? 0;
+            if (rows == 0 || (data[0]?.Length ?? 0) == 0)
+                return null;
+
+            if (type == 'V')
+                return Brackets(Flatten(data));
+
+            var cols = 0;
+            for (var i = 0; i < rows; ++i)
+                cols = Math.Max(cols, data[i]?.Length ?? 0);
+
+            if ((type == 'C' || type == 'D') && cols != 1 && rows != 1)
+                throw Exceptions.IndexOutOfRange($"{rows}, {cols}");
+
+            return type switch
+            {
+                'R' => Rows(data),
+                'C' => $"vec2col({Brackets(Axis(data))})",
+                'D' => $"vec2diag({Brackets(Axis(data))})",
+                'L' => $"copy({Rows(data)}; ltriang({rows}); 1; 1)",
+                'U' => $"copy({Rows(Skyline(data))}; utriang({rows}); 1; 1)",
+                'S' => $"copy({Rows(Skyline(data))}; symmetric({rows}); 1; 1)",
+                _ => throw Exceptions.InvalidType(type),
+            };
+        }
+
+        private static string Rows(string[][] data)
+        {
+            var sb = new StringBuilder("[");
+            for (int i = 0, n = data.Length; i < n; ++i)
+            {
+                if (i > 0)
+                    sb.Append('|');
+
+                var row = data[i];
+                // An empty row still has to hold something to keep the brackets valid;
+                // zero is what the missing cells are read as anyway.
+                if (row is null || row.Length == 0)
+                    sb.Append('0');
+                else
+                    AppendCells(sb, row);
+            }
+            return sb.Append(']').ToString();
+        }
+
+        private static string Brackets(string[] values)
+        {
+            var sb = new StringBuilder("[");
+            AppendCells(sb, values);
+            return sb.Append(']').ToString();
+        }
+
+        private static void AppendCells(StringBuilder sb, string[] cells)
+        {
+            for (int j = 0, m = cells.Length; j < m; ++j)
+            {
+                if (j > 0)
+                    sb.Append("; ");
+
+                var cell = cells[j];
+                sb.Append(string.IsNullOrWhiteSpace(cell) ? "0" : cell.Trim());
+            }
+        }
+
+        /// <summary>Every cell, row by row — how a <c>type=V</c> read fills its vector.</summary>
+        private static string[] Flatten(string[][] data)
+        {
+            var cells = new List<string>();
+            foreach (var row in data)
+                if (row is not null)
+                    cells.AddRange(row);
+
+            return [.. cells];
+        }
+
+        private static string[] Axis(string[][] data)
+        {
+            if (data.Length == 1)
+                return data[0];
+
+            var values = new string[data.Length];
+            for (var i = 0; i < data.Length; ++i)
+                values[i] = data[i] is { Length: > 0 } row ? row[0] : null;
+
+            return values;
+        }
+
+        private static string[][] Skyline(string[][] data)
+        {
+            var n = data.Length;
+            var shifted = new string[n][];
+            for (var i = 0; i < n; ++i)
+            {
+                var row = data[i];
+                var m = Math.Min(row?.Length ?? 0, n - i);
+                shifted[i] = new string[i + m];
+                for (var j = 0; j < m; ++j)
+                    shifted[i][i + j] = row[j];
+            }
+            return shifted;
+        }
+    }
+}

--- a/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.ReadWriteOptions.cs
+++ b/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.ReadWriteOptions.cs
@@ -40,7 +40,7 @@ namespace Calcpad.Core
             // #append M to filename.csv@R1C1:R2C2 type=[Y|N] sep=,
             // #append M to filename.txt@R1C1:R2C2 type=[Y|N] sep=
 
-            internal ReadWriteOptions(ReadOnlySpan<char> s, int command, string sourceDir = null)
+            internal ReadWriteOptions(ReadOnlySpan<char> s, int command, string sourceDir = null, PathRoots pathRoots = null)
             {
                 if (command > 0)
                     Type = 'N';
@@ -126,7 +126,11 @@ namespace Calcpad.Core
                     Ext = ts.Cut();
                     IsExcel = Ext.StartsWith("xls", StringComparison.OrdinalIgnoreCase);
                 }
-                var path = Environment.ExpandEnvironmentVariables($"{Path}.{Ext}");
+                var rawPath = $"{Path}.{Ext}";
+                if (pathRoots != null && !pathRoots.TryExpand(rawPath, out rawPath, out var tokenError))
+                    throw new MathParserException(tokenError);
+
+                var path = Environment.ExpandEnvironmentVariables(rawPath);
                 FullPath = sourceDir != null
                     ? System.IO.Path.GetFullPath(path, sourceDir)
                     : System.IO.Path.GetFullPath(path);

--- a/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.Tokens.cs
+++ b/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.Tokens.cs
@@ -95,6 +95,22 @@ namespace Calcpad.Core
             tokens.Add(token);
         }
 
+        private void ExpandImageSources(List<Token> tokens)
+        {
+            var directory = string.IsNullOrEmpty(SourceFilePath)
+                ? null : System.IO.Path.GetDirectoryName(SourceFilePath);
+            foreach (var token in tokens)
+            {
+                if (token.Type == TokenTypes.Expression ||
+                    !token.Value.Contains("<img", StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                var value = token.Value;
+                token.Value = ImageReferences.ExpandSources(value, _pathRoots, directory,
+                    error => AppendError(value, error, _currentLine));
+            }
+        }
+
         private static TokenTypes GetTokenType(char separator)
         {
             return separator switch

--- a/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.UI.cs
+++ b/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.UI.cs
@@ -1,0 +1,669 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Web;
+
+namespace Calcpad.Core
+{
+    public partial class ExpressionParser
+    {
+        private sealed class UiPropertyMetadata
+        {
+            public string Type { get; init; }
+            public string Style { get; init; }
+            public string ReportStyle { get; init; }
+            public string VariableName { get; init; }
+            public string DataValues { get; set; }
+            public string DeclarationKey { get; init; }
+
+            public string Key { get; init; }
+            public int Rows { get; set; }
+            public int Columns { get; set; }
+            public bool HasDeclaredShape { get; init; }
+            public string[] ColumnHeaders { get; init; }
+            public string[] RowHeaders { get; init; }
+            public string[] Keys { get; init; }
+            public string[] Values { get; init; }
+        }
+
+        public bool EnableUi { get; set; }
+        public Dictionary<string, string> UiOverrides { get; set; }
+        private List<UiPropertyMetadata> _lineUiControls;
+        private int _uiTakeIndex;
+        private int _uiSkipChars;
+        private readonly Dictionary<string, int> _uiVarCounts = [];
+        private readonly Dictionary<(string Name, int Line, int Occurrence), int> _uiDeclarationIndex = [];
+        private readonly Dictionary<string, int> _uiLineOccurrences = [];
+        private bool HasUiControls => _lineUiControls is { Count: > 0 };
+        private const string UiKeyword = "#UI";
+        private const char ThinSpace = '\u2009'; // MathParser separates a value from its unit with this
+
+        private KeywordResult ParseKeywordUi(ReadOnlySpan<char> s)
+        {
+            ResetUiState();
+            var cursor = UiKeyword.Length;
+            while (cursor < s.Length && s[cursor] == ' ')
+                ++cursor;
+
+            var properties = new UiDto();
+            if (cursor < s.Length && s[cursor] == '{')
+            {
+                var braceEnd = s.IndexOf('}');
+                if (braceEnd < 0)
+                {
+                    AppendError(s.ToString(), Messages.Improper_format_for_UI_keyword_Missing_closing_brace, _currentLine);
+                    _uiSkipChars = s.Length;
+                    return KeywordResult.None;
+                }
+                try
+                {
+                    properties = UiDto.Parse(s[cursor..(braceEnd + 1)].ToString()) ?? new UiDto();
+                }
+                catch (JsonException)
+                {
+                    AppendError(s.ToString(), string.Format(Messages.Invalid_JSON_in_0, UiKeyword), _currentLine);
+                    _uiSkipChars = SkipSpaces(s, UiKeyword.Length);
+                    return KeywordResult.None;
+                }
+                _uiSkipChars = SkipSpaces(s, braceEnd + 1);
+            }
+            else
+                _uiSkipChars = cursor;
+
+            var errors = properties.Validate();
+            if (errors.Count > 0)
+            {
+                foreach (var error in errors)
+                    AppendError(s.ToString(), error.Message, _currentLine);
+
+                return KeywordResult.None;
+            }
+
+            int uiRows = properties.Rows ?? 0, uiColumns = properties.Columns ?? 0;
+            var hasDeclaredShape = uiRows > 0 && uiColumns > 0;
+            _lineUiControls = [];
+            foreach (var assignment in UiSyntax.EnumerateAssignments(s[_uiSkipChars..]))
+            {
+                if (assignment.Name.EndsWith('$'))
+                {
+                    AppendError(s.ToString(), Messages.Only_numbers_are_supported_by_the_UI_keyword, _currentLine);
+                    return KeywordResult.None;
+                }
+                if (!UiSyntax.IsValue(assignment.Rhs))
+                {
+                    AppendError(s.ToString(), Messages.UI_directives_do_not_support_expressions, _currentLine);
+                    return KeywordResult.None;
+                }
+
+                var type = properties.Type ?? (IsDatagridRhs(assignment.Rhs) ? "datagrid" : "entry");
+                int rows = uiRows, columns = uiColumns;
+                if (type == "datagrid" && !hasDeclaredShape)
+                {
+                    if (assignment.Rhs.Length > 1 && assignment.Rhs[0] == '[' && assignment.Rhs[^1] == ']')
+                        AutoDetectGridSize(assignment.Rhs, ref rows, ref columns);
+                    else
+                        AutoDetectGridSizeFromFunction(assignment.Rhs, ref rows, ref columns);
+                }
+
+                var (declarationKey, key) = GetUiKey(assignment.Name);
+                _lineUiControls.Add(new UiPropertyMetadata
+                {
+                    Type = type,
+                    Style = properties.Style,
+                    ReportStyle = properties.ReportStyle,
+                    VariableName = assignment.Name,
+                    DeclarationKey = declarationKey,
+                    Key = key,
+                    Rows = rows,
+                    Columns = columns,
+                    HasDeclaredShape = hasDeclaredShape,
+                    ColumnHeaders = properties.ColumnHeaders,
+                    RowHeaders = properties.RowHeaders,
+                    Keys = properties.Keys,
+                    Values = properties.Values
+                });
+            }
+            if (_lineUiControls.Count == 0)
+            {
+                _lineUiControls = null;
+                AppendError(s.ToString(), Messages.The_UI_keyword_requires_a_variable_assignment, _currentLine);
+            }
+            return KeywordResult.None;
+        }
+
+        private UiPropertyMetadata TakeUiControl(string expression)
+        {
+            if (!HasUiControls)
+                return null;
+
+            var eqIndex = IndexOfAssignment(expression);
+            if (eqIndex < 1)
+                return null;
+
+            var name = ExtractVariableName(expression.AsSpan(0, eqIndex));
+            for (var i = _uiTakeIndex; i < _lineUiControls.Count; ++i)
+            {
+                if (_lineUiControls[i].VariableName != name)
+                    continue;
+
+                _uiTakeIndex = i + 1;
+                return _lineUiControls[i];
+            }
+            return null;
+        }
+
+        private (string DeclarationKey, string Key) GetUiKey(string varName)
+        {
+            var occurrence = _uiLineOccurrences.GetValueOrDefault(varName);
+            _uiLineOccurrences[varName] = occurrence + 1;
+            var id = (varName, _currentLine, occurrence);
+            if (!_uiDeclarationIndex.TryGetValue(id, out var ordinal))
+            {
+                ordinal = _uiVarCounts.GetValueOrDefault(varName) + 1;
+                _uiVarCounts[varName] = ordinal;
+                _uiDeclarationIndex[id] = ordinal;
+            }
+            var declarationKey = $"{varName}:{ordinal}";
+            if (_loops.Count == 0)
+                return (declarationKey, declarationKey);
+
+            var passes = new int[_loops.Count];
+            var i = _loops.Count;
+            foreach (var loop in _loops) // enumerates innermost first
+                passes[--i] = loop.Pass;
+
+            return (declarationKey, $"{declarationKey}:{string.Join('.', passes)}");
+        }
+
+        private static int IndexOfAssignment(ReadOnlySpan<char> s)
+        {
+            // Segments are the consumed prefix each time, so their lengths sum to the offset.
+            var offset = 0;
+            foreach (var segment in s.EnumerateComments())
+            {
+                if (UiSyntax.IsCode(segment))
+                {
+                    var i = segment.IndexOf('=');
+                    if (i >= 0)
+                        return offset + i;
+                }
+                offset += segment.Length;
+            }
+            return -1;
+        }
+
+        private static string ExtractVariableName(ReadOnlySpan<char> lhs)
+        {
+            var sb = new StringBuilder();
+            foreach (var segment in lhs.EnumerateComments())
+            {
+                if (UiSyntax.IsCode(segment))
+                    sb.Append(segment);
+            }
+            return sb.ToString().Trim();
+        }
+
+        private static int SkipSpaces(ReadOnlySpan<char> s, int start)
+        {
+            while (start < s.Length && s[start] == ' ')
+                ++start;
+            return start;
+        }
+
+        private static bool IsDatagridRhs(ReadOnlySpan<char> rhs) =>
+            rhs.Length > 1 && rhs[0] == '[' && rhs[^1] == ']' ||
+            StartsWithFunction(rhs, "vector") ||
+            StartsWithFunction(rhs, "matrix");
+
+        private static bool StartsWithFunction(ReadOnlySpan<char> rhs, ReadOnlySpan<char> funcName)
+        {
+            if (!rhs.StartsWith(funcName, StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            var rest = rhs[funcName.Length..].TrimStart();
+            return rest.Length > 0 && rest[0] == '(';
+        }
+
+        private static void AutoDetectGridSize(ReadOnlySpan<char> rhs, ref int rows, ref int columns)
+        {
+            var bracketStart = rhs.IndexOf('[');
+            var bracketEnd = rhs.LastIndexOf(']');
+            if (bracketStart < 0 || bracketEnd <= bracketStart)
+                return;
+
+            var content = rhs[(bracketStart + 1)..bracketEnd];
+            var pipeIndex = content.IndexOf('|');
+            var firstRow = pipeIndex < 0 ? content : content[..pipeIndex];
+            if (rows == 0)
+                rows = pipeIndex < 0 ? 1 : content.Count('|') + 1;
+            if (columns == 0)
+                columns = firstRow.Count(';') + 1;
+        }
+
+        private static void AutoDetectGridSizeFromFunction(ReadOnlySpan<char> rhs, ref int rows, ref int columns)
+        {
+            var parenStart = rhs.IndexOf('(');
+            var parenEnd = rhs.LastIndexOf(')');
+            if (parenStart < 0 || parenEnd <= parenStart)
+                return;
+
+            var args = rhs[(parenStart + 1)..parenEnd].Trim();
+            if (StartsWithFunction(rhs, "vector"))
+            {
+                if (int.TryParse(args, out var n) && n > 0)
+                {
+                    if (rows == 0) rows = 1;
+                    if (columns == 0) columns = n;
+                }
+                return;
+            }
+            var semicolon = args.IndexOf(';');
+            if (semicolon > 0 &&
+                int.TryParse(args[..semicolon].Trim(), out var m) && m > 0 &&
+                int.TryParse(args[(semicolon + 1)..].Trim(), out var k) && k > 0)
+            {
+                if (rows == 0) rows = m;
+                if (columns == 0) columns = k;
+            }
+        }
+
+        private void ResolveDatagridShape(UiPropertyMetadata ui)
+        {
+            if (ui.Rows > 0 && ui.Columns > 0)
+                return;
+
+            var (rows, columns) = _parser.GetVariableShape(ui.VariableName);
+            if (ui.Rows == 0)
+                ui.Rows = rows;
+
+            if (ui.Columns == 0)
+                ui.Columns = columns;
+        }
+
+        private void ResolveShapeFromSizingCall(UiPropertyMetadata ui, string expression)
+        {
+            if (ui.Rows > 0 && ui.Columns > 0 || !_calculate || _isVal < 0)
+                return;
+
+            var eqIndex = IndexOfAssignment(expression);
+            if (eqIndex < 0)
+                return;
+
+            var rhs = expression.AsSpan(eqIndex + 1).Trim();
+            var isVector = StartsWithFunction(rhs, "vector");
+            if (!isVector && !StartsWithFunction(rhs, "matrix"))
+                return;
+
+            var parenStart = rhs.IndexOf('(');
+            var parenEnd = rhs.LastIndexOf(')');
+            if (parenStart < 0 || parenEnd <= parenStart)
+                return;
+
+            var args = rhs[(parenStart + 1)..parenEnd];
+            if (isVector)
+            {
+                var n = EvaluateCount(args);
+                if (n > 0)
+                {
+                    if (ui.Rows == 0)
+                        ui.Rows = 1;
+
+                    if (ui.Columns == 0)
+                        ui.Columns = n;
+                }
+                return;
+            }
+            var separator = IndexOfArgumentSeparator(args);
+            if (separator < 0)
+                return;
+
+            var m = EvaluateCount(args[..separator]);
+            var k = EvaluateCount(args[(separator + 1)..]);
+            if (m > 0 && k > 0)
+            {
+                if (ui.Rows == 0)
+                    ui.Rows = m;
+
+                if (ui.Columns == 0)
+                    ui.Columns = k;
+            }
+        }
+
+        private static int IndexOfArgumentSeparator(ReadOnlySpan<char> args)
+        {
+            var depth = 0;
+            for (var i = 0; i < args.Length; ++i)
+            {
+                var c = args[i];
+                if (c is '(' or '[' or '{')
+                    ++depth;
+                else if (c is ')' or ']' or '}')
+                    --depth;
+                else if (c == ';' && depth == 0)
+                    return i;
+            }
+            return -1;
+        }
+
+        private int EvaluateCount(ReadOnlySpan<char> expression)
+        {
+            try
+            {
+                _parser.Parse(expression, false);
+                _parser.Calculate(false);
+                var n = Math.Round(_parser.Real);
+                return n > 0 && n < int.MaxValue ? (int)n : 0;
+            }
+            catch (MathParserException)
+            {
+                _parser.ResetStack();
+                return 0;
+            }
+        }
+
+        private string PrepareUiExpression(UiPropertyMetadata ui, string expression)
+        {
+            var isDatagrid = ui.Type == "datagrid";
+            if (isDatagrid && EnableUi)
+                expression = ResizeDatagridMatrixToFit(ui, expression);
+
+            if (TryGetUiOverride(ui, out var value))
+            {
+                if (isDatagrid)
+                {
+                    ResolveShapeFromSizingCall(ui, expression);
+                    if (ui.Rows > 0 && ui.Columns > 0)
+                        value = ReshapeMatrixLiteral(value, ui.Rows, ui.Columns);
+                }
+                var overridden = ApplyUiOverride(ui, expression, value);
+                if (overridden is not null)
+                    expression = overridden;
+            }
+
+            if (isDatagrid)
+                CaptureDatagridValues(ui, expression);
+
+            return expression;
+        }
+
+        private static string ResizeDatagridMatrixToFit(UiPropertyMetadata ui, string expression) =>
+            ui.HasDeclaredShape ? ReshapeMatrixLiteral(expression, ui.Rows, ui.Columns) : expression;
+
+        private static string ReshapeMatrixLiteral(string s, int rows, int columns)
+        {
+            var bracketStart = s.IndexOf('[');
+            var bracketEnd = s.LastIndexOf(']');
+            if (bracketStart < 0 || bracketEnd <= bracketStart)
+                return s;
+
+            var cells = SplitMatrixLiteral(s[(bracketStart + 1)..bracketEnd]);
+            var sb = new StringBuilder();
+            for (var r = 0; r < rows; ++r)
+            {
+                if (r > 0)
+                    sb.Append(" | ");
+
+                for (var c = 0; c < columns; ++c)
+                {
+                    if (c > 0)
+                        sb.Append("; ");
+
+                    var value = r < cells.Count && c < cells[r].Length ? cells[r][c] : string.Empty;
+                    sb.Append(value.Length == 0 ? "0" : value);
+                }
+            }
+            return string.Concat(s.AsSpan(0, bracketStart + 1), sb.ToString(), s.AsSpan(bracketEnd));
+        }
+
+        private static List<string[]> SplitMatrixLiteral(string content)
+        {
+            var rows = new List<string[]>();
+            foreach (var row in content.Split('|'))
+            {
+                var cells = row.Split(';');
+                for (var i = 0; i < cells.Length; ++i)
+                    cells[i] = cells[i].Trim();
+
+                rows.Add(cells);
+            }
+            return rows;
+        }
+
+        private static void CaptureDatagridValues(UiPropertyMetadata ui, string expression)
+        {
+            var eqIndex = IndexOfAssignment(expression);
+            if (eqIndex < 0)
+                return;
+
+            var rhs = expression[(eqIndex + 1)..].Trim();
+            var bracketStart = rhs.IndexOf('[');
+            var bracketEnd = rhs.LastIndexOf(']');
+            if (bracketStart >= 0 && bracketEnd > bracketStart)
+            {
+                ui.DataValues = rhs[(bracketStart + 1)..bracketEnd].Replace(" ", "");
+                return;
+            }
+            var row = string.Join(";", Enumerable.Repeat("0", ui.Columns));
+            ui.DataValues = string.Join("|", Enumerable.Repeat(row, ui.Rows));
+        }
+
+        private bool TryGetUiOverride(UiPropertyMetadata ui, out string value)
+        {
+            value = null;
+            return UiOverrides is not null &&
+                (UiOverrides.TryGetValue(ui.Key, out value) ||
+                UiOverrides.TryGetValue(ui.DeclarationKey, out value) ||
+                UiOverrides.TryGetValue(ui.VariableName, out value));
+        }
+
+        private static string ApplyUiOverride(UiPropertyMetadata ui, string expression, string value)
+        {
+            var eqIndex = IndexOfAssignment(expression);
+            if (eqIndex < 0)
+                return null;
+
+            var lhs = expression[..(eqIndex + 1)];
+            var rhs = expression[(eqIndex + 1)..].TrimStart();
+            if (ui.Type == "datagrid")
+            {
+                var bracketEnd = rhs.LastIndexOf(']');
+                return bracketEnd < 0 || rhs.IndexOf('[') < 0 ?
+                    $"{lhs} {value}" :
+                    $"{lhs} {value}{rhs[(bracketEnd + 1)..]}";
+            }
+
+            if (ui.Type is "dropdown" or "radio")
+                return $"{lhs} {value}";
+
+            var i = 0;
+            while (i < rhs.Length && IsNumericChar(rhs[i]))
+                ++i;
+
+            return i == 0 ? null : $"{lhs} {value}{rhs[i..]}";
+        }
+
+        private static bool IsNumericChar(char c) =>
+            c is >= '0' and <= '9' or '.' or '-' or '+' or 'e' or 'E';
+
+        private string GetUiAttributes(UiPropertyMetadata ui)
+        {
+            var sb = new StringBuilder()
+                .Append($" data-ui-type=\"{ui.Type}\"")
+                .Append($" data-ui-line=\"{_parser.Line}\"")
+                .Append($" data-ui-var=\"{HttpUtility.HtmlAttributeEncode(ui.Key)}\"");
+            if (ui.Style is not null)
+                sb.Append($" data-ui-style=\"{HttpUtility.HtmlAttributeEncode(ui.Style)}\"");
+            if (ui.Type == "datagrid")
+                sb.Append($" data-ui-rows=\"{ui.Rows}\" data-ui-columns=\"{ui.Columns}\"");
+
+            return sb.ToString();
+        }
+
+        private string AddReportStyle(UiPropertyMetadata ui, string attributes)
+        {
+            var style = ui.ReportStyle;
+            if (string.IsNullOrEmpty(style))
+                return attributes;
+
+            const string classAttr = "class=\"";
+            var i = attributes.IndexOf(classAttr, StringComparison.Ordinal);
+            return i < 0 ?
+                $"{attributes} class=\"{HttpUtility.HtmlAttributeEncode(style)}\"" :
+                attributes.Insert(i + classAttr.Length, HttpUtility.HtmlAttributeEncode(style) + " ");
+        }
+
+        private string InjectUiInput(UiPropertyMetadata ui, string equationHtml) =>
+            ui.Type switch
+            {
+                "dropdown" => ReplaceEquation(equationHtml, (v, u) => BuildUiDropdown(ui, SelectedValue(v, u))),
+                "radio" => ReplaceEquation(equationHtml, (v, u) => BuildUiRadio(ui, SelectedValue(v, u))),
+                "checkbox" => ReplaceEquation(equationHtml, (v, _) => BuildUiCheckbox(ui, v)),
+                _ => InjectUiControl(equationHtml, (v, _) => BuildUiEntry(ui, v))
+            };
+
+        private static string InjectUiControl(string equationHtml, Func<string, string, string> build)
+        {
+            var resultStart = ResultStart(equationHtml);
+            if (resultStart < 0)
+                return equationHtml;
+
+            SplitValueAndUnit(equationHtml[resultStart..], out var value, out var unitHtml);
+            return equationHtml[..resultStart] + build(value, unitHtml) + unitHtml;
+        }
+
+        private static string ReplaceEquation(string equationHtml, Func<string, string, string> build)
+        {
+            var resultStart = ResultStart(equationHtml);
+            if (resultStart < 0)
+                return equationHtml;
+
+            SplitValueAndUnit(equationHtml[resultStart..], out var value, out var unitHtml);
+            return build(value, unitHtml);
+        }
+
+        private static int ResultStart(string equationHtml)
+        {
+            const string assignOp = " = ";
+            var lastAssign = equationHtml.LastIndexOf(assignOp, StringComparison.Ordinal);
+            return lastAssign < 0 ? -1 : lastAssign + assignOp.Length;
+        }
+
+        private static string SelectedValue(string value, string unitHtml)
+        {
+            var sb = new StringBuilder(StripSpaces(value));
+            var inTag = false;
+            foreach (var c in unitHtml)
+            {
+                if (c == '<')
+                    inTag = true;
+                else if (c == '>')
+                    inTag = false;
+                else if (!inTag && c is not (' ' or ThinSpace))
+                    sb.Append(c);
+            }
+            return sb.ToString();
+        }
+
+        private static string StripSpaces(string s) => s.Replace(" ", string.Empty);
+
+        private static string UiClass(UiPropertyMetadata ui, string baseClass) =>
+            HttpUtility.HtmlAttributeEncode(ui.Style is null ?
+                baseClass :
+                $"{baseClass} {ui.Style}");
+
+        private string UiBinding(UiPropertyMetadata ui) =>
+            $" data-ui-var=\"{HttpUtility.HtmlAttributeEncode(ui.Key)}\" data-ui-line=\"{_parser.Line}\"";
+
+        private string BuildUiEntry(UiPropertyMetadata ui, string value) =>
+            $"<input type=\"text\" class=\"{UiClass(ui, "calcpad-ui-input")}\" value=\"{HttpUtility.HtmlAttributeEncode(value)}\"{UiBinding(ui)}>";
+
+        private string BuildUiDropdown(UiPropertyMetadata ui, string value)
+        {
+            var sb = new StringBuilder()
+                .Append($"<select class=\"{UiClass(ui, "calcpad-ui-dropdown")}\"{UiBinding(ui)}>");
+            for (int i = 0, len = ui.Keys.Length; i < len; ++i)
+            {
+                var selected = StripSpaces(ui.Values[i]) == value ? " selected" : string.Empty;
+                sb.Append($"<option value=\"{HttpUtility.HtmlAttributeEncode(ui.Values[i])}\"{selected}>")
+                  .Append($"{HttpUtility.HtmlEncode(ui.Keys[i])}</option>");
+            }
+            return sb.Append("</select>").ToString();
+        }
+
+        private string BuildUiRadio(UiPropertyMetadata ui, string value)
+        {
+            var group = HttpUtility.HtmlAttributeEncode($"ui-radio-{ui.Key}");
+            var sb = new StringBuilder()
+                .Append($"<span class=\"{UiClass(ui, "calcpad-ui-radio")}\"{UiBinding(ui)}>");
+            for (int i = 0, len = ui.Keys.Length; i < len; ++i)
+            {
+                var isChecked = StripSpaces(ui.Values[i]) == value ? " checked" : string.Empty;
+                sb.Append("<label class=\"calcpad-ui-radio-label\">")
+                  .Append($"<input type=\"radio\" name=\"{group}\" value=\"{HttpUtility.HtmlAttributeEncode(ui.Values[i])}\"{isChecked}>")
+                  .Append($" {HttpUtility.HtmlEncode(ui.Keys[i])}</label>");
+            }
+            return sb.Append("</span>").ToString();
+        }
+
+        private string BuildUiCheckbox(UiPropertyMetadata ui, string value)
+        {
+            var isChecked = value.Trim() == "1" ? " checked" : string.Empty;
+            return $"<input type=\"checkbox\" class=\"{UiClass(ui, "calcpad-ui-checkbox")}\"{UiBinding(ui)}{isChecked}>";
+        }
+
+        private string BuildUiDatagrid(UiPropertyMetadata ui)
+        {
+            var sb = new StringBuilder()
+                .Append($"<div class=\"{UiClass(ui, "calcpad-ui-datagrid")}\"{UiBinding(ui)}")
+                .Append($" data-ui-rows=\"{ui.Rows}\" data-ui-columns=\"{ui.Columns}\"")
+                .Append($" data-ui-values=\"{HttpUtility.HtmlAttributeEncode(ui.DataValues ?? string.Empty)}\"");
+            if (ui.ColumnHeaders is not null)
+                sb.Append($" data-ui-col-headers=\"{HttpUtility.HtmlAttributeEncode(string.Join(",", ui.ColumnHeaders))}\"");
+            if (ui.RowHeaders is not null)
+                sb.Append($" data-ui-row-headers=\"{HttpUtility.HtmlAttributeEncode(string.Join(",", ui.RowHeaders))}\"");
+
+            return sb.Append("></div>").ToString();
+        }
+
+        private static void SplitValueAndUnit(string resultHtml, out string value, out string unitHtml)
+        {
+            var unitStart = resultHtml.IndexOf('<');
+            if (unitStart < 0)
+            {
+                value = resultHtml.Trim();
+                unitHtml = string.Empty;
+            }
+            else if (unitStart == 0)
+            {
+                value = string.Empty;
+                unitHtml = resultHtml;
+            }
+            else
+            {
+                value = resultHtml[..unitStart].TrimEnd(ThinSpace, ' ');
+                unitHtml = ThinSpace + resultHtml[unitStart..];
+            }
+            // The angle units are written straight after the number, without markup of
+            // their own, so they have to be split off the value by hand.
+            var i = value.Length;
+            while (i > 0 && value[i - 1] is '°' or '′' or '″')
+                --i;
+
+            if (i == value.Length)
+                return;
+
+            unitHtml = value[i..] + unitHtml;
+            value = value[..i];
+        }
+
+        private void ResetUiState()
+        {
+            _lineUiControls = null;
+            _uiTakeIndex = 0;
+            _uiSkipChars = 0;
+            _uiLineOccurrences.Clear();
+        }
+    }
+}

--- a/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.cs
+++ b/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.cs
@@ -20,6 +20,8 @@ namespace Calcpad.Core
         private int _decimals;
         private bool _calculate;
         private bool _isVisible;
+        private readonly Stack<bool> _visibilityStack = new();
+        private readonly Stack<int> _outputModeStack = new();
         private bool _isPausedByUser;
         private int _pauseCharCount;
         private bool _isMarkdownOn;
@@ -34,16 +36,25 @@ namespace Calcpad.Core
 
         public Settings Settings { get; set; } = new();
         public string SourceFilePath { get; set; }
+        private PathRoots _pathRoots = new();
+        private bool _hasInheritedPathRoots;
+
+        public PathRoots PathRoots
+        {
+            get => _pathRoots;
+            set
+            {
+                _hasInheritedPathRoots = value is not null;
+                _pathRoots = value ?? new PathRoots();
+            }
+        }
         public string HtmlResult { get; private set; }
         public IReadOnlyList<CalcpadError> Errors => _errorList;
-        public static bool IsUs
-        {
-            get => Unit.IsUs;
-            set => Unit.IsUs = value;
-        }
         public bool IsPaused => _startLine > 0;
         public bool Debug { get; set; }
+        public bool ForPrint { get; set; }
         public bool ShowWarnings { get; set; } = true;
+        public bool ShowErrorLines { get; set; } = true;
         public readonly List<string> OpenXmlExpressions = new(100);
 
         static ExpressionParser()
@@ -71,7 +82,6 @@ namespace Calcpad.Core
 
         private void Parse(ReadOnlySpan<char> code, bool calculate, bool getXml)
         {
-            Unit.IsUs = Settings.IsUs;
             var lines = new List<int> { 0 };
             var len = code.Length;
             for (int i = 0; i < len; ++i)
@@ -89,6 +99,9 @@ namespace Calcpad.Core
             {
                 while (++_currentLine < lineCount)
                 {
+                    // #UI metadata is scoped to the line that declared it. Clearing here
+                    // covers the paths that skip ParseLine, e.g. an unsatisfied condition.
+                    ResetUiState();
                     ref var currentLineCache = ref _lineCache[_currentLine];
                     var keyword = currentLineCache.Keyword;
                     if (keyword == Keyword.SkipLine)
@@ -173,11 +186,13 @@ namespace Calcpad.Core
                             tokens = _lineCache[_currentLine].Tokens;
                         else
                         {
-                            var skipChars = keyword == Keyword.Const ? 7 : _condition.KeywordLength;
+                            var skipChars = keyword == Keyword.Ui ? _uiSkipChars :
+                                keyword == Keyword.Const ? KeywordLength(Keyword.Const) : _condition.KeywordLength;
                             tokens = GetTokens(textSpan[skipChars..]);
                             if (_isMarkdownOn)
                                 ParseMarkdown(tokens);
 
+                            ExpandImageSources(tokens);
                             _lineCache[_currentLine] = new(tokens, keyword, _parser.Line);
                         }
                         _parser.HasInputFields = false;
@@ -384,7 +399,14 @@ namespace Calcpad.Core
                         if (_isVal != 1)
                         {
                             htmlId = HtmlId;
-                            AppendHtmlLineStart(lineType, isIndent);
+                            if (HasUiControls)
+                            {
+                                htmlId = EnableUi
+                                    ? _lineUiControls.Count == 1 ? htmlId + GetUiAttributes(_lineUiControls[0]) : htmlId
+                                    : AddReportStyle(_lineUiControls[0], htmlId);
+                            }
+
+                            AppendHtmlLineStart(lineType, isIndent, htmlId);
                         }
                         if (lineType == TokenTypes.Html && !string.IsNullOrEmpty(htmlId))
                             tokens[0] = new Token(InsertAttribute(tokens[0].Value, htmlId), TokenTypes.Html);
@@ -395,6 +417,16 @@ namespace Calcpad.Core
                         ParseTokens(tokens, true, getXml);
                         if (_isVal != 1)
                             AppendHtmlLineEnd(lineType, keyword == Keyword.If);
+
+                        if (EnableUi && HasUiControls)
+                        {
+                            foreach (var ui in _lineUiControls)
+                                if (ui.Type == "datagrid")
+                                {
+                                    ResolveDatagridShape(ui);
+                                    _sb.AppendLine(BuildUiDatagrid(ui));
+                                }
+                        }
                     }
                 }
                 else
@@ -409,15 +441,15 @@ namespace Calcpad.Core
                 }
             }
 
-            void AppendHtmlLineStart(TokenTypes lineType, bool isIndent)
+            void AppendHtmlLineStart(TokenTypes lineType, bool isIndent, string htmlId)
             {
                 if (isIndent)
                     _sb.Append("</div>");
 
                 if (lineType == TokenTypes.Heading)
-                    _sb.Append($"<h3{HtmlId}>");
+                    _sb.Append($"<h3{htmlId}>");
                 else if (lineType != TokenTypes.Html)
-                    _sb.Append($"<p{HtmlId}>");
+                    _sb.Append($"<p{htmlId}>");
             }
 
             void AppendHtmlLineEnd(TokenTypes lineType, bool indent)
@@ -459,10 +491,15 @@ namespace Calcpad.Core
                 _condition = new();
                 _loops.Clear();
                 _isVal = 0;
+                _outputModeStack.Clear();
                 _parser.SetVariable("Units", new RealValue(UnitsFactor()));
                 _previousKeyword = Keyword.None;
                 _isMarkdownOn = false;
+                _uiVarCounts.Clear();
+                _uiDeclarationIndex.Clear();
                 OpenXmlExpressions.Clear();
+                if (!_hasInheritedPathRoots)
+                    _pathRoots = new PathRoots();
             }
             else
             {
@@ -473,9 +510,12 @@ namespace Calcpad.Core
                 if (n > 0)
                     _sb.Remove(_pauseCharCount, n);
             }
+            _parser.IsUs = Settings.IsUs;
             _parser.IsEnabled = _calculate;
             _currentLine = _startLine - 1;
             _isVisible = true;
+            _visibilityStack.Clear();
+            ResetUiState();
         }
 
         private void Finalize(int lineCount)
@@ -537,8 +577,11 @@ namespace Calcpad.Core
                 {
                     try
                     {
-                        var cacheID = token.CacheID;
-                        if (cacheID < 0)
+                        var ui = TakeUiControl(token.Value);
+                        var cacheID = ui is null ? token.CacheID : -1;
+                        if (ui is not null)
+                            _parser.Parse(PrepareUiExpression(ui, token.Value));
+                        else if (cacheID < 0)
                         {
                             _parser.Parse(token.Value);
                             if (isLoop)
@@ -559,14 +602,22 @@ namespace Calcpad.Core
                             else
                             {
                                 var html = _parser.ToHtml();
-                                if (getXml && Settings.Math.FormatEquations)
+                                if (EnableUi && ui is not null)
+                                    html = ui.Type == "datagrid" ?
+                                        string.Empty :
+                                        InjectUiInput(ui, html);
+
+                                if (html.Length != 0)
                                 {
-                                    var xml = _parser.ToXml();
-                                    OpenXmlExpressions.Add(xml);
-                                    _sb.Append($"<span class=\"eq\" id=\"eq-{OpenXmlExpressions.Count - 1}\">{html}</span>");
+                                    if (getXml && Settings.Math.FormatEquations)
+                                    {
+                                        var xml = _parser.ToXml();
+                                        OpenXmlExpressions.Add(xml);
+                                        _sb.Append($"<span class=\"eq\" id=\"eq-{OpenXmlExpressions.Count - 1}\">{html}</span>");
+                                    }
+                                    else
+                                        _sb.Append($"<span class=\"eq\">{html}</span>");
                                 }
-                                else
-                                    _sb.Append($"<span class=\"eq\">{html}</span>");
                             }
                         }
                     }
@@ -578,7 +629,7 @@ namespace Calcpad.Core
                             errText = token.Value.Replace("?", "<input type=\"text\" size=\"2\" name=\"Var\">");
                         else
                             errText = HttpUtility.HtmlEncode(token.Value);
-                        errText = string.Format(Messages.Error_in_0_on_line_1_2, errText, LineHtml(_currentLine), ex.Message);
+                        errText = FormatError(errText, ex.Message, _currentLine);
                         _sb.Append($"<span class=\"err\"{Id(_currentLine)}>{errText}</span>");
                         RecordError(_currentLine, ex.Message, Debug);
 
@@ -594,7 +645,7 @@ namespace Calcpad.Core
         void AppendError(string lineContent, string text, int line)
         {
             string s = lineContent.Replace("<", "&lt;").Replace(">", "&gt;");
-            _sb.Append(ErrHtml(string.Format(Messages.Error_in_0_on_line_1_2, s, LineHtml(line), text), line));
+            _sb.Append(ErrHtml(FormatError(s, text, line), line));
             RecordError(line, text, Debug);
         }
 
@@ -613,6 +664,10 @@ namespace Calcpad.Core
         }
 
         private static string LineHtml(int line) => $"[<a href=\"#0\" data-text=\"{line + 1}\">{line + 1}</a>]";
+        private string FormatError(string expr, string msg, int line) =>
+            ShowErrorLines
+                ? string.Format(Messages.Error_in_0_on_line_1_2, expr, LineHtml(line), msg)
+                : string.Format(Messages.Error_in_0_1, expr, msg);
         private string ErrHtml(string text, int line) => $"<p class=\"err\"{Id(line)}>{text}</p>";
         private string Id(int line)
         {

--- a/Calcpad.Core/Parsers/MacroParser.cs
+++ b/Calcpad.Core/Parsers/MacroParser.cs
@@ -80,14 +80,24 @@ namespace Calcpad.Core
             Def,
             EndDef,
             Include,
+            ProjectPath,
+            LibraryPath,
         }
+        private const string DefKeyword = "#def";
+        private const string EndDefKeyword = "#end def";
+        private const string IncludeKeyword = "#include";
+        private const string ProjectPathKeyword = "#projectpath";
+        private const string LibraryPathKeyword = "#librarypath";
+        private const string FieldsMarker = "#{";
         private readonly List<int> _lineNumbers = [];
         // Filesystem path comparison must match the host OS to avoid false-positive circular
         // detection on case-sensitive filesystems (Linux) or missed detection on Windows.
         private static readonly StringComparer PathComparer =
             OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
         private readonly HashSet<string> _includeStack = new(PathComparer);
-        private static readonly Dictionary<string, Macro> Macros = new(StringComparer.Ordinal);
+        private PathRoots _pathRoots = new();
+        public PathRoots PathRoots => _pathRoots;
+        private readonly Dictionary<string, Macro> _macros = new(StringComparer.Ordinal);
         public Func<string, Queue<string>, string> Include;
         public string SourceFilePath { get; set; }
         private readonly List<CalcpadError> _errorList = new();
@@ -95,16 +105,42 @@ namespace Calcpad.Core
 
         private static Keywords GetKeyword(ReadOnlySpan<char> s)
         {
-            if (s.Length < 4)
+            if (s.Length < DefKeyword.Length)
                 return Keywords.None;
-            if (s.StartsWith("#def", StringComparison.OrdinalIgnoreCase))
+            if (s.StartsWith(DefKeyword, StringComparison.OrdinalIgnoreCase))
                 return Keywords.Def;
-            if (s.StartsWith("#end def", StringComparison.OrdinalIgnoreCase))
+            if (s.StartsWith(EndDefKeyword, StringComparison.OrdinalIgnoreCase))
                 return Keywords.EndDef;
-            if (s.StartsWith("#include", StringComparison.OrdinalIgnoreCase))
+            if (s.StartsWith(IncludeKeyword, StringComparison.OrdinalIgnoreCase))
                 return Keywords.Include;
+            if (s.StartsWith(ProjectPathKeyword, StringComparison.OrdinalIgnoreCase))
+                return Keywords.ProjectPath;
+            if (s.StartsWith(LibraryPathKeyword, StringComparison.OrdinalIgnoreCase))
+                return Keywords.LibraryPath;
 
             return Keywords.None;
+        }
+
+        public static bool TryGetIncludePath(ReadOnlySpan<char> line, out int start, out int length)
+        {
+            start = 0;
+            length = 0;
+            if (!line.StartsWith(IncludeKeyword, StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            var pathStart = IncludeKeyword.Length;
+            var n = line.IndexOfAny('\'', '"');
+            var nf1 = line.LastIndexOf('#');
+            if (n <= pathStart || nf1 > 0 && nf1 < n)
+                n = nf1;
+
+            if (n <= pathStart)
+                n = line.Length;
+
+            var name = line[pathStart..n];
+            start = pathStart + name.Length - name.TrimStart().Length;
+            length = name.Trim().Length;
+            return length > 0;
         }
 
         private int _parsedLineNumber;
@@ -114,11 +150,12 @@ namespace Calcpad.Core
             if (includeLine == 0)
             {
                 sb = new StringBuilder(sourceCode.Length);
-                Macros.Clear();
+                _macros.Clear();
                 _lineNumbers.Clear();
                 _includeStack.Clear();
                 _parsedLineNumber = 0;
                 _errorList.Clear();
+                _pathRoots = new PathRoots();
             }
             var macroBuilder = new StringBuilder(1000);
             var macroName = string.Empty;
@@ -143,7 +180,7 @@ namespace Calcpad.Core
                         AppendLine(sourceLine);
                         continue;
                     }
-                    if (lineContent[0] == '#' && ParseKeyword(lineContent))
+                    if (lineContent[0] == '#' && ParseKeyword(lineContent, sourceLine))
                         continue;
 
                     if (macroDefCount == 1)
@@ -152,7 +189,7 @@ namespace Calcpad.Core
                         continue;
                     }
 
-                    if (Macros.Count != 0)
+                    if (_macros.Count != 0)
                     {
                         try
                         {
@@ -188,7 +225,7 @@ namespace Calcpad.Core
             }
             return hasErrors;
 
-            bool ParseKeyword(ReadOnlySpan<char> lineContent)
+            bool ParseKeyword(ReadOnlySpan<char> lineContent, ReadOnlySpan<char> sourceLine)
             {
                 var keyword = GetKeyword(lineContent);
                 switch (keyword)
@@ -202,25 +239,42 @@ namespace Calcpad.Core
                     case Keywords.EndDef:
                         ParseEndDef(lineContent);
                         return true;
+                    case Keywords.ProjectPath:
+                    case Keywords.LibraryPath:
+                        ParsePathRoot(lineContent, sourceLine);
+                        return true;
                     default:
                         return false;
                 }
             }
 
+            void ParsePathRoot(ReadOnlySpan<char> lineContent, ReadOnlySpan<char> sourceLine)
+            {
+                PathRoots.IsDeclaration(lineContent, out var isProject, out var start, out var length);
+                if (length == 0)
+                {
+                    AppendError(lineContent, string.Format(Messages.Missing_path_value_0,
+                        isProject ? "#ProjectPath" : "#LibraryPath"));
+                    return;
+                }
+
+                var rawValue = lineContent.Slice(start, length).ToString();
+                var declaringDir = !string.IsNullOrEmpty(SourceFilePath)
+                    ? Path.GetDirectoryName(SourceFilePath) : null;
+                if (!_pathRoots.TryDeclare(isProject, rawValue, declaringDir, out var error))
+                    AppendError(lineContent, error);
+                else
+                    AppendLine(sourceLine);
+            }
+
             void ParseInclude(ReadOnlySpan<char> lineContent)
             {
-                int n = lineContent.Length;
-                if (n < 9)
+                if (lineContent.Length <= IncludeKeyword.Length)
                     AppendError(lineContent, Messages.Missing_source_file_for_include);
-                n = lineContent.IndexOfAny('\'', '"');
+
+                TryGetIncludePath(lineContent, out var start, out var length);
+                var rawFileName = lineContent.Slice(start, length).ToString();
                 var nf1 = lineContent.LastIndexOf('#');
-                if (n < 9 || nf1 > 0 && nf1 < n)
-                    n = nf1;
-
-                if (n < 9)
-                    n = lineContent.Length;
-
-                var rawFileName = lineContent[8..n].Trim().ToString();
 
                 Queue<string> fields = new();
                 if (nf1 > 0)
@@ -230,7 +284,7 @@ namespace Calcpad.Core
                         AppendError(lineContent, Messages.Brackets_not_closed);
                     else
                     {
-                        SplitEnumerator split = lineContent[(nf1 + 2)..nf2].EnumerateSplits(';');
+                        SplitEnumerator split = lineContent[(nf1 + FieldsMarker.Length)..nf2].EnumerateSplits(';');
                         foreach (var item in split)
                             fields.Enqueue(item.Trim().ToString());
                     }
@@ -238,7 +292,12 @@ namespace Calcpad.Core
 
                 var sourceDir = !string.IsNullOrEmpty(SourceFilePath)
                     ? Path.GetDirectoryName(SourceFilePath) : null;
-                var expanded = Environment.ExpandEnvironmentVariables(rawFileName);
+                if (!_pathRoots.TryExpand(rawFileName, out var tokenExpanded, out var tokenError))
+                {
+                    AppendError(lineContent, tokenError);
+                    return;
+                }
+                var expanded = Environment.ExpandEnvironmentVariables(tokenExpanded);
                 var resolvedPath = sourceDir != null
                     ? Path.GetFullPath(expanded, sourceDir)
                     : Path.GetFullPath(expanded);
@@ -277,7 +336,7 @@ namespace Calcpad.Core
                 var textSpan = new TextSpan(lineContent);
                 if (macroDefCount == 0)
                 {
-                    int i = 4, len = lineContent.Length;
+                    int i = DefKeyword.Length, len = lineContent.Length;
                     var c = EatSpace(lineContent, ref i);
                     textSpan.Reset(i);
                     while (i < len)
@@ -407,7 +466,7 @@ namespace Calcpad.Core
 
             void AddMacro(ReadOnlySpan<char> lineContent, string name, Macro macro)
             {
-                if (!Macros.TryAdd(name, macro))
+                if (!_macros.TryAdd(name, macro))
                     AppendError(lineContent, string.Format(Messages.Duplicate_macro_name_0, name));
             }
             static string LineHtml(int line) => $"[<a href=\"#0\" data-text=\"{line}\">{line}</a>]";
@@ -423,13 +482,13 @@ namespace Calcpad.Core
             return fields;
         }
 
-        private static string ApplyMacros(ReadOnlySpan<char> lineContent, HashSet<string> currentlyExpanding = null)
+        private string ApplyMacros(ReadOnlySpan<char> lineContent, HashSet<string> currentlyExpanding = null)
         {
             var index = lineContent.IndexOf("$");
             if (index < 0)
                 return lineContent.ToString();
 
-            index = lineContent.IndexOf("#{");
+            index = lineContent.IndexOf(FieldsMarker);
             var stringBuilder = new StringBuilder(200);
             var macroArguments = new List<string>();
             var bracketCount = 0;
@@ -439,7 +498,7 @@ namespace Calcpad.Core
             Queue<string> fields = null;
             if (index >= 0)
             {
-                var s = lineContent[(index + 2)..];
+                var s = lineContent[(index + FieldsMarker.Length)..];
                 lineContent = lineContent[..index];
                 var n = s.IndexOf('}');
                 if (n < 0)
@@ -481,7 +540,7 @@ namespace Calcpad.Core
                     for (j = 0; j < mlen; ++j)
                     {
                         var candidate = macroName[j..];
-                        if (Macros.TryGetValue(candidate, out macro))
+                        if (_macros.TryGetValue(candidate, out macro))
                         {
                             macroKey = candidate;
                             break;
@@ -541,7 +600,7 @@ namespace Calcpad.Core
             return stringBuilder.ToString();
         }
 
-        private static string ExpandMacro(Macro macro, List<string> macroArguments, string macroKey, ref HashSet<string> currentlyExpanding)
+        private string ExpandMacro(Macro macro, List<string> macroArguments, string macroKey, ref HashSet<string> currentlyExpanding)
         {
             if (currentlyExpanding != null && currentlyExpanding.Contains(macroKey))
                 throw Exceptions.CircularMacroReference(macroKey);

--- a/Calcpad.Core/Parsers/MathParser/MathParser.Compiler.cs
+++ b/Calcpad.Core/Parsers/MathParser/MathParser.Compiler.cs
@@ -200,7 +200,7 @@ namespace Calcpad.Core
                 return values;
             }
 
-            private static Expression ParseToken(Token t) =>
+            private Expression ParseToken(Token t) =>
                 t.Type switch
                 {
                     TokenTypes.Unit =>
@@ -361,14 +361,14 @@ namespace Calcpad.Core
                 return Expression.Call(LuDecompositionMethod, a, b);
             }
 
-            private static Expression ParseVariableToken(VariableToken t)
+            private Expression ParseVariableToken(VariableToken t)
             {
                 var v = t.Variable;
                 if (v.IsInitialized || t.Type == TokenTypes.Vector || t.Type == TokenTypes.Matrix)
                     return Expression.Property(Expression.Constant(v), typeof(Variable), nameof(Variable.Value));
                 try
                 {
-                    var u = Unit.Get(t.Content);
+                    var u = Unit.Get(t.Content, _parser.IsUs);
                     t.Type = TokenTypes.Unit;
                     v.SetValue(u);
                     return Expression.Constant(v.Value, typeof(IValue));

--- a/Calcpad.Core/Parsers/MathParser/MathParser.Evaluator.cs
+++ b/Calcpad.Core/Parsers/MathParser/MathParser.Evaluator.cs
@@ -235,7 +235,7 @@ namespace Calcpad.Core
                 try
                 {
                     if (!_units.TryGetValue(s, out var u))
-                        u = Unit.Get(s);
+                        u = Unit.Get(s, _parser.IsUs);
 
                     t.Type = TokenTypes.Unit;
                     v.SetValue(u);

--- a/Calcpad.Core/Parsers/MathParser/MathParser.Input.cs
+++ b/Calcpad.Core/Parsers/MathParser/MathParser.Input.cs
@@ -480,7 +480,7 @@ namespace Calcpad.Core
                             _parser._targetUnits = null;
                         }
                         else
-                            _parser._targetUnits = UnitsParser.Parse(unit.Trim(), _units);
+                            _parser._targetUnits = UnitsParser.Parse(unit.Trim(), _units, _parser.IsUs);
                     }
                 }
                 else
@@ -717,11 +717,11 @@ namespace Calcpad.Core
                 }
             }
 
-            private static ValueToken MakeUnitValueToken(string units)
+            private ValueToken MakeUnitValueToken(string units)
             {
                 try
                 {
-                    var unit = Unit.Get(units);
+                    var unit = Unit.Get(units, _parser.IsUs);
                     var v = new RealValue(unit);
                     return new ValueToken(v)
                     {
@@ -777,7 +777,7 @@ namespace Calcpad.Core
                         i >= assignmentIndex &&
                         t.Type == TokenTypes.Variable &&
                         !DefinedVariables.Contains(t.Content) &&
-                        Unit.TryGet(t.Content, out var u)
+                        Unit.TryGet(t.Content, _parser.IsUs, out var u)
                     )
                     {
                         t.Type = TokenTypes.Unit;

--- a/Calcpad.Core/Parsers/MathParser/MathParser.cs
+++ b/Calcpad.Core/Parsers/MathParser/MathParser.cs
@@ -41,6 +41,7 @@ namespace Calcpad.Core
         private bool _isCalculated;
         private int _isSolver;
         private Unit _targetUnits;
+        internal bool IsUs { get; set; } = true;
         private int _functionDefinitionIndex;
         private KeyValuePair<string, IValue> _backupVariable;
         private double Precision
@@ -176,6 +177,16 @@ namespace Calcpad.Core
                 throw Exceptions.VariableNotExist(name);
             }
         }
+
+        internal (int Rows, int Columns) GetVariableShape(string name) =>
+            !_variables.TryGetValue(name, out var v) || !v.IsInitialized
+                ? (0, 0)
+                : v.Value switch
+                {
+                    Vector vector => (1, vector.Length),
+                    Matrix matrix => (matrix.RowCount, matrix.ColCount),
+                    _ => (0, 0)
+                };
 
         internal Variable GetVariableRef(string name)
         {
@@ -406,7 +417,7 @@ namespace Calcpad.Core
             }
         }
 
-        private static RealValue ParseValue(ReadOnlySpan<char> s)
+        private RealValue ParseValue(ReadOnlySpan<char> s)
         {
             if (s.Length == 0)
                 return RealValue.Zero;
@@ -444,8 +455,8 @@ namespace Calcpad.Core
             if (n < s.Length)
             {
                 var unitSpan = s[n..];
-                if (!Unit.TryGet(unitSpan.ToString(), out u))
-                    u = UnitsParser.Parse(unitSpan, null);
+                if (!Unit.TryGet(unitSpan.ToString(), IsUs, out u))
+                    u = UnitsParser.Parse(unitSpan, null, IsUs);
             }
             return n == 0 ? new(u) : new(d, u);
         }
@@ -457,7 +468,7 @@ namespace Calcpad.Core
             if (Math.Abs(d) == 0d)
                 d = 1d;
 
-            var u = d * (value.Units ?? Unit.Get(string.Empty));
+            var u = d * (value.Units ?? Unit.Get(string.Empty, IsUs));
             u.Text = name;
             if (_units.TryAdd(name, u))
                 _input.DefinedVariables.Add(name);
@@ -602,7 +613,7 @@ namespace Calcpad.Core
             {
                 var s = _rpn[0].Content;
                 ref var u = ref CollectionsMarshal.GetValueRefOrAddDefault(_units, s, out bool _);
-                u = Unit.Get(string.Empty);
+                u = Unit.Get(string.Empty, IsUs);
                 u.Text = s;
             }
         }

--- a/Calcpad.Core/Parsers/UnitsParser.cs
+++ b/Calcpad.Core/Parsers/UnitsParser.cs
@@ -110,15 +110,15 @@ namespace Calcpad.Core
             _ => -1,
         };
 
-        internal static Unit Parse(ReadOnlySpan<char> expression, Dictionary<string, Unit> units)
+        internal static Unit Parse(ReadOnlySpan<char> expression, Dictionary<string, Unit> units, bool isUs)
         {
-            var input = GetInput(expression, units);
+            var input = GetInput(expression, units, isUs);
             UnitValidator.Check(input);
             var rpn = GetRpn(input);
             return Evaluate(rpn);
         }
 
-        private static Queue<Token> GetInput(ReadOnlySpan<char> expression, Dictionary<string, Unit> units)
+        private static Queue<Token> GetInput(ReadOnlySpan<char> expression, Dictionary<string, Unit> units, bool isUs)
         {
             // Tokenize input string
             // It is converted to a queue of recognizable tokens
@@ -197,7 +197,7 @@ namespace Calcpad.Core
                 if (pt == TokenTypes.Units)
                 {
                     if (units is null || !units.TryGetValue(literal, out var u))
-                        Unit.TryGet(literal, out u);
+                        Unit.TryGet(literal, isUs, out u);
 
                     if (u is null)
                         throw Exceptions.InvalidUnits(literal);

--- a/Calcpad.Core/PathRoots.cs
+++ b/Calcpad.Core/PathRoots.cs
@@ -1,0 +1,163 @@
+using System;
+using System.IO;
+
+namespace Calcpad.Core
+{
+    public sealed class PathRoots
+    {
+        private const string ProjectToken = "{project}";
+        private const string LibraryToken = "{library}";
+        private const string UserToken = "{user}";
+        private const string ProjectKeyword = "#projectpath";
+        private const string LibraryKeyword = "#librarypath";
+
+        public string Project { get; private set; }
+        public string Library { get; private set; }
+
+        public static bool HasToken(ReadOnlySpan<char> path) =>
+            path.StartsWith(ProjectToken, StringComparison.OrdinalIgnoreCase)
+            || path.StartsWith(LibraryToken, StringComparison.OrdinalIgnoreCase);
+
+        public static bool IsUserToken(ReadOnlySpan<char> path) =>
+            path.StartsWith(UserToken, StringComparison.OrdinalIgnoreCase);
+
+        private static string ExpandUserToken(string raw)
+        {
+            var rest = raw[UserToken.Length..];
+            if (rest.Length > 0 && (rest[0] == '/' || rest[0] == '\\'))
+                rest = rest[1..];
+
+            var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            return rest.Length == 0 ? home : Path.Combine(home, rest);
+        }
+        public static bool TryGetTokenKind(ReadOnlySpan<char> path, out bool isProject)
+        {
+            if (path.StartsWith(ProjectToken, StringComparison.OrdinalIgnoreCase))
+            {
+                isProject = true;
+                return true;
+            }
+            if (path.StartsWith(LibraryToken, StringComparison.OrdinalIgnoreCase))
+            {
+                isProject = false;
+                return true;
+            }
+            isProject = false;
+            return false;
+        }
+
+        public static bool IsDeclaration(ReadOnlySpan<char> line, out bool isProject, out int start, out int length)
+        {
+            isProject = false;
+            start = 0;
+            length = 0;
+
+            if (line.StartsWith(ProjectKeyword, StringComparison.OrdinalIgnoreCase))
+                isProject = true;
+            else if (line.StartsWith(LibraryKeyword, StringComparison.OrdinalIgnoreCase))
+                isProject = false;
+            else
+                return false;
+
+            var keywordLength = isProject ? ProjectKeyword.Length : LibraryKeyword.Length;
+            var rest = line[keywordLength..];
+            var trimmedStart = rest.Length - rest.TrimStart().Length;
+            var value = rest[trimmedStart..];
+            var commentIndex = value.IndexOfAny('\'', '"');
+            if (commentIndex >= 0)
+                value = value[..commentIndex];
+            value = value.TrimEnd();
+
+            start = keywordLength + trimmedStart;
+            length = value.Length;
+            return true;
+        }
+
+        private static readonly StringComparer PathComparer =
+            OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+
+        public bool TryDeclare(bool isProject, string rawValue, string declaringDirectory, out string error)
+        {
+            error = null;
+            if (string.IsNullOrWhiteSpace(rawValue))
+            {
+                error = string.Format(Messages.Missing_path_value_0,
+                    isProject ? "#ProjectPath" : "#LibraryPath");
+                return false;
+            }
+
+            string resolved;
+            try
+            {
+                var expanded = IsUserToken(rawValue.AsSpan()) ? ExpandUserToken(rawValue) : rawValue;
+                expanded = Environment.ExpandEnvironmentVariables(expanded);
+                resolved = string.IsNullOrEmpty(declaringDirectory)
+                    ? Path.GetFullPath(expanded)
+                    : Path.GetFullPath(expanded, declaringDirectory);
+            }
+            catch (Exception ex)
+            {
+                error = ex.Message;
+                return false;
+            }
+
+            if (!Directory.Exists(resolved))
+            {
+                error = string.Format(Messages.Path_root_folder_not_found_0_1,
+                    isProject ? "#ProjectPath" : "#LibraryPath", resolved);
+                return false;
+            }
+
+            var existing = isProject ? Project : Library;
+            if (existing is not null)
+            {
+                if (PathComparer.Equals(existing, resolved))
+                    return true;
+
+                error = string.Format(Messages.Duplicate_path_declaration_0,
+                    isProject ? "#ProjectPath" : "#LibraryPath");
+                return false;
+            }
+
+            if (isProject)
+                Project = resolved;
+            else
+                Library = resolved;
+            return true;
+        }
+
+        public bool TryExpand(string raw, out string expanded, out string error)
+        {
+            error = null;
+            expanded = raw;
+            if (raw is null)
+                return true;
+
+            if (IsUserToken(raw.AsSpan()))
+            {
+                expanded = ExpandUserToken(raw);
+                return true;
+            }
+
+            if (!TryGetTokenKind(raw.AsSpan(), out var isProject))
+                return true;
+
+            var tokenLength = (isProject ? ProjectToken : LibraryToken).Length;
+            var root = isProject ? Project : Library;
+            if (root is null)
+            {
+                error = string.Format(Messages.Path_root_not_declared_0_1,
+                    isProject ? ProjectToken : LibraryToken,
+                    isProject ? "#ProjectPath" : "#LibraryPath");
+                return false;
+            }
+
+            var rest = raw[tokenLength..];
+            if (rest.Length > 0 && (rest[0] == '/' || rest[0] == '\\'))
+                rest = rest[1..];
+
+            expanded = rest.Length == 0 ? root : Path.Combine(root, rest);
+            return true;
+        }
+    }
+}

--- a/Calcpad.Core/Settings.cs
+++ b/Calcpad.Core/Settings.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text.Json;
 
 namespace Calcpad.Core
 {
@@ -12,6 +11,7 @@ namespace Calcpad.Core
         Substitute,
         FormatEquations,
         ZeroSmallMatrixElements,
+        ShowHiddenOutput,
         MaxOutputCount,
         Units,
         IsUs,
@@ -27,12 +27,10 @@ namespace Calcpad.Core
         Tol
     }
 
-    public readonly record struct SettingError(SettingKey Key, string Message);
-
     /// <summary>
     /// JSON payload of the <c>#settings {...}</c> directive.
     /// </summary>
-    public sealed class SettingsDto
+    public sealed class SettingsDto : DirectiveDto<SettingsDto, SettingKey>
     {
         public int? Decimals { get; set; }
         public int? Degrees { get; set; }
@@ -40,6 +38,7 @@ namespace Calcpad.Core
         public bool? Substitute { get; set; }
         public bool? FormatEquations { get; set; }
         public bool? ZeroSmallMatrixElements { get; set; }
+        public bool? ShowHiddenOutput { get; set; }
         public int? MaxOutputCount { get; set; }
         public string Units { get; set; }
         public bool? IsUs { get; set; }
@@ -54,25 +53,14 @@ namespace Calcpad.Core
         public double? Precision { get; set; }
         public double? Tol { get; set; }
 
-        private static readonly JsonSerializerOptions Options = new() { PropertyNameCaseInsensitive = true };
-
-        /// <summary>Recognized keys, derived from <see cref="SettingKey"/> (case-insensitive).</summary>
-        public static readonly IReadOnlySet<string> KnownKeys =
-            new HashSet<string>(Enum.GetNames(typeof(SettingKey)), StringComparer.OrdinalIgnoreCase);
-
-        /// <summary>Deserializes a <c>#settings</c> JSON payload. Throws <see cref="JsonException"/> on malformed JSON or a wrong value type.</summary>
-        public static SettingsDto Parse(string json) => JsonSerializer.Deserialize<SettingsDto>(json, Options);
-
         /// <summary>
-        /// Returns an entry for every provided value that is outside its allowed range.
         /// Bounds mirror how <c>Calcpad.Core</c> constrains each value: <c>decimals</c> and
         /// <c>maxOutputCount</c> match their setter clamps, <c>precision</c>/<c>tol</c> match the
         /// solver's read clamp, <c>degrees</c> is a hard array index (0..2), and the plot
         /// dimensions only require a positive size (Core imposes no upper bound).
         /// </summary>
-        public IReadOnlyList<SettingError> Validate()
+        protected override void Validate(List<DirectiveError<SettingKey>> errors)
         {
-            var errors = new List<SettingError>();
             CheckRange(errors, SettingKey.Decimals, "decimals", Decimals, 0, 15);
             CheckRange(errors, SettingKey.Degrees, "degrees", Degrees, 0, 2);
             CheckRange(errors, SettingKey.MaxOutputCount, "maxOutputCount", MaxOutputCount, 5, 100);
@@ -83,18 +71,6 @@ namespace Calcpad.Core
             CheckRange(errors, SettingKey.Tol, "tol", Tol, 1e-15, 1e-2);
             if (ColorScale is not null && !Enum.TryParse<PlotSettings.ColorScales>(ColorScale, true, out _))
                 errors.Add(new(SettingKey.ColorScale, $"'colorScale' must be one of: {string.Join(", ", Enum.GetNames(typeof(PlotSettings.ColorScales)))}"));
-            return errors;
-        }
-
-        private static void CheckRange<T>(List<SettingError> errors, SettingKey key, string name, T? value, double min, double? max) where T : struct, IConvertible
-        {
-            if (value is null)
-                return;
-            var d = value.Value.ToDouble(null);
-            if (d < min || max.HasValue && d > max.Value)
-                errors.Add(new(key, max.HasValue
-                    ? $"'{name}' must be between {min} and {max.Value}"
-                    : $"'{name}' must be at least {min}"));
         }
     }
 
@@ -104,7 +80,7 @@ namespace Calcpad.Core
         public MathSettings Math { get; set; } = new();
         public PlotSettings Plot { get; set; } = new();
         public string Units { get; set; } = "m";
-        public bool IsUs { get; set; }
+        public bool IsUs { get; set; } = true;
     }
 
     [Serializable()]
@@ -130,6 +106,7 @@ namespace Calcpad.Core
         public bool Substitute { get; set; }
         public bool FormatEquations { get; set; }
         public bool ZeroSmallMatrixElements { get; set; }
+        public bool ShowHiddenOutput { get; set; }
         public int MaxOutputCount
         {
             get => _maxOutputCount;
@@ -155,6 +132,7 @@ namespace Calcpad.Core
             Substitute = true;
             FormatEquations = true;
             ZeroSmallMatrixElements = true;
+            ShowHiddenOutput = false;
             MaxOutputCount = 20;
             Precision = 1e-14;
             Tol = 1e-6;

--- a/Calcpad.Core/UiDto.cs
+++ b/Calcpad.Core/UiDto.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Calcpad.Core
+{
+    public enum UiKey
+    {
+        Type,
+        Mode,
+        Style,
+        ReportStyle,
+        Rows,
+        Columns,
+        ColumnHeaders,
+        RowHeaders,
+        Keys,
+        Values
+    }
+
+    /// <summary>
+    /// JSON payload of the <c>#UI {...}</c> directive.
+    /// </summary>
+    public sealed class UiDto : DirectiveDto<UiDto, UiKey>
+    {
+        public string Type { get; set; }
+        public string Mode { get; set; }
+        public string Style { get; set; }
+        public string ReportStyle { get; set; }
+        public int? Rows { get; set; }
+        public int? Columns { get; set; }
+        public string[] ColumnHeaders { get; set; }
+        public string[] RowHeaders { get; set; }
+        public string[] Keys { get; set; }
+        public string[] Values { get; set; }
+
+        /// <summary>The control types <see cref="ExpressionParser"/> knows how to render.</summary>
+        public static readonly IReadOnlyList<string> KnownTypes =
+            ["entry", "datagrid", "dropdown", "radio", "checkbox"];
+
+        /// <summary>True for the types whose choices come from the paired keys and values arrays.</summary>
+        public bool HasOptions => Type is "dropdown" or "radio";
+
+        protected override void Validate(List<DirectiveError<UiKey>> errors)
+        {
+            if (Type is not null && !KnownTypes.Contains(Type))
+                errors.Add(new(UiKey.Type, string.Format(
+                    Messages.The_UI_type_0_is_not_recognized_expected_one_of_1, Type, string.Join(", ", KnownTypes))));
+
+            if (Mode is not null && !Mode.Equals("number", StringComparison.OrdinalIgnoreCase))
+                errors.Add(new(UiKey.Mode, Messages.Only_numbers_are_supported_by_the_UI_keyword));
+
+            CheckNotNegative(errors, UiKey.Rows, "rows", Rows);
+            CheckNotNegative(errors, UiKey.Columns, "columns", Columns);
+
+            if (HasOptions)
+            {
+                if (Keys is null || Values is null)
+                    errors.Add(new(UiKey.Keys, string.Format(
+                        Messages.The_UI_0_requires_both_keys_and_values_arrays, Type)));
+                else if (Keys.Length != Values.Length)
+                    errors.Add(new(UiKey.Keys, string.Format(
+                        Messages.The_UI_0_keys_and_values_arrays_must_have_the_same_length, Type, Keys.Length, Values.Length)));
+            }
+
+            // Only checked against a declared size: an omitted one is auto-detected later,
+            // from the right hand side the payload cannot see.
+            CheckHeaderCount(errors, UiKey.ColumnHeaders, "columnHeaders", ColumnHeaders, Columns, "columns");
+            CheckHeaderCount(errors, UiKey.RowHeaders, "rowHeaders", RowHeaders, Rows, "rows");
+        }
+
+        private static void CheckNotNegative(List<DirectiveError<UiKey>> errors, UiKey key, string name, int? value)
+        {
+            if (value < 0)
+                errors.Add(new(key, string.Format(Messages.The_UI_0_must_not_be_negative, name)));
+        }
+
+        private static void CheckHeaderCount(List<DirectiveError<UiKey>> errors, UiKey key, string name, string[] headers, int? size, string sizeName)
+        {
+            if (headers is null || size is null || headers.Length <= size)
+                return;
+
+            errors.Add(new(key, string.Format(
+                Messages.The_UI_0_has_1_entries_but_the_grid_has_2_3, name, headers.Length, size.Value, sizeName)));
+        }
+    }
+}

--- a/Calcpad.Core/UiSyntax.cs
+++ b/Calcpad.Core/UiSyntax.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Collections.Generic;
+
+namespace Calcpad.Core
+{
+    public static class UiSyntax
+    {
+        public static List<(string Name, string Rhs)> EnumerateAssignments(ReadOnlySpan<char> s)
+        {
+            var found = new List<(string, string)>();
+            foreach (var segment in s.EnumerateComments())
+            {
+                if (!IsCode(segment))
+                    continue;
+
+                var i = segment.IndexOf('=');
+                if (i < 1)
+                    continue;
+
+                var name = segment[..i].Trim().ToString();
+                if (name.Length != 0)
+                    found.Add((name, segment[(i + 1)..].Trim().ToString()));
+            }
+            return found;
+        }
+
+        /// <summary>True for a segment of <see cref="CommentEnumerator"/> that is code, not a comment.</summary>
+        public static bool IsCode(ReadOnlySpan<char> segment) =>
+            !segment.IsEmpty && segment[0] != '\'' && segment[0] != '"';
+
+        public static bool IsValue(ReadOnlySpan<char> rhs)
+        {
+            rhs = rhs.Trim();
+            if (rhs.IsEmpty)
+                return true;
+
+            if (rhs[0] == '[')
+                return IsMatrixLiteral(rhs);
+
+            return IsConstructor(rhs, "vector") ||
+                IsConstructor(rhs, "matrix") ||
+                IsNumber(rhs);
+        }
+
+        private static bool IsMatrixLiteral(ReadOnlySpan<char> s)
+        {
+            if (s[^1] != ']')
+                return false;
+
+            foreach (var row in s[1..^1].EnumerateSplits('|'))
+                foreach (var cell in row.EnumerateSplits(';'))
+                {
+                    var value = cell.Trim();
+                    if (!value.IsEmpty && !IsNumber(value))
+                        return false;
+                }
+
+            return true;
+        }
+
+        private static bool IsConstructor(ReadOnlySpan<char> s, ReadOnlySpan<char> name)
+        {
+            if (!s.StartsWith(name, StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            var rest = s[name.Length..].TrimStart();
+            return rest.Length > 1 && rest[0] == '(' && ClosesAtEnd(rest);
+        }
+
+        private static bool ClosesAtEnd(ReadOnlySpan<char> s)
+        {
+            var depth = 0;
+            for (var i = 0; i < s.Length; ++i)
+            {
+                if (s[i] == '(')
+                    ++depth;
+                else if (s[i] == ')' && --depth == 0)
+                    return i == s.Length - 1;
+            }
+            return false;
+        }
+
+        private static bool IsNumber(ReadOnlySpan<char> s)
+        {
+            if (s.IsEmpty)
+                return false;
+
+            var i = s[0] is '+' or '-' or '−' ? 1 : 0;
+            var digits = SkipDigits(s, ref i);
+            if (i < s.Length && s[i] == '.')
+            {
+                ++i;
+                digits += SkipDigits(s, ref i);
+            }
+            return digits > 0 && IsUnits(s[i..]);
+        }
+
+        private static bool IsUnits(ReadOnlySpan<char> s)
+        {
+            if (s.IsWhiteSpace())
+                return true;
+
+            var expectName = true;
+            for (var i = 0; i < s.Length;)
+            {
+                var c = s[i];
+                if (c == ' ')
+                    ++i;
+                else if (expectName)
+                {
+                    if (!IsUnitChar(c))
+                        return false;
+
+                    while (i < s.Length && IsUnitChar(s[i]))
+                        ++i;
+
+                    expectName = false;
+                }
+                else if (c == '^')
+                {
+                    ++i;
+                    if (!IsPower(s, ref i))
+                        return false;
+                }
+                else if (c is '*' or '/' or '·' or '×' or '∙')
+                {
+                    ++i;
+                    expectName = true;
+                }
+                else
+                    return false;
+            }
+            return !expectName;
+        }
+
+        private static bool IsPower(ReadOnlySpan<char> s, ref int i)
+        {
+            while (i < s.Length && s[i] == ' ')
+                ++i;
+
+            if (i < s.Length && s[i] is '+' or '-' or '−')
+                ++i;
+
+            var digits = SkipDigits(s, ref i);
+            if (i < s.Length && s[i] == '.')
+            {
+                ++i;
+                digits += SkipDigits(s, ref i);
+            }
+            return digits > 0;
+        }
+
+        private static int SkipDigits(ReadOnlySpan<char> s, ref int i)
+        {
+            var start = i;
+            while (i < s.Length && char.IsAsciiDigit(s[i]))
+                ++i;
+
+            return i - start;
+        }
+
+        private static bool IsUnitChar(char c) =>
+            char.IsLetter(c) || c is '°' or '%' or '‰' or '‱' or '′' or '″' or '℧' or '_';
+    }
+}

--- a/Calcpad.Tests/Scalars/UnitsTests.cs
+++ b/Calcpad.Tests/Scalars/UnitsTests.cs
@@ -1791,7 +1791,38 @@
 
         [Fact]
         [Trait("Category", "Mechanical Formulas")]
-        public void Test_ton_ft_s2() => Test("100ton*32.17404855643045ft/s^2", "224kip");
+        public void Test_ton_ft_s2()
+        {
+            // Settings.IsUs defaults to true (US) — go through ExpressionParser rather than
+            // TestCalc/MathParser directly, since only ExpressionParser.Parse reads it.
+            var parser = new ExpressionParser { Settings = new Settings() };
+            parser.Parse("r = 100ton*32.17404855643045ft/s^2", true, false);
+            Assert.Contains("200", parser.HtmlResult);
+        }
+
+        [Fact]
+        [Trait("Category", "Mechanical Formulas")]
+        public void Test_ton_ft_s2_UK()
+        {
+            var parser = new ExpressionParser { Settings = new Settings() };
+            parser.Parse("#settings {\"isUs\": false}\nr = 100ton*32.17404855643045ft/s^2", true, false);
+            Assert.Contains("224", parser.HtmlResult);
+        }
+
+        [Fact]
+        [Trait("Category", "Mechanical Formulas")]
+        public async Task ConcurrentParsers_DoNotShareIsUsSetting()
+        {
+            var tasks = Enumerable.Range(0, 32).Select(i => Task.Run(() =>
+            {
+                var isUs = i % 2 == 0;
+                var parser = new ExpressionParser { Settings = new Settings() };
+                parser.Parse($"#settings {{\"isUs\": {(isUs ? "true" : "false")}}}\nr = 100ton*32.17404855643045ft/s^2", true, false);
+                Assert.Contains(isUs ? "200" : "224", parser.HtmlResult);
+            }));
+
+            await Task.WhenAll(tasks);
+        }
 
         [Fact]
         [Trait("Category", "Mechanical Formulas")]

--- a/Calcpad.Tests/SettingsDirectiveTests.cs
+++ b/Calcpad.Tests/SettingsDirectiveTests.cs
@@ -73,7 +73,7 @@ namespace Calcpad.Tests
         {
             var parser = new ExpressionParser { Settings = new Settings(), Debug = true };
             parser.Parse("#settings {not valid}\nx = 1", true, false);
-            Assert.Contains("Invalid settings", parser.HtmlResult);
+            Assert.Contains("Invalid JSON in #settings", parser.HtmlResult);
         }
 
         [Fact]
@@ -82,7 +82,7 @@ namespace Calcpad.Tests
             // Unrecognized keys are silently ignored by the engine (the linter warns).
             var parser = new ExpressionParser { Settings = new Settings(), Debug = true };
             parser.Parse("#settings {\"nonsense\": 4}\nx = 1", true, false);
-            Assert.DoesNotContain("Invalid settings", parser.HtmlResult);
+            Assert.DoesNotContain("Invalid JSON in #settings", parser.HtmlResult);
         }
     }
 }

--- a/Examples/Engineering/3D, Plotting, Drawing/Bolt 3D Model.html.stub
+++ b/Examples/Engineering/3D, Plotting, Drawing/Bolt 3D Model.html.stub
@@ -38,6 +38,21 @@
  </p>
  <p>
   Bolt diameter -
+  <select data-target="bolt">
+   <option value="12">M12</option>
+   <option value="14">M14</option>
+   <option value="16">M16</option>
+   <option value="18">M18</option>
+   <option value="20">M20</option>
+   <option value="22">M22</option>
+   <option value="24">M24</option>
+   <option value="27">M27</option>
+   <option value="30">M30</option>
+   <option value="36">M36</option>
+  </select>
+ </p>
+ <p>
+  Bolt diameter -
   <span class="eq">
    <var>d</var>
    = 12
@@ -103,6 +118,18 @@
    =
    <u class="input-54">10.9</u>
   </span>
+ </p>
+ <p>
+  Bolt steel grade -
+  <select data-target="grade">
+   <option value="4.6">4.6</option>
+   <option value="4.8">4.8</option>
+   <option value="5.6">5.6</option>
+   <option value="5.8">5.8</option>
+   <option value="6.8">6.8</option>
+   <option value="8.8">8.8</option>
+   <option value="10.9">10.9</option>
+  </select>
  </p>
  Bolt steel grade - 10.9
  <p>

--- a/Examples/Engineering/Parametric Curves/Common Spirals.html.stub
+++ b/Examples/Engineering/Parametric Curves/Common Spirals.html.stub
@@ -686,4 +686,11 @@ circle.Series1 {fill:Tomato;}
    </polyline>
   </g>
  </svg>
+ <p>
+ </p>
+ <p>
+  Tip: Click "
+  <b>Calculate</b>
+  " to see the respective plot.
+ </p>
 </div>

--- a/Examples/Engineering/Parametric Curves/Cornu Spiral.html.stub
+++ b/Examples/Engineering/Parametric Curves/Cornu Spiral.html.stub
@@ -144,4 +144,11 @@ circle.Series1 {fill:Tomato;}
    </polyline>
   </g>
  </svg>
+ <p>
+ </p>
+ <p>
+  Tip: Click "
+  <b>Calculate</b>
+  " to see the respective plot.
+ </p>
 </div>

--- a/Examples/Engineering/Parametric Curves/Epicycloid.html.stub
+++ b/Examples/Engineering/Parametric Curves/Epicycloid.html.stub
@@ -87,6 +87,13 @@
     = 2.1
    </span>
   </p>
+  <p>
+  </p>
+  <p>
+   Tip: Click "
+   <b>Calculate</b>
+   " to see the respective plot.
+  </p>
   <svg class="plot" data-plot="svg" height="1840px" style="width:346.3pt; height:340.74pt;" version="1.1" viewbox=" 0 0 1870 1840" width="1870px" xmlns="http://www.w3.org/2000/svg">
    <style type="text/css">
     .plot text {fill:Black; font-family:'Segoe UI', Sans; font-size:44px}

--- a/Examples/Engineering/Parametric Curves/Hypocycloid.html.stub
+++ b/Examples/Engineering/Parametric Curves/Hypocycloid.html.stub
@@ -87,6 +87,13 @@
     = 7.33
    </span>
   </p>
+  <p>
+  </p>
+  <p>
+   Tip: Click "
+   <b>Calculate</b>
+   " to see the respective plot.
+  </p>
   <svg class="plot" data-plot="svg" height="1840px" style="width:346.3pt; height:340.74pt;" version="1.1" viewbox=" 0 0 1870 1840" width="1870px" xmlns="http://www.w3.org/2000/svg">
    <style type="text/css">
     .plot text {fill:Black; font-family:'Segoe UI', Sans; font-size:44px}

--- a/Examples/Engineering/Parametric Curves/Lissajous Curve.html.stub
+++ b/Examples/Engineering/Parametric Curves/Lissajous Curve.html.stub
@@ -43,6 +43,13 @@
    <u class="input-10">3</u>
   </span>
  </p>
+ <p>
+ </p>
+ <p>
+  Tip: Click "
+  <b>Calculate</b>
+  " to see the respective plot.
+ </p>
  <svg class="plot" data-plot="svg" height="1840px" style="width:346.3pt; height:340.74pt;" version="1.1" viewbox=" 0 0 1870 1840" width="1870px" xmlns="http://www.w3.org/2000/svg">
   <style type="text/css">
    .plot text {fill:Black; font-family:'Segoe UI', Sans; font-size:44px}

--- a/Examples/Engineering/Parametric Curves/Rose Curve.html.stub
+++ b/Examples/Engineering/Parametric Curves/Rose Curve.html.stub
@@ -52,6 +52,63 @@
    )
   </span>
  </p>
+ <p>
+  Coefficients
+  <i>a</i>
+  /
+  <i>b</i>
+  =
+  <select data-target="ab">
+   <option value="2;1">2</option>
+   <option value="3;1">3</option>
+   <option value="4;1">4</option>
+   <option value="5;1">5</option>
+   <option value="6;1">6</option>
+   <option value="7;1">7</option>
+   <option value="3;2">3/2</option>
+   <option value="5;2">5/2</option>
+   <option value="7;2">7/2</option>
+   <option value="2;3">2/3</option>
+   <option value="4;3">4/3</option>
+   <option value="5;3">5/3</option>
+   <option value="7;3">7/3</option>
+   <option value="3;4">3/4</option>
+   <option value="5;4">5/4</option>
+   <option value="7;4">7/4</option>
+   <option value="2;5">2/5</option>
+   <option value="3;5">3/5</option>
+   <option value="4;5">4/5</option>
+   <option value="6;5">6/5</option>
+   <option value="7;5">7/5</option>
+   <option value="5;6">5/6</option>
+   <option value="7;6">7/6</option>
+   <option value="2;7">2/7</option>
+   <option value="3;7">3/7</option>
+   <option value="4;7">4/7</option>
+   <option value="5;7">5/7</option>
+   <option value="6;7">6/7</option>
+  </select>
+ </p>
+ <p id="ab" style="display:none;">
+  <span class="eq">
+   <var>a</var>
+   =
+   <u class="input-38">4</u>
+  </span>
+  ,
+  <span class="eq">
+   <var>b</var>
+   =
+   <u class="input-38">1</u>
+  </span>
+ </p>
+ <p>
+ </p>
+ <p>
+  Tip: Click "
+  <b>Calculate</b>
+  " to see the respective plot.
+ </p>
  Coefficients
  <i>a</i>
  /

--- a/Examples/Structural/Cantilevers/Concentrated Force.html.stub
+++ b/Examples/Structural/Cantilevers/Concentrated Force.html.stub
@@ -61,6 +61,10 @@
    </span>
    m
   </p>
+  <p>
+  </p>
+  <p>
+  </p>
   <p>Bending</p>
   <p>
    <span class="eq">

--- a/Examples/Structural/Cantilevers/Concentrated Moment.html.stub
+++ b/Examples/Structural/Cantilevers/Concentrated Moment.html.stub
@@ -57,6 +57,8 @@
    </span>
    m
   </p>
+  <p>
+  </p>
   <p>Bending</p>
   <p>
    <span class="eq">

--- a/Examples/Structural/Cantilevers/Linearly Distributed Load.html.stub
+++ b/Examples/Structural/Cantilevers/Linearly Distributed Load.html.stub
@@ -109,6 +109,10 @@
    m
   </p>
   <p>
+  </p>
+  <p>
+  </p>
+  <p>
    <span class="eq">
     <var>q</var>
     (

--- a/Examples/Structural/Cantilevers/Partially Distributed Load.html.stub
+++ b/Examples/Structural/Cantilevers/Partially Distributed Load.html.stub
@@ -102,6 +102,8 @@
    </span>
    m
   </p>
+  <p>
+  </p>
   <p>Bending</p>
   <p>
    <span class="eq">

--- a/Examples/Structural/Fully Restrained Beams/Concentrated Force.html.stub
+++ b/Examples/Structural/Fully Restrained Beams/Concentrated Force.html.stub
@@ -253,6 +253,10 @@
    </span>
    m
   </p>
+  <p>
+  </p>
+  <p>
+  </p>
   <p>Bending</p>
   <p>
    <span class="eq">

--- a/Examples/Structural/Fully Restrained Beams/Concentrated Moment.html.stub
+++ b/Examples/Structural/Fully Restrained Beams/Concentrated Moment.html.stub
@@ -206,6 +206,8 @@
    </span>
    m
   </p>
+  <p>
+  </p>
   <p>Bending</p>
   <p>
    <span class="eq">

--- a/Examples/Structural/Fully Restrained Beams/Linearly Distributed Load.html.stub
+++ b/Examples/Structural/Fully Restrained Beams/Linearly Distributed Load.html.stub
@@ -290,6 +290,10 @@
    m
   </p>
   <p>
+  </p>
+  <p>
+  </p>
+  <p>
    <span class="eq">
     <var>q</var>
     (

--- a/Examples/Structural/Fully Restrained Beams/Partially Distributed Load.html.stub
+++ b/Examples/Structural/Fully Restrained Beams/Partially Distributed Load.html.stub
@@ -337,6 +337,8 @@
    </span>
    m
   </p>
+  <p>
+  </p>
   <p>Bending</p>
   <p>
    <span class="eq">

--- a/Examples/Structural/Fully Restrained Beams/Uniformly Distributed Load.html.stub
+++ b/Examples/Structural/Fully Restrained Beams/Uniformly Distributed Load.html.stub
@@ -120,6 +120,10 @@
    </span>
    m
   </p>
+  <p>
+  </p>
+  <p>
+  </p>
   <p>Bending</p>
   <p>
    <span class="eq">

--- a/Examples/Structural/Loads/Wind Load.html.stub
+++ b/Examples/Structural/Loads/Wind Load.html.stub
@@ -221,6 +221,24 @@
     = 1
    </span>
   </p>
+  <p id="C" style="display:none;">
+   <span class="eq">
+    <var>C</var>
+    =
+    <u class="input-39">4</u>
+   </span>
+  </p>
+  <p class="ref">[EN 1991-1-4, Table 4.1]</p>
+  <p>Terrain categories</p>
+  <p>
+   <select data-target="C">
+    <option value="0">0. Sea or coastal area...</option>
+    <option value="1">I. Lakes or flat and horizontal area...</option>
+    <option value="2">II. Area with low vegetation...</option>
+    <option value="3">III. Area with regular cover of vegetation or buildings...</option>
+    <option value="4">IV. Area in which at least 15 % of the surface is covered with buildings with h &gt; 15 m</option>
+   </select>
+  </p>
   <p class="ref">[EN 1991-1-4, Table 4.1]</p>
   <p>
    Terrain category - IV:

--- a/Examples/Structural/Propped Cantilevers/Concentrated Force.html.stub
+++ b/Examples/Structural/Propped Cantilevers/Concentrated Force.html.stub
@@ -182,6 +182,8 @@
    </span>
    m
   </p>
+  <p>
+  </p>
   <p>Bending</p>
   <p>
    <span class="eq">

--- a/Examples/Structural/Propped Cantilevers/Concentrated Moment.html.stub
+++ b/Examples/Structural/Propped Cantilevers/Concentrated Moment.html.stub
@@ -164,6 +164,8 @@
    </span>
    m
   </p>
+  <p>
+  </p>
   <p>Bending</p>
   <p>
    <span class="eq">

--- a/Examples/Structural/Propped Cantilevers/Linearly Distributed Load.html.stub
+++ b/Examples/Structural/Propped Cantilevers/Linearly Distributed Load.html.stub
@@ -1,6 +1,7 @@
 <div class="calcpad-output">
  <!-- Propped cantilever under a trapezoidal load defined by end intensities $q_1$ and $q_2$, locating the in-span peak from the zero of the shear $V(x)$. -->
  <div style="max-width:180mm;">
+  <img alt="propped-cantilever-beam-distributed-load-linear-left.png" class="side" src="Images/mechanics/beams/propped-cantilever-beam-distributed-load-linear-left.png" style="width:210pt;"/>
   <p>
    <b>Input data</b>
   </p>
@@ -32,291 +33,227 @@
   </p>
   <div class="side">
    <img alt="propped-cantilever-beam-distributed-load-linear-right.png" src="Images/mechanics/beams/propped-cantilever-beam-distributed-load-linear-right.png" style="width:210pt;"/>
-  </div>
-  <p>
-   <span class="eq">
-    <var>Δq</var>
-    =
-    <var>q</var>
-    <sub>2</sub>
-    −
-    <var>q</var>
-    <sub>1</sub>
-    = 10 − 5 = 5
-   </span>
-   kN/m
-  </p>
-  <p>
-   <b>Internal forces</b>
-  </p>
-  <p>Bending at support</p>
-  <p>
-   <span class="eq">
-    <var>M</var>
-    <sub>A</sub>
-    =
-    <span class="dvc">
-     ( 8 ·
+   <p>
+    Calculate internal forces at
+    <span class="eq">
+     <var>x</var>
+     <sub>1</sub>
+     =
+     <u class="input-42">1</u>
+    </span>
+    m
+   </p>
+   <p>
+   </p>
+   <p>
+   </p>
+   <p>
+   </p>
+   <p>
+    <span class="eq">
+     <var>q</var>
+     (
+     <var>x</var>
+     )  =
      <var>q</var>
      <sub>1</sub>
-     + 7 ·
-     <var>q</var>
-     <sub>2</sub>
-     )  ·
-     <var>l</var>
-     <sup>2</sup>
-     <span class="dvl">
-     </span>
-     120
-    </span>
-    =
-    <span class="dvc">
-     ( 8 · 5 + 7 · 10 )  · 10
-     <sup>2</sup>
-     <span class="dvl">
-     </span>
-     120
-    </span>
-    = 91.67
-   </span>
-   kN·m
-  </p>
-  <p>Shear</p>
-  <p>
-   <span class="eq">
-    <var>V</var>
-    <sub>A</sub>
-    =
-    <span class="dvc">
-     ( 16 ·
-     <var>q</var>
-     <sub>1</sub>
-     + 9 ·
-     <var>q</var>
-     <sub>2</sub>
-     )  ·
-     <var>l</var>
-     <span class="dvl">
-     </span>
-     40
-    </span>
-    =
-    <span class="dvc">
-     ( 16 · 5 + 9 · 10 )  · 10
-     <span class="dvl">
-     </span>
-     40
-    </span>
-    = 42.5
-   </span>
-   kN
-  </p>
-  <p>
-   <span class="eq">
-    <var>V</var>
-    <sub>B</sub>
-    =
-    <span class="dvc">
-     ( 4 ·
-     <var>q</var>
-     <sub>1</sub>
-     + 11 ·
-     <var>q</var>
-     <sub>2</sub>
-     )  ·
-     <var>l</var>
-     <span class="dvl">
-     </span>
-     40
-    </span>
-    =
-    <span class="dvc">
-     ( 4 · 5 + 11 · 10 )  · 10
-     <span class="dvl">
-     </span>
-     40
-    </span>
-    = 32.5
-   </span>
-   kN
-  </p>
-  <p>Bending at mid-span</p>
-  <p>
-   <span class="eq">
-    <var>x</var>
-    <sub>max</sub>
-    =
-    <span class="dvc up">
-     <var>l</var>
-     ·
-     <span class="b1">(</span>
-     <span class="o1">
-      <span class="r1">
+     +
+     <span class="dvc">
+      <var>Δq</var>
+      ·
+      <var>x</var>
+      <span class="dvl">
       </span>
+      <var>l</var>
+     </span>
+    </span>
+   </p>
+   <p>Bending</p>
+   <p>
+    <span class="eq">
+     <var>M</var>
+     (
+     <var>x</var>
+     )  = -
+     <var>M</var>
+     <sub>A</sub>
+     +
+     <var>V</var>
+     <sub>A</sub>
+     ·
+     <var>x</var>
+     −
+     <span class="dvc">
+      ( 2 ·
       <var>q</var>
       <sub>1</sub>
-      <sup>2</sup>
       +
-      <span class="dvc">
-       2 ·
-       <var>V</var>
-       <sub>A</sub>
-       ·
-       <var>Δq</var>
-       <span class="dvl">
-       </span>
-       <var>l</var>
+      <var>q</var>
+      (
+      <var>x</var>
+      )  )  ·
+      <var>x</var>
+      <sup>2</sup>
+      <span class="dvl">
       </span>
+      6
      </span>
+    </span>
+   </p>
+   <svg class="plot" data-plot="svg" height="840px" style="width:494.44pt; height:155.56pt;" version="1.1" viewbox=" 0 0 2670 840" width="2670px" xmlns="http://www.w3.org/2000/svg">
+    <style type="text/css">
+     .plot text {fill:Black; font-family:'Segoe UI', Sans; font-size:44px}
+.plot text.left {text-anchor: start;}
+.plot text.sm {font-size:44px}
+.plot text.mid {text-anchor: middle;}
+.plot text.end {text-anchor: end;}
+.plot .Grid, .plot .Frame, .plot .Axis{fill:none; stroke-width:4;}
+.plot .Grid {stroke:rgba(0, 0, 0, 0.08);}
+.plot .Frame {stroke:rgba(0, 0, 0, 0.24);}
+.plot .Axis {stroke: Black;}
+.plot polyline {fill:none; stroke-width:6;}
+.plot [class^="Fill"] {stroke:none;}
+.Series1 {stroke:Tomato;}
+circle.Series1 {fill:Tomato;}
+.Fill1 {fill:Tomato; fill-opacity:0.050;}
+    </style>
+    <g class="plot">
+     <rect class="Frame" height="600" width="2400" x="180" y="120">
+     </rect>
+     <line class="Grid" x1="180" x2="2580" y1="696.04" y2="696.04">
+     </line>
+     <text class="sm end" x="161" y="714.04">-50</text>
+     <line class="Grid" x1="180" x2="2580" y1="594.52" y2="594.52">
+     </line>
+     <text class="sm end" x="161" y="612.52">-25</text>
+     <line class="Grid" x1="180" x2="2580" y1="493" y2="493">
+     </line>
+     <text class="sm end" x="161" y="511">0</text>
+     <line class="Grid" x1="180" x2="2580" y1="391.48" y2="391.48">
+     </line>
+     <text class="sm end" x="161" y="409.48">25</text>
+     <line class="Grid" x1="180" x2="2580" y1="289.96" y2="289.96">
+     </line>
+     <text class="sm end" x="161" y="307.96">50</text>
+     <line class="Grid" x1="180" x2="2580" y1="188.45" y2="188.45">
+     </line>
+     <text class="sm end" x="161" y="206.45">75</text>
+     <line class="Grid" x1="180" x2="180" y1="120" y2="720">
+     </line>
+     <text class="sm mid" x="180" y="772">0</text>
+     <line class="Grid" x1="300" x2="300" y1="120" y2="720">
+     </line>
+     <text class="sm mid" x="300" y="772">0.5</text>
+     <line class="Grid" x1="420" x2="420" y1="120" y2="720">
+     </line>
+     <text class="sm mid" x="420" y="772">1</text>
+     <line class="Grid" x1="540" x2="540" y1="120" y2="720">
+     </line>
+     <text class="sm mid" x="540" y="772">1.5</text>
+     <line class="Grid" x1="660" x2="660" y1="120" y2="720">
+     </line>
+     <text class="sm mid" x="660" y="772">2</text>
+     <line class="Grid" x1="780" x2="780" y1="120" y2="720">
+     </line>
+     <text class="sm mid" x="780" y="772">2.5</text>
+     <line class="Grid" x1="900" x2="900" y1="120" y2="720">
+     </line>
+     <text class="sm mid" x="900" y="772">3</text>
+     <line class="Grid" x1="1020" x2="1020" y1="120" y2="720">
+     </line>
+     <text class="sm mid" x="1020" y="772">3.5</text>
+     <line class="Grid" x1="1140" x2="1140" y1="120" y2="720">
+     </line>
+     <text class="sm mid" x="1140" y="772">4</text>
+     <line class="Grid" x1="1260" x2="1260" y1="120" y2="720">
+     </line>
+     <text class="sm mid" x="1260" y="772">4.5</text>
+     <line class="Grid" x1="1380" x2="1380" y1="120" y2="720">
+     </line>
+     <text class="sm mid" x="1380" y="772">5</text>
+     <line class="Grid" x1="1500" x2="1500" y1="120" y2="720">
+     </line>
+     <text class="sm mid" x="1500" y="772">5.5</text>
+     <line class="Grid" x1="1620" x2="1620" y1="120" y2="720">
+     </line>
+     <text class="sm mid" x="1620" y="772">6</text>
+     <line class="Grid" x1="1740" x2="1740" y1="120" y2="720">
+     </line>
+     <text class="sm mid" x="1740" y="772">6.5</text>
+     <line class="Grid" x1="1860" x2="1860" y1="120" y2="720">
+     </line>
+     <text class="sm mid" x="1860" y="772">7</text>
+     <line class="Grid" x1="1980" x2="1980" y1="120" y2="720">
+     </line>
+     <text class="sm mid" x="1980" y="772">7.5</text>
+     <line class="Grid" x1="2100" x2="2100" y1="120" y2="720">
+     </line>
+     <text class="sm mid" x="2100" y="772">8</text>
+     <line class="Grid" x1="2220" x2="2220" y1="120" y2="720">
+     </line>
+     <text class="sm mid" x="2220" y="772">8.5</text>
+     <line class="Grid" x1="2340" x2="2340" y1="120" y2="720">
+     </line>
+     <text class="sm mid" x="2340" y="772">9</text>
+     <line class="Grid" x1="2460" x2="2460" y1="120" y2="720">
+     </line>
+     <text class="sm mid" x="2460" y="772">9.5</text>
+     <text class="sm mid" x="2580" y="772">10</text>
+     <line class="Axis" x1="180" x2="2580" y1="493" y2="493">
+     </line>
+     <text x="2602" y="475">x</text>
+     <line class="Axis" x1="180" x2="180" y1="120" y2="720">
+     </line>
+     <text class="mid" x="180" y="84">y</text>
+     <text x="8" y="823">[0; -56.09]</text>
+     <text class="end" x="2662" y="44">[10; 91.67]</text>
+     <polyline class="Series1" points="180,120.77 257.42,175.37 334.84,227.79 412.26,277.97 489.68,325.82 567.1,371.29 644.52,414.31 721.94,454.81 799.35,492.71 876.77,527.96 954.19,560.48 1031.61,590.21 1109.03,617.07 1186.45,641.01 1263.87,661.94 1341.29,679.81 1418.71,694.55 1496.13,706.08 1573.55,714.34 1650.97,719.26 1728.39,720.77 1805.81,718.8 1883.23,713.3 1960.65,704.18 2038.06,691.38 2115.48,674.83 2192.9,654.46 2270.32,630.21 2347.74,602.01 2425.16,569.78 2502.58,533.47 2580,493">
+     </polyline>
+     <polygon class="Fill1" points="180,493 180,120.77 257.42,175.37 334.84,227.79 412.26,277.97 489.68,325.82 567.1,371.29 644.52,414.31 721.94,454.81 799.35,492.71 876.77,527.96 954.19,560.48 1031.61,590.21 1109.03,617.07 1186.45,641.01 1263.87,661.94 1341.29,679.81 1418.71,694.55 1496.13,706.08 1573.55,714.34 1650.97,719.26 1728.39,720.77 1805.81,718.8 1883.23,713.3 1960.65,704.18 2038.06,691.38 2115.48,674.83 2192.9,654.46 2270.32,630.21 2347.74,602.01 2425.16,569.78 2502.58,533.47 2580,493 2580,493" stroke-width="0">
+     </polygon>
+    </g>
+   </svg>
+   <p>
+    <span class="eq">
+     <var>M</var>
+     (
+     <var>x</var>
+     <sub>1</sub>
+     )  =
+     <var>M</var>
+     ( 1 )  = -51.75
+    </span>
+    kN·m
+   </p>
+   <p>Shear</p>
+   <p>
+    <span class="eq">
+     <var>V</var>
+     (
+     <var>x</var>
+     )  =
+     <var>V</var>
+     <sub>A</sub>
      −
-     <var>q</var>
-     <sub>1</sub>
-     <span class="b1">)</span>
-     <span class="dvl">
-     </span>
-     <var>Δq</var>
-    </span>
-    =
-    <span class="dvc up">
-     10 ·
-     <span class="b1">(</span>
-     <span class="o1">
-      <span class="r1">
-      </span>
-      5
-      <sup>2</sup>
+     <span class="dvc">
+      (
+      <var>q</var>
+      <sub>1</sub>
       +
-      <span class="dvc">
-       2 · 42.5 · 5
-       <span class="dvl">
-       </span>
-       10
+      <var>q</var>
+      (
+      <var>x</var>
+      )  )  ·
+      <var>x</var>
+      <span class="dvl">
       </span>
+      2
      </span>
-     − 5
-     <span class="b1">)</span>
-     <span class="dvl">
-     </span>
-     5
     </span>
-    = 6.43
-   </span>
-   m
-  </p>
-  <p>
-   <span class="eq">
-    <var>M</var>
-    <sub>max</sub>
-    =
-    <var>V</var>
-    <sub>A</sub>
-    ·
-    <var>x</var>
-    <sub>max</sub>
-    −
-    <span class="dvc">
-     <var>x</var>
-     <sub>max</sub>
-     <sup>2</sup>
-     ·  ( 3 ·
-     <var>l</var>
-     ·
-     <var>q</var>
-     <sub>1</sub>
-     +
-     <var>Δq</var>
-     ·
-     <var>x</var>
-     <sub>max</sub>
-     )
-     <span class="dvl">
-     </span>
-     6 ·
-     <var>l</var>
-    </span>
-    −
-    <var>M</var>
-    <sub>A</sub>
-    = 42.5 · 6.43 −
-    <span class="dvc">
-     6.43
-     <sup>2</sup>
-     ·  ( 3 · 10 · 5 + 5 · 6.43 )
-     <span class="dvl">
-     </span>
-     6 · 10
-    </span>
-    − 91.67 = 56.09
-   </span>
-   kN·m
-  </p>
-  <p>
-   <b>Diagrams</b>
-  </p>
-  <p>
-   Calculate internal forces at
-   <span class="eq">
-    <var>x</var>
-    <sub>1</sub>
-    =
-    <u class="input-42">1</u>
-   </span>
-   m
-  </p>
-  <p>
-   <span class="eq">
-    <var>q</var>
-    (
-    <var>x</var>
-    )  =
-    <var>q</var>
-    <sub>1</sub>
-    +
-    <span class="dvc">
-     <var>Δq</var>
-     ·
-     <var>x</var>
-     <span class="dvl">
-     </span>
-     <var>l</var>
-    </span>
-   </span>
-  </p>
-  <p>Bending</p>
-  <p>
-   <span class="eq">
-    <var>M</var>
-    (
-    <var>x</var>
-    )  = -
-    <var>M</var>
-    <sub>A</sub>
-    +
-    <var>V</var>
-    <sub>A</sub>
-    ·
-    <var>x</var>
-    −
-    <span class="dvc">
-     ( 2 ·
-     <var>q</var>
-     <sub>1</sub>
-     +
-     <var>q</var>
-     (
-     <var>x</var>
-     )  )  ·
-     <var>x</var>
-     <sup>2</sup>
-     <span class="dvl">
-     </span>
-     6
-    </span>
-   </span>
-  </p>
-  <svg class="plot" data-plot="svg" height="840px" style="width:494.44pt; height:155.56pt;" version="1.1" viewbox=" 0 0 2670 840" width="2670px" xmlns="http://www.w3.org/2000/svg">
-   <style type="text/css">
-    .plot text {fill:Black; font-family:'Segoe UI', Sans; font-size:44px}
+   </p>
+   <svg class="plot" data-plot="svg" height="840px" style="width:494.44pt; height:155.56pt;" version="1.1" viewbox=" 0 0 2670 840" width="2670px" xmlns="http://www.w3.org/2000/svg">
+    <style type="text/css">
+     .plot text {fill:Black; font-family:'Segoe UI', Sans; font-size:44px}
 .plot text.left {text-anchor: start;}
 .plot text.sm {font-size:44px}
 .plot text.mid {text-anchor: middle;}
@@ -330,271 +267,121 @@
 .Series1 {stroke:Tomato;}
 circle.Series1 {fill:Tomato;}
 .Fill1 {fill:Tomato; fill-opacity:0.050;}
-   </style>
-   <g class="plot">
-    <rect class="Frame" height="600" width="2400" x="180" y="120">
-    </rect>
-    <line class="Grid" x1="180" x2="2580" y1="696.04" y2="696.04">
-    </line>
-    <text class="sm end" x="161" y="714.04">-50</text>
-    <line class="Grid" x1="180" x2="2580" y1="594.52" y2="594.52">
-    </line>
-    <text class="sm end" x="161" y="612.52">-25</text>
-    <line class="Grid" x1="180" x2="2580" y1="493" y2="493">
-    </line>
-    <text class="sm end" x="161" y="511">0</text>
-    <line class="Grid" x1="180" x2="2580" y1="391.48" y2="391.48">
-    </line>
-    <text class="sm end" x="161" y="409.48">25</text>
-    <line class="Grid" x1="180" x2="2580" y1="289.96" y2="289.96">
-    </line>
-    <text class="sm end" x="161" y="307.96">50</text>
-    <line class="Grid" x1="180" x2="2580" y1="188.45" y2="188.45">
-    </line>
-    <text class="sm end" x="161" y="206.45">75</text>
-    <line class="Grid" x1="180" x2="180" y1="120" y2="720">
-    </line>
-    <text class="sm mid" x="180" y="772">0</text>
-    <line class="Grid" x1="300" x2="300" y1="120" y2="720">
-    </line>
-    <text class="sm mid" x="300" y="772">0.5</text>
-    <line class="Grid" x1="420" x2="420" y1="120" y2="720">
-    </line>
-    <text class="sm mid" x="420" y="772">1</text>
-    <line class="Grid" x1="540" x2="540" y1="120" y2="720">
-    </line>
-    <text class="sm mid" x="540" y="772">1.5</text>
-    <line class="Grid" x1="660" x2="660" y1="120" y2="720">
-    </line>
-    <text class="sm mid" x="660" y="772">2</text>
-    <line class="Grid" x1="780" x2="780" y1="120" y2="720">
-    </line>
-    <text class="sm mid" x="780" y="772">2.5</text>
-    <line class="Grid" x1="900" x2="900" y1="120" y2="720">
-    </line>
-    <text class="sm mid" x="900" y="772">3</text>
-    <line class="Grid" x1="1020" x2="1020" y1="120" y2="720">
-    </line>
-    <text class="sm mid" x="1020" y="772">3.5</text>
-    <line class="Grid" x1="1140" x2="1140" y1="120" y2="720">
-    </line>
-    <text class="sm mid" x="1140" y="772">4</text>
-    <line class="Grid" x1="1260" x2="1260" y1="120" y2="720">
-    </line>
-    <text class="sm mid" x="1260" y="772">4.5</text>
-    <line class="Grid" x1="1380" x2="1380" y1="120" y2="720">
-    </line>
-    <text class="sm mid" x="1380" y="772">5</text>
-    <line class="Grid" x1="1500" x2="1500" y1="120" y2="720">
-    </line>
-    <text class="sm mid" x="1500" y="772">5.5</text>
-    <line class="Grid" x1="1620" x2="1620" y1="120" y2="720">
-    </line>
-    <text class="sm mid" x="1620" y="772">6</text>
-    <line class="Grid" x1="1740" x2="1740" y1="120" y2="720">
-    </line>
-    <text class="sm mid" x="1740" y="772">6.5</text>
-    <line class="Grid" x1="1860" x2="1860" y1="120" y2="720">
-    </line>
-    <text class="sm mid" x="1860" y="772">7</text>
-    <line class="Grid" x1="1980" x2="1980" y1="120" y2="720">
-    </line>
-    <text class="sm mid" x="1980" y="772">7.5</text>
-    <line class="Grid" x1="2100" x2="2100" y1="120" y2="720">
-    </line>
-    <text class="sm mid" x="2100" y="772">8</text>
-    <line class="Grid" x1="2220" x2="2220" y1="120" y2="720">
-    </line>
-    <text class="sm mid" x="2220" y="772">8.5</text>
-    <line class="Grid" x1="2340" x2="2340" y1="120" y2="720">
-    </line>
-    <text class="sm mid" x="2340" y="772">9</text>
-    <line class="Grid" x1="2460" x2="2460" y1="120" y2="720">
-    </line>
-    <text class="sm mid" x="2460" y="772">9.5</text>
-    <text class="sm mid" x="2580" y="772">10</text>
-    <line class="Axis" x1="180" x2="2580" y1="493" y2="493">
-    </line>
-    <text x="2602" y="475">x</text>
-    <line class="Axis" x1="180" x2="180" y1="120" y2="720">
-    </line>
-    <text class="mid" x="180" y="84">y</text>
-    <text x="8" y="823">[0; -56.09]</text>
-    <text class="end" x="2662" y="44">[10; 91.67]</text>
-    <polyline class="Series1" points="180,120.77 257.42,175.37 334.84,227.79 412.26,277.97 489.68,325.82 567.1,371.29 644.52,414.31 721.94,454.81 799.35,492.71 876.77,527.96 954.19,560.48 1031.61,590.21 1109.03,617.07 1186.45,641.01 1263.87,661.94 1341.29,679.81 1418.71,694.55 1496.13,706.08 1573.55,714.34 1650.97,719.26 1728.39,720.77 1805.81,718.8 1883.23,713.3 1960.65,704.18 2038.06,691.38 2115.48,674.83 2192.9,654.46 2270.32,630.21 2347.74,602.01 2425.16,569.78 2502.58,533.47 2580,493">
-    </polyline>
-    <polygon class="Fill1" points="180,493 180,120.77 257.42,175.37 334.84,227.79 412.26,277.97 489.68,325.82 567.1,371.29 644.52,414.31 721.94,454.81 799.35,492.71 876.77,527.96 954.19,560.48 1031.61,590.21 1109.03,617.07 1186.45,641.01 1263.87,661.94 1341.29,679.81 1418.71,694.55 1496.13,706.08 1573.55,714.34 1650.97,719.26 1728.39,720.77 1805.81,718.8 1883.23,713.3 1960.65,704.18 2038.06,691.38 2115.48,674.83 2192.9,654.46 2270.32,630.21 2347.74,602.01 2425.16,569.78 2502.58,533.47 2580,493 2580,493" stroke-width="0">
-    </polygon>
-   </g>
-  </svg>
-  <p>
-   <span class="eq">
-    <var>M</var>
-    (
-    <var>x</var>
-    <sub>1</sub>
-    )  =
-    <var>M</var>
-    ( 1 )  = -51.75
-   </span>
-   kN·m
-  </p>
-  <p>Shear</p>
-  <p>
-   <span class="eq">
-    <var>V</var>
-    (
-    <var>x</var>
-    )  =
-    <var>V</var>
-    <sub>A</sub>
-    −
-    <span class="dvc">
+    </style>
+    <g class="plot">
+     <rect class="Frame" height="600" width="2400" x="180" y="120">
+     </rect>
+     <line class="Grid" x1="180" x2="2580" y1="701" y2="701">
+     </line>
+     <text class="sm end" x="161" y="719">-30</text>
+     <line class="Grid" x1="180" x2="2580" y1="621" y2="621">
+     </line>
+     <text class="sm end" x="161" y="639">-20</text>
+     <line class="Grid" x1="180" x2="2580" y1="541" y2="541">
+     </line>
+     <text class="sm end" x="161" y="559">-10</text>
+     <line class="Grid" x1="180" x2="2580" y1="461" y2="461">
+     </line>
+     <text class="sm end" x="161" y="479">0</text>
+     <line class="Grid" x1="180" x2="2580" y1="381" y2="381">
+     </line>
+     <text class="sm end" x="161" y="399">10</text>
+     <line class="Grid" x1="180" x2="2580" y1="301" y2="301">
+     </line>
+     <text class="sm end" x="161" y="319">20</text>
+     <line class="Grid" x1="180" x2="2580" y1="221" y2="221">
+     </line>
+     <text class="sm end" x="161" y="239">30</text>
+     <line class="Grid" x1="180" x2="2580" y1="141" y2="141">
+     </line>
+     <text class="sm end" x="161" y="159">40</text>
+     <line class="Grid" x1="180" x2="180" y1="120" y2="720">
+     </line>
+     <text class="sm mid" x="180" y="772">0</text>
+     <line class="Grid" x1="300" x2="300" y1="120" y2="720">
+     </line>
+     <text class="sm mid" x="300" y="772">0.5</text>
+     <line class="Grid" x1="420" x2="420" y1="120" y2="720">
+     </line>
+     <text class="sm mid" x="420" y="772">1</text>
+     <line class="Grid" x1="540" x2="540" y1="120" y2="720">
+     </line>
+     <text class="sm mid" x="540" y="772">1.5</text>
+     <line class="Grid" x1="660" x2="660" y1="120" y2="720">
+     </line>
+     <text class="sm mid" x="660" y="772">2</text>
+     <line class="Grid" x1="780" x2="780" y1="120" y2="720">
+     </line>
+     <text class="sm mid" x="780" y="772">2.5</text>
+     <line class="Grid" x1="900" x2="900" y1="120" y2="720">
+     </line>
+     <text class="sm mid" x="900" y="772">3</text>
+     <line class="Grid" x1="1020" x2="1020" y1="120" y2="720">
+     </line>
+     <text class="sm mid" x="1020" y="772">3.5</text>
+     <line class="Grid" x1="1140" x2="1140" y1="120" y2="720">
+     </line>
+     <text class="sm mid" x="1140" y="772">4</text>
+     <line class="Grid" x1="1260" x2="1260" y1="120" y2="720">
+     </line>
+     <text class="sm mid" x="1260" y="772">4.5</text>
+     <line class="Grid" x1="1380" x2="1380" y1="120" y2="720">
+     </line>
+     <text class="sm mid" x="1380" y="772">5</text>
+     <line class="Grid" x1="1500" x2="1500" y1="120" y2="720">
+     </line>
+     <text class="sm mid" x="1500" y="772">5.5</text>
+     <line class="Grid" x1="1620" x2="1620" y1="120" y2="720">
+     </line>
+     <text class="sm mid" x="1620" y="772">6</text>
+     <line class="Grid" x1="1740" x2="1740" y1="120" y2="720">
+     </line>
+     <text class="sm mid" x="1740" y="772">6.5</text>
+     <line class="Grid" x1="1860" x2="1860" y1="120" y2="720">
+     </line>
+     <text class="sm mid" x="1860" y="772">7</text>
+     <line class="Grid" x1="1980" x2="1980" y1="120" y2="720">
+     </line>
+     <text class="sm mid" x="1980" y="772">7.5</text>
+     <line class="Grid" x1="2100" x2="2100" y1="120" y2="720">
+     </line>
+     <text class="sm mid" x="2100" y="772">8</text>
+     <line class="Grid" x1="2220" x2="2220" y1="120" y2="720">
+     </line>
+     <text class="sm mid" x="2220" y="772">8.5</text>
+     <line class="Grid" x1="2340" x2="2340" y1="120" y2="720">
+     </line>
+     <text class="sm mid" x="2340" y="772">9</text>
+     <line class="Grid" x1="2460" x2="2460" y1="120" y2="720">
+     </line>
+     <text class="sm mid" x="2460" y="772">9.5</text>
+     <text class="sm mid" x="2580" y="772">10</text>
+     <line class="Axis" x1="180" x2="2580" y1="461" y2="461">
+     </line>
+     <text x="2602" y="443">x</text>
+     <line class="Axis" x1="180" x2="180" y1="120" y2="720">
+     </line>
+     <text class="mid" x="180" y="84">y</text>
+     <text x="8" y="823">[0; -32.5]</text>
+     <text class="end" x="2662" y="44">[10; 42.5]</text>
+     <polyline class="Series1" points="180,121 257.42,134.11 334.84,147.64 412.26,161.58 489.68,175.94 567.1,190.72 644.52,205.91 721.94,221.52 799.35,237.55 876.77,253.99 954.19,270.84 1031.61,288.12 1109.03,305.81 1186.45,323.91 1263.87,342.44 1341.29,361.37 1418.71,380.73 1496.13,400.5 1573.55,420.69 1650.97,441.29 1728.39,462.31 1805.81,483.75 1883.23,505.6 1960.65,527.87 2038.06,550.55 2115.48,573.65 2192.9,597.17 2270.32,621.1 2347.74,645.45 2425.16,670.22 2502.58,695.4 2580,721">
+     </polyline>
+     <polygon class="Fill1" points="180,461 180,121 257.42,134.11 334.84,147.64 412.26,161.58 489.68,175.94 567.1,190.72 644.52,205.91 721.94,221.52 799.35,237.55 876.77,253.99 954.19,270.84 1031.61,288.12 1109.03,305.81 1186.45,323.91 1263.87,342.44 1341.29,361.37 1418.71,380.73 1496.13,400.5 1573.55,420.69 1650.97,441.29 1728.39,462.31 1805.81,483.75 1883.23,505.6 1960.65,527.87 2038.06,550.55 2115.48,573.65 2192.9,597.17 2270.32,621.1 2347.74,645.45 2425.16,670.22 2502.58,695.4 2580,721 2580,461" stroke-width="0">
+     </polygon>
+    </g>
+   </svg>
+   <p>
+    <span class="eq">
+     <var>V</var>
      (
-     <var>q</var>
+     <var>x</var>
      <sub>1</sub>
-     +
-     <var>q</var>
-     (
-     <var>x</var>
-     )  )  ·
-     <var>x</var>
-     <span class="dvl">
-     </span>
-     2
+     )  =
+     <var>V</var>
+     ( 1 )  = 37.25
     </span>
-   </span>
-  </p>
-  <svg class="plot" data-plot="svg" height="840px" style="width:494.44pt; height:155.56pt;" version="1.1" viewbox=" 0 0 2670 840" width="2670px" xmlns="http://www.w3.org/2000/svg">
-   <style type="text/css">
-    .plot text {fill:Black; font-family:'Segoe UI', Sans; font-size:44px}
-.plot text.left {text-anchor: start;}
-.plot text.sm {font-size:44px}
-.plot text.mid {text-anchor: middle;}
-.plot text.end {text-anchor: end;}
-.plot .Grid, .plot .Frame, .plot .Axis{fill:none; stroke-width:4;}
-.plot .Grid {stroke:rgba(0, 0, 0, 0.08);}
-.plot .Frame {stroke:rgba(0, 0, 0, 0.24);}
-.plot .Axis {stroke: Black;}
-.plot polyline {fill:none; stroke-width:6;}
-.plot [class^="Fill"] {stroke:none;}
-.Series1 {stroke:Tomato;}
-circle.Series1 {fill:Tomato;}
-.Fill1 {fill:Tomato; fill-opacity:0.050;}
-   </style>
-   <g class="plot">
-    <rect class="Frame" height="600" width="2400" x="180" y="120">
-    </rect>
-    <line class="Grid" x1="180" x2="2580" y1="701" y2="701">
-    </line>
-    <text class="sm end" x="161" y="719">-30</text>
-    <line class="Grid" x1="180" x2="2580" y1="621" y2="621">
-    </line>
-    <text class="sm end" x="161" y="639">-20</text>
-    <line class="Grid" x1="180" x2="2580" y1="541" y2="541">
-    </line>
-    <text class="sm end" x="161" y="559">-10</text>
-    <line class="Grid" x1="180" x2="2580" y1="461" y2="461">
-    </line>
-    <text class="sm end" x="161" y="479">0</text>
-    <line class="Grid" x1="180" x2="2580" y1="381" y2="381">
-    </line>
-    <text class="sm end" x="161" y="399">10</text>
-    <line class="Grid" x1="180" x2="2580" y1="301" y2="301">
-    </line>
-    <text class="sm end" x="161" y="319">20</text>
-    <line class="Grid" x1="180" x2="2580" y1="221" y2="221">
-    </line>
-    <text class="sm end" x="161" y="239">30</text>
-    <line class="Grid" x1="180" x2="2580" y1="141" y2="141">
-    </line>
-    <text class="sm end" x="161" y="159">40</text>
-    <line class="Grid" x1="180" x2="180" y1="120" y2="720">
-    </line>
-    <text class="sm mid" x="180" y="772">0</text>
-    <line class="Grid" x1="300" x2="300" y1="120" y2="720">
-    </line>
-    <text class="sm mid" x="300" y="772">0.5</text>
-    <line class="Grid" x1="420" x2="420" y1="120" y2="720">
-    </line>
-    <text class="sm mid" x="420" y="772">1</text>
-    <line class="Grid" x1="540" x2="540" y1="120" y2="720">
-    </line>
-    <text class="sm mid" x="540" y="772">1.5</text>
-    <line class="Grid" x1="660" x2="660" y1="120" y2="720">
-    </line>
-    <text class="sm mid" x="660" y="772">2</text>
-    <line class="Grid" x1="780" x2="780" y1="120" y2="720">
-    </line>
-    <text class="sm mid" x="780" y="772">2.5</text>
-    <line class="Grid" x1="900" x2="900" y1="120" y2="720">
-    </line>
-    <text class="sm mid" x="900" y="772">3</text>
-    <line class="Grid" x1="1020" x2="1020" y1="120" y2="720">
-    </line>
-    <text class="sm mid" x="1020" y="772">3.5</text>
-    <line class="Grid" x1="1140" x2="1140" y1="120" y2="720">
-    </line>
-    <text class="sm mid" x="1140" y="772">4</text>
-    <line class="Grid" x1="1260" x2="1260" y1="120" y2="720">
-    </line>
-    <text class="sm mid" x="1260" y="772">4.5</text>
-    <line class="Grid" x1="1380" x2="1380" y1="120" y2="720">
-    </line>
-    <text class="sm mid" x="1380" y="772">5</text>
-    <line class="Grid" x1="1500" x2="1500" y1="120" y2="720">
-    </line>
-    <text class="sm mid" x="1500" y="772">5.5</text>
-    <line class="Grid" x1="1620" x2="1620" y1="120" y2="720">
-    </line>
-    <text class="sm mid" x="1620" y="772">6</text>
-    <line class="Grid" x1="1740" x2="1740" y1="120" y2="720">
-    </line>
-    <text class="sm mid" x="1740" y="772">6.5</text>
-    <line class="Grid" x1="1860" x2="1860" y1="120" y2="720">
-    </line>
-    <text class="sm mid" x="1860" y="772">7</text>
-    <line class="Grid" x1="1980" x2="1980" y1="120" y2="720">
-    </line>
-    <text class="sm mid" x="1980" y="772">7.5</text>
-    <line class="Grid" x1="2100" x2="2100" y1="120" y2="720">
-    </line>
-    <text class="sm mid" x="2100" y="772">8</text>
-    <line class="Grid" x1="2220" x2="2220" y1="120" y2="720">
-    </line>
-    <text class="sm mid" x="2220" y="772">8.5</text>
-    <line class="Grid" x1="2340" x2="2340" y1="120" y2="720">
-    </line>
-    <text class="sm mid" x="2340" y="772">9</text>
-    <line class="Grid" x1="2460" x2="2460" y1="120" y2="720">
-    </line>
-    <text class="sm mid" x="2460" y="772">9.5</text>
-    <text class="sm mid" x="2580" y="772">10</text>
-    <line class="Axis" x1="180" x2="2580" y1="461" y2="461">
-    </line>
-    <text x="2602" y="443">x</text>
-    <line class="Axis" x1="180" x2="180" y1="120" y2="720">
-    </line>
-    <text class="mid" x="180" y="84">y</text>
-    <text x="8" y="823">[0; -32.5]</text>
-    <text class="end" x="2662" y="44">[10; 42.5]</text>
-    <polyline class="Series1" points="180,121 257.42,134.11 334.84,147.64 412.26,161.58 489.68,175.94 567.1,190.72 644.52,205.91 721.94,221.52 799.35,237.55 876.77,253.99 954.19,270.84 1031.61,288.12 1109.03,305.81 1186.45,323.91 1263.87,342.44 1341.29,361.37 1418.71,380.73 1496.13,400.5 1573.55,420.69 1650.97,441.29 1728.39,462.31 1805.81,483.75 1883.23,505.6 1960.65,527.87 2038.06,550.55 2115.48,573.65 2192.9,597.17 2270.32,621.1 2347.74,645.45 2425.16,670.22 2502.58,695.4 2580,721">
-    </polyline>
-    <polygon class="Fill1" points="180,461 180,121 257.42,134.11 334.84,147.64 412.26,161.58 489.68,175.94 567.1,190.72 644.52,205.91 721.94,221.52 799.35,237.55 876.77,253.99 954.19,270.84 1031.61,288.12 1109.03,305.81 1186.45,323.91 1263.87,342.44 1341.29,361.37 1418.71,380.73 1496.13,400.5 1573.55,420.69 1650.97,441.29 1728.39,462.31 1805.81,483.75 1883.23,505.6 1960.65,527.87 2038.06,550.55 2115.48,573.65 2192.9,597.17 2270.32,621.1 2347.74,645.45 2425.16,670.22 2502.58,695.4 2580,721 2580,461" stroke-width="0">
-    </polygon>
-   </g>
-  </svg>
-  <p>
-   <span class="eq">
-    <var>V</var>
-    (
-    <var>x</var>
-    <sub>1</sub>
-    )  =
-    <var>V</var>
-    ( 1 )  = 37.25
-   </span>
-   kN
-  </p>
+    kN
+   </p>
+  </div>
  </div>
 </div>

--- a/Examples/Structural/Propped Cantilevers/Partially Distributed Load.html.stub
+++ b/Examples/Structural/Propped Cantilevers/Partially Distributed Load.html.stub
@@ -306,6 +306,8 @@
    </span>
    m
   </p>
+  <p>
+  </p>
   <p>Bending</p>
   <p>
    <span class="eq">

--- a/Examples/Structural/Propped Cantilevers/Uniformly Distributed Load.html.stub
+++ b/Examples/Structural/Propped Cantilevers/Uniformly Distributed Load.html.stub
@@ -167,6 +167,10 @@
    </span>
    m
   </p>
+  <p>
+  </p>
+  <p>
+  </p>
   <p>Bending</p>
   <p>
    <span class="eq">

--- a/Examples/Structural/Reinforced Concrete - Seismic Detailing/Beam Detailing for DCM.html.stub
+++ b/Examples/Structural/Reinforced Concrete - Seismic Detailing/Beam Detailing for DCM.html.stub
@@ -352,6 +352,13 @@
    </span>
    MPa
   </p>
+  <p>
+   Steel class -
+   <select data-target="C">
+    <option value="0">Class B</option>
+    <option value="1">Class C</option>
+   </select>
+  </p>
   Selected steel class
   <b>B500B</b>
   <p>

--- a/Examples/Structural/Reinforced Concrete - Seismic Detailing/Column Detailing for DCM.html.stub
+++ b/Examples/Structural/Reinforced Concrete - Seismic Detailing/Column Detailing for DCM.html.stub
@@ -191,6 +191,13 @@
    </span>
    MPa
   </p>
+  <p>
+   Steel class -
+   <select data-target="C">
+    <option value="0">Class B</option>
+    <option value="1">Class C</option>
+   </select>
+  </p>
   Selected steel class
   <b>B500B</b>
   <p>

--- a/Examples/Structural/Reinforced Concrete - Seismic Detailing/Shear Wall Detailing for DCM.html.stub
+++ b/Examples/Structural/Reinforced Concrete - Seismic Detailing/Shear Wall Detailing for DCM.html.stub
@@ -280,6 +280,13 @@
    </span>
    MPa
   </p>
+  <p>
+   Steel class -
+   <select data-target="C">
+    <option value="0">Class B</option>
+    <option value="1">Class C</option>
+   </select>
+  </p>
   Selected steel class
   <b>B500B</b>
   <p>

--- a/Examples/Structural/Reinforced Concrete/Areas of Reinforcement Bars.html.stub
+++ b/Examples/Structural/Reinforced Concrete/Areas of Reinforcement Bars.html.stub
@@ -13,6 +13,7 @@
   </span>
   cm²
  </p>
+ <img alt="bars.png" src="Images/structures/rc/design/bars.png" style="height:104pt; width:122pt;"/>
  <table class="bordered">
   <tr>
    <th>Count</th>

--- a/Examples/Structural/Reinforced Concrete/Column Design for Bending and Axial Force.html.stub
+++ b/Examples/Structural/Reinforced Concrete/Column Design for Bending and Axial Force.html.stub
@@ -227,6 +227,13 @@
     </td>
    </tr>
   </table>
+  <p>
+   All input values for M
+   <sub>Ed</sub>
+   and N
+   <sub>Ed</sub>
+   must be positive!
+  </p>
   <p>Positive axial force is compressive!</p>
   <h4>Material properties</h4>
   <p class="ref" style="float:right">[EN 1992-1-1, Table 3.1]</p>

--- a/Examples/Structural/Reinforced Concrete/Column Design for Biaxial Bending and Axial Force (with Units).html.stub
+++ b/Examples/Structural/Reinforced Concrete/Column Design for Biaxial Bending and Axial Force (with Units).html.stub
@@ -1788,6 +1788,46 @@ circle.Series1 {fill:Tomato;}
    <span class="eq">
     <var>M</var>
     <sub>Edy</sub>
+    =
+    <u class="input-194">50</u>
+    <i>kNm</i>
+   </span>
+  </p>
+  <p>
+   Bending resistance -
+   <span class="eq">
+    <var>M</var>
+    <sub>Rdy</sub>
+    =
+    <u class="input-195">100</u>
+    <i>kNm</i>
+   </span>
+  </p>
+  <p>
+   Effective length -
+   <span class="eq">
+    <var>L</var>
+    <sub>oy</sub>
+    =
+    <u class="input-196">1</u>
+    ·
+    <var>L</var>
+    =
+    <u class="input-196">1</u>
+    · 4
+    <i>m</i>
+    = 4
+    <i>m</i>
+   </span>
+  </p>
+  <img alt="Column_Biaxial.png" class="side" src="Images/structures/rc/design/column-biaxial.png" style="width:190pt;"/>
+  <h4>Biaxial bending design</h4>
+  <p>For the other direction:</p>
+  <p>
+   Design moment -
+   <span class="eq">
+    <var>M</var>
+    <sub>Edy</sub>
     = 50
     <i>kNm</i>
    </span>

--- a/Examples/Structural/Reinforced Concrete/Column Design for Biaxial Bending and Axial Force.html.stub
+++ b/Examples/Structural/Reinforced Concrete/Column Design for Biaxial Bending and Axial Force.html.stub
@@ -1644,6 +1644,44 @@ circle.Series1 {fill:Tomato;}
    <span class="eq">
     <var>M</var>
     <sub>Edy</sub>
+    =
+    <u class="input-192">50</u>
+   </span>
+   kN·m
+  </p>
+  <p>
+   Bending resistance -
+   <span class="eq">
+    <var>M</var>
+    <sub>Rdy</sub>
+    =
+    <u class="input-193">100</u>
+   </span>
+   kN·m
+  </p>
+  <p>
+   Effective length -
+   <span class="eq">
+    <var>L</var>
+    <sub>oy</sub>
+    =
+    <u class="input-194">1</u>
+    ·
+    <var>L</var>
+    =
+    <u class="input-194">1</u>
+    · 4000 = 4000
+   </span>
+   mm
+  </p>
+  <img alt="column-biaxial.png" class="side" src="Images/structures/rc/design/column-biaxial.png" style="width:190pt;"/>
+  <h4>Biaxial bending design</h4>
+  <p>For the other direction:</p>
+  <p>
+   Design moment -
+   <span class="eq">
+    <var>M</var>
+    <sub>Edy</sub>
     = 50
    </span>
    kN.m

--- a/Examples/Structural/Reinforced Concrete/SLS Design of Beam with Rectangular Section.html.stub
+++ b/Examples/Structural/Reinforced Concrete/SLS Design of Beam with Rectangular Section.html.stub
@@ -16,6 +16,14 @@
     <u class="input-8">0</u>
    </span>
   </p>
+  <p>
+   <select class="flip_trigger" data-target="type">
+    <option value="1">Cantilever with concentrated load</option>
+    <option value="2">Cantilever with uniformly distributed load</option>
+    <option value="3">Simply supported beam with concentrated load</option>
+    <option value="0">Simply supported beam with uniformly distributed load</option>
+   </select>
+  </p>
   <img alt="deflection-beam-uniform.png" class="side flip flip_0" src="Images/structures/rc/design/deflection-beam-uniform.png" style="width:150pt;"/>
   <p>Simply supported beam with uniformly distributed load</p>
   <p>
@@ -35,6 +43,12 @@
     =
     <u class="input-45">0.4</u>
    </span>
+  </p>
+  <p>
+   <select data-target="w_max">
+    <option value="0.4">X0 or XC1</option>
+    <option value="0.3">XC2, XC3, XC4, XD1, XD2, XS2 or XS3</option>
+   </select>
   </p>
   <p>X0 or XC1</p>
   <p>
@@ -2269,4 +2283,5 @@
    mm - The condition is satisfied!
   </p>
  </div>
+ <script>if(window.jQuery){$(".flip_trigger").change(function(){$(".flip").hide();$(".flip_"+$(this).val()).show();});$(".flip").hide();$(".flip_"+$(".flip_base input").val()).show();}</script>
 </div>

--- a/Examples/Structural/Reinforced Concrete/SLS Design of Beam with Tee Section.html.stub
+++ b/Examples/Structural/Reinforced Concrete/SLS Design of Beam with Tee Section.html.stub
@@ -16,6 +16,14 @@
     <u class="input-8">0</u>
    </span>
   </p>
+  <p>
+   <select class="flip_trigger" data-target="type">
+    <option value="1">Cantilever with concentrated load</option>
+    <option value="2">Cantilever with uniformly distributed load</option>
+    <option value="3">Simply supported beam with concentrated load</option>
+    <option value="0">Simply supported beam with uniformly distributed load</option>
+   </select>
+  </p>
   <img alt="deflection-beam-uniform.png" class="side flip flip_0" src="Images/structures/rc/design/deflection-beam-uniform.png" style="width:150pt;"/>
   <p>Simply supported beam with uniformly distributed load</p>
   <p>
@@ -35,6 +43,12 @@
     =
     <u class="input-45">0.4</u>
    </span>
+  </p>
+  <p>
+   <select data-target="w_max">
+    <option value="0.4">X0 or XC1</option>
+    <option value="0.3">XC2, XC3, XC4, XD1, XD2, XS2 или XS3</option>
+   </select>
   </p>
   <p>X0 or XC1</p>
   <p>
@@ -2397,4 +2411,5 @@
    mm - The condition is satisfied!
   </p>
  </div>
+ <script>if(window.jQuery){$(".flip_trigger").change(function(){$(".flip").hide();$(".flip_"+$(this).val()).show();});$(".flip").hide();$(".flip_"+$(".flip_base input").val()).show();}</script>
 </div>

--- a/Examples/Structural/Simply Supported Beams/Concentrated Force.html.stub
+++ b/Examples/Structural/Simply Supported Beams/Concentrated Force.html.stub
@@ -130,6 +130,8 @@
    </span>
    m
   </p>
+  <p>
+  </p>
   <p>Bending</p>
   <p>
    <span class="eq">

--- a/Examples/Structural/Simply Supported Beams/Concentrated Forces.html.stub
+++ b/Examples/Structural/Simply Supported Beams/Concentrated Forces.html.stub
@@ -117,6 +117,8 @@
    m
   </p>
   <p>
+  </p>
+  <p>
    <span class="eq">
     <var>a</var>
     =

--- a/Examples/Structural/Simply Supported Beams/Concentrated Moment.html.stub
+++ b/Examples/Structural/Simply Supported Beams/Concentrated Moment.html.stub
@@ -121,6 +121,8 @@
    </span>
    m
   </p>
+  <p>
+  </p>
   <p>Bending</p>
   <p>
    <span class="eq">

--- a/Examples/Structural/Simply Supported Beams/Linearly Distributed Load.html.stub
+++ b/Examples/Structural/Simply Supported Beams/Linearly Distributed Load.html.stub
@@ -303,6 +303,12 @@
    </span>
    m
   </p>
+  <p>
+  </p>
+  <p>
+  </p>
+  <p>
+  </p>
   <p>Bending</p>
   <p>
    <span class="eq">

--- a/Examples/Structural/Simply Supported Beams/Partially Distributed Load.html.stub
+++ b/Examples/Structural/Simply Supported Beams/Partially Distributed Load.html.stub
@@ -237,6 +237,8 @@
    </span>
    m
   </p>
+  <p>
+  </p>
   <p>Bending</p>
   <p>
    <span class="eq">

--- a/Examples/Structural/Simply Supported Beams/Uniformly Distributed Load.html.stub
+++ b/Examples/Structural/Simply Supported Beams/Uniformly Distributed Load.html.stub
@@ -91,6 +91,8 @@
    </span>
    m
   </p>
+  <p>
+  </p>
   <p>Bending</p>
   <p>
    <span class="eq">

--- a/Examples/Structural/Steel/I-Section Properties Excel.html.stub
+++ b/Examples/Structural/Steel/I-Section Properties Excel.html.stub
@@ -19,288 +19,293 @@
      </p>
      <h4>Dimensions</h4>
      <p>
-      Section type -
-      <select data-target="section" style="font-weight:bold; border:none; background: none; color: black; box-shadow:none; appearance: none;">
-       <option value="1">IPE 100A</option>
-       <option value="2">IPE 100</option>
-       <option value="3">IPE 120</option>
-       <option value="4">IPE 140 A</option>
-       <option value="5">IPE 140</option>
-       <option value="6">IPE 140 R</option>
-       <option value="7">IPE 160 A</option>
-       <option value="8">IPE 160</option>
-       <option value="9">IPE 160 R</option>
-       <option value="10">IPE 180 A</option>
-       <option value="11">IPE 180</option>
-       <option value="12">IPE 180 O</option>
-       <option value="13">IPE 180 R</option>
-       <option value="14">IPE 200 A</option>
-       <option value="15">IPE 200</option>
-       <option value="16">IPE 200 O</option>
-       <option value="17">IPE 200 R</option>
-       <option value="18">IPE 220 A</option>
-       <option value="19">IPE 220</option>
-       <option value="20">IPE 220 O</option>
-       <option value="21">IPE 220 R</option>
-       <option value="22">IPE 240 A</option>
-       <option value="23">IPE 240</option>
-       <option value="24">IPE 240 O</option>
-       <option value="25">IPE 240 R</option>
-       <option value="26">IPE 270 A</option>
-       <option value="27">IPE 270</option>
-       <option value="28">IPE 270 O</option>
-       <option value="29">IPE 270 R</option>
-       <option value="30">IPE 300 A</option>
-       <option value="31">IPE 300</option>
-       <option value="32">IPE 300O</option>
-       <option value="33">IPE 300 R</option>
-       <option value="34">IPE 330 A</option>
-       <option value="35">IPE 330</option>
-       <option value="36">IPE 330 O</option>
-       <option value="37">IPE 330 R</option>
-       <option value="38">IPE 360 A</option>
-       <option value="39">IPE 360</option>
-       <option value="40">IPE 360 O</option>
-       <option value="41">IPE 360 R</option>
-       <option value="42">IPE 400 A</option>
-       <option value="43">IPE 400</option>
-       <option value="44">IPE 400 O</option>
-       <option value="45">IPE 400 R</option>
-       <option value="46">IPE 400 V</option>
-       <option value="47">IPE 450 A</option>
-       <option value="48">IPE 450</option>
-       <option value="49">IPE 450 O</option>
-       <option value="50">IPE 450 R</option>
-       <option value="51">IPE 450 V</option>
-       <option value="52">IPE 500 A</option>
-       <option value="53">IPE 500</option>
-       <option value="54">IPE 500 O</option>
-       <option value="55">IPE 500 R</option>
-       <option value="56">IPE 500 V</option>
-       <option value="57">IPE 550 A</option>
-       <option value="58">IPE 550</option>
-       <option value="59">IPE 550 O</option>
-       <option value="60">IPE 550 R</option>
-       <option value="61">IPE 550 V</option>
-       <option value="62">IPE 600 A</option>
-       <option value="63">IPE 600</option>
-       <option value="64">IPE 600 O</option>
-       <option value="65">IPE 600 R</option>
-       <option value="66">IPE 600 V</option>
-       <option value="67">IPE 750 x 137</option>
-       <option value="68">IPE 750 x 147</option>
-       <option value="69">IPE 750 x 161</option>
-       <option value="70">
-        IPE 750 x 174
-        <option value="71">
-         IPE 750 x185
-         <option value="72">
-          IPE 750 x 197
-          <option value="73">
-           IPE 750 x 210
-           <option value="74">
-            IPE 750 x 223
-            <option value="75">
-             HE 100 AA
-             <option value="76">
-              HE 100 A
-              <option value="77">
-               HE 100 A
-               <option value="78">
-                HE 100 B
-                <option value="79">
-                 HE 120 AA
-                 <option value="80">
-                  HE 120 A
-                  <option value="81">
-                   HE 120 B
-                   <option value="82">
-                    HE 140 AA
-                    <option value="83">
-                     HE 140 A
-                     <option value="84">
-                      HE 140 B
-                      <option value="85">
-                       HE 160 AA
-                       <option value="86">
-                        HE 160 A
-                        <option value="87">
-                         HE 160 B
-                         <option value="88">
-                          HE 160 M
-                          <option value="89">
-                           HE 180 AA
-                           <option value="90">
-                            HE 180 A
-                            <option value="91">
-                             HE 180 B
-                             <option value="92">
-                              HE 180 M
-                              <option value="93">
-                               HE 200 AA
-                               <option value="94">
-                                HE 200 A
-                                <option value="95">
-                                 HE 200 B
-                                 <option value="96">
-                                  HE 200 M
-                                  <option value="97">
-                                   HE 220 AA
-                                   <option value="98">
-                                    HE 220 A
-                                    <option value="99">
-                                     HE 220 B
-                                     <option value="100">
-                                      HE 220 M
-                                      <option value="101">
-                                       HE 240 AA
-                                       <option value="102">
-                                        HE 240 A
-                                        <option value="103">
-                                         HE 240 B
-                                         <option value="104">
-                                          HE 240 M
-                                          <option value="105">
-                                           HE 260 AA
-                                           <option value="106">
-                                            HE 260 A
-                                            <option value="107">
-                                             HE 260 B
-                                             <option value="108">
-                                              HE 260 M
-                                              <option value="109">
-                                               HE 280 AA
-                                               <option value="110">
-                                                HE 280 A
-                                                <option value="111">
-                                                 HE 280 B
-                                                 <option value="112">
-                                                  HE 280 M
-                                                  <option value="113">
-                                                   HE 300 AA
-                                                   <option value="114">
-                                                    HE 300 A
-                                                    <option value="115">
-                                                     HE 300 B
-                                                     <option value="116">
-                                                      HE 300 C
-                                                      <option value="117">
-                                                       HE 300 M
-                                                       <option value="118">
-                                                        HE 320 AA
-                                                        <option value="119">
-                                                         HE 320 A
-                                                         <option value="120">
-                                                          HE 320 B
-                                                          <option value="121">
-                                                           HE 320 M
-                                                           <option value="122">
-                                                            HE 340 AA
-                                                            <option value="123">
-                                                             HE 340 A
-                                                             <option value="124">
-                                                              HE 340 B
-                                                              <option value="125">
-                                                               HE 340 M
-                                                               <option value="126">
-                                                                HE 360 AA
-                                                                <option value="127">
-                                                                 HE 360 A
-                                                                 <option value="128">
-                                                                  HE 360 B
-                                                                  <option value="129">
-                                                                   HE 360 M
-                                                                   <option value="130">
-                                                                    HE 400 AA
-                                                                    <option value="131">
-                                                                     HE 400 x 107
-                                                                     <option value="132">
-                                                                      HE 400 A
-                                                                      <option value="133">
-                                                                       HE 400 B
-                                                                       <option value="134">
-                                                                        HE 400 M
-                                                                        <option value="135">
-                                                                         HE 450 AA
-                                                                         <option value="136">
-                                                                          HE 450 x 124
-                                                                          <option value="137">
-                                                                           HE 450 A
-                                                                           <option value="138">
-                                                                            HE 450 B
-                                                                            <option value="139">
-                                                                             HE 450 M
-                                                                             <option value="140">
-                                                                              HE 500 AA
-                                                                              <option value="141">
-                                                                               HE 500 A
-                                                                               <option value="142">
-                                                                                HE 500 B
-                                                                                <option value="143">
-                                                                                 HE 500 M
-                                                                                 <option value="144">
-                                                                                  HE 550 AA
-                                                                                  <option value="145">
-                                                                                   HE 550 A
-                                                                                   <option value="146">
-                                                                                    HE 550 B
-                                                                                    <option value="147">
-                                                                                     HE 550 M
-                                                                                     <option value="148">
-                                                                                      HE 600 AA
-                                                                                      <option value="149">
-                                                                                       HE 600 x 137
-                                                                                       <option value="150">
-                                                                                        HE 600 x 151
-                                                                                        <option value="151">
-                                                                                         HE 600 x 175
-                                                                                         <option value="152">
-                                                                                          HE 600 A
-                                                                                          <option value="153">
-                                                                                           HE 600 B
-                                                                                           <option value="154">
-                                                                                            HE 600 M
-                                                                                            <option value="155">
-                                                                                             HE 650 AA
-                                                                                             <option value="156">
-                                                                                              HE 650 A
-                                                                                              <option value="157">
-                                                                                               HE 650 B
-                                                                                               <option value="158">
-                                                                                                HE 650 M
-                                                                                                <option value="159">
-                                                                                                 HE 700 AA
-                                                                                                 <option value="160">
-                                                                                                  HE 700 x 166
-                                                                                                  <option value="161">
-                                                                                                   HE 700 A
-                                                                                                   <option value="162">
-                                                                                                    HE 700 B
-                                                                                                    <option value="163">
-                                                                                                     HE 700 M
-                                                                                                     <option value="164">
-                                                                                                      HE 800 AA
-                                                                                                      <option value="165">
-                                                                                                       HE 800 A
-                                                                                                       <option value="166">
-                                                                                                        HE 800 B
-                                                                                                        <option value="167">
-                                                                                                         HE 800 M
-                                                                                                         <option value="168">
-                                                                                                          HE 900 AA
-                                                                                                          <option value="169">
-                                                                                                           HE 900 A
-                                                                                                           <option value="170">
-                                                                                                            HE 900 B
-                                                                                                            <option value="171">
-                                                                                                             HE 900 M
-                                                                                                             <option value="172">
-                                                                                                              HE 1000 A
-                                                                                                              <option value="173">
-                                                                                                               HE 1000 A
-                                                                                                               <option value="174">
-                                                                                                                HE 1000 B
-                                                                                                                <option value="175">HE 1000 M</option>
+      Select section -
+      <select data-target="section">
+       <p>
+        Section type -
+        <select data-target="section" style="font-weight:bold; border:none; background: none; color: black; box-shadow:none; appearance: none;">
+         <option value="1">IPE 100A</option>
+         <option value="2">IPE 100</option>
+         <option value="3">IPE 120</option>
+         <option value="4">IPE 140 A</option>
+         <option value="5">IPE 140</option>
+         <option value="6">IPE 140 R</option>
+         <option value="7">IPE 160 A</option>
+         <option value="8">IPE 160</option>
+         <option value="9">IPE 160 R</option>
+         <option value="10">IPE 180 A</option>
+         <option value="11">IPE 180</option>
+         <option value="12">IPE 180 O</option>
+         <option value="13">IPE 180 R</option>
+         <option value="14">IPE 200 A</option>
+         <option value="15">IPE 200</option>
+         <option value="16">IPE 200 O</option>
+         <option value="17">IPE 200 R</option>
+         <option value="18">IPE 220 A</option>
+         <option value="19">IPE 220</option>
+         <option value="20">IPE 220 O</option>
+         <option value="21">IPE 220 R</option>
+         <option value="22">IPE 240 A</option>
+         <option value="23">IPE 240</option>
+         <option value="24">IPE 240 O</option>
+         <option value="25">IPE 240 R</option>
+         <option value="26">IPE 270 A</option>
+         <option value="27">IPE 270</option>
+         <option value="28">IPE 270 O</option>
+         <option value="29">IPE 270 R</option>
+         <option value="30">IPE 300 A</option>
+         <option value="31">IPE 300</option>
+         <option value="32">IPE 300O</option>
+         <option value="33">IPE 300 R</option>
+         <option value="34">IPE 330 A</option>
+         <option value="35">IPE 330</option>
+         <option value="36">IPE 330 O</option>
+         <option value="37">IPE 330 R</option>
+         <option value="38">IPE 360 A</option>
+         <option value="39">IPE 360</option>
+         <option value="40">IPE 360 O</option>
+         <option value="41">IPE 360 R</option>
+         <option value="42">IPE 400 A</option>
+         <option value="43">IPE 400</option>
+         <option value="44">IPE 400 O</option>
+         <option value="45">IPE 400 R</option>
+         <option value="46">IPE 400 V</option>
+         <option value="47">IPE 450 A</option>
+         <option value="48">IPE 450</option>
+         <option value="49">IPE 450 O</option>
+         <option value="50">IPE 450 R</option>
+         <option value="51">IPE 450 V</option>
+         <option value="52">IPE 500 A</option>
+         <option value="53">IPE 500</option>
+         <option value="54">IPE 500 O</option>
+         <option value="55">IPE 500 R</option>
+         <option value="56">IPE 500 V</option>
+         <option value="57">IPE 550 A</option>
+         <option value="58">IPE 550</option>
+         <option value="59">IPE 550 O</option>
+         <option value="60">IPE 550 R</option>
+         <option value="61">IPE 550 V</option>
+         <option value="62">IPE 600 A</option>
+         <option value="63">IPE 600</option>
+         <option value="64">IPE 600 O</option>
+         <option value="65">IPE 600 R</option>
+         <option value="66">IPE 600 V</option>
+         <option value="67">IPE 750 x 137</option>
+         <option value="68">IPE 750 x 147</option>
+         <option value="69">IPE 750 x 161</option>
+         <option value="70">
+          IPE 750 x 174
+          <option value="71">
+           IPE 750 x185
+           <option value="72">
+            IPE 750 x 197
+            <option value="73">
+             IPE 750 x 210
+             <option value="74">
+              IPE 750 x 223
+              <option value="75">
+               HE 100 AA
+               <option value="76">
+                HE 100 A
+                <option value="77">
+                 HE 100 A
+                 <option value="78">
+                  HE 100 B
+                  <option value="79">
+                   HE 120 AA
+                   <option value="80">
+                    HE 120 A
+                    <option value="81">
+                     HE 120 B
+                     <option value="82">
+                      HE 140 AA
+                      <option value="83">
+                       HE 140 A
+                       <option value="84">
+                        HE 140 B
+                        <option value="85">
+                         HE 160 AA
+                         <option value="86">
+                          HE 160 A
+                          <option value="87">
+                           HE 160 B
+                           <option value="88">
+                            HE 160 M
+                            <option value="89">
+                             HE 180 AA
+                             <option value="90">
+                              HE 180 A
+                              <option value="91">
+                               HE 180 B
+                               <option value="92">
+                                HE 180 M
+                                <option value="93">
+                                 HE 200 AA
+                                 <option value="94">
+                                  HE 200 A
+                                  <option value="95">
+                                   HE 200 B
+                                   <option value="96">
+                                    HE 200 M
+                                    <option value="97">
+                                     HE 220 AA
+                                     <option value="98">
+                                      HE 220 A
+                                      <option value="99">
+                                       HE 220 B
+                                       <option value="100">
+                                        HE 220 M
+                                        <option value="101">
+                                         HE 240 AA
+                                         <option value="102">
+                                          HE 240 A
+                                          <option value="103">
+                                           HE 240 B
+                                           <option value="104">
+                                            HE 240 M
+                                            <option value="105">
+                                             HE 260 AA
+                                             <option value="106">
+                                              HE 260 A
+                                              <option value="107">
+                                               HE 260 B
+                                               <option value="108">
+                                                HE 260 M
+                                                <option value="109">
+                                                 HE 280 AA
+                                                 <option value="110">
+                                                  HE 280 A
+                                                  <option value="111">
+                                                   HE 280 B
+                                                   <option value="112">
+                                                    HE 280 M
+                                                    <option value="113">
+                                                     HE 300 AA
+                                                     <option value="114">
+                                                      HE 300 A
+                                                      <option value="115">
+                                                       HE 300 B
+                                                       <option value="116">
+                                                        HE 300 C
+                                                        <option value="117">
+                                                         HE 300 M
+                                                         <option value="118">
+                                                          HE 320 AA
+                                                          <option value="119">
+                                                           HE 320 A
+                                                           <option value="120">
+                                                            HE 320 B
+                                                            <option value="121">
+                                                             HE 320 M
+                                                             <option value="122">
+                                                              HE 340 AA
+                                                              <option value="123">
+                                                               HE 340 A
+                                                               <option value="124">
+                                                                HE 340 B
+                                                                <option value="125">
+                                                                 HE 340 M
+                                                                 <option value="126">
+                                                                  HE 360 AA
+                                                                  <option value="127">
+                                                                   HE 360 A
+                                                                   <option value="128">
+                                                                    HE 360 B
+                                                                    <option value="129">
+                                                                     HE 360 M
+                                                                     <option value="130">
+                                                                      HE 400 AA
+                                                                      <option value="131">
+                                                                       HE 400 x 107
+                                                                       <option value="132">
+                                                                        HE 400 A
+                                                                        <option value="133">
+                                                                         HE 400 B
+                                                                         <option value="134">
+                                                                          HE 400 M
+                                                                          <option value="135">
+                                                                           HE 450 AA
+                                                                           <option value="136">
+                                                                            HE 450 x 124
+                                                                            <option value="137">
+                                                                             HE 450 A
+                                                                             <option value="138">
+                                                                              HE 450 B
+                                                                              <option value="139">
+                                                                               HE 450 M
+                                                                               <option value="140">
+                                                                                HE 500 AA
+                                                                                <option value="141">
+                                                                                 HE 500 A
+                                                                                 <option value="142">
+                                                                                  HE 500 B
+                                                                                  <option value="143">
+                                                                                   HE 500 M
+                                                                                   <option value="144">
+                                                                                    HE 550 AA
+                                                                                    <option value="145">
+                                                                                     HE 550 A
+                                                                                     <option value="146">
+                                                                                      HE 550 B
+                                                                                      <option value="147">
+                                                                                       HE 550 M
+                                                                                       <option value="148">
+                                                                                        HE 600 AA
+                                                                                        <option value="149">
+                                                                                         HE 600 x 137
+                                                                                         <option value="150">
+                                                                                          HE 600 x 151
+                                                                                          <option value="151">
+                                                                                           HE 600 x 175
+                                                                                           <option value="152">
+                                                                                            HE 600 A
+                                                                                            <option value="153">
+                                                                                             HE 600 B
+                                                                                             <option value="154">
+                                                                                              HE 600 M
+                                                                                              <option value="155">
+                                                                                               HE 650 AA
+                                                                                               <option value="156">
+                                                                                                HE 650 A
+                                                                                                <option value="157">
+                                                                                                 HE 650 B
+                                                                                                 <option value="158">
+                                                                                                  HE 650 M
+                                                                                                  <option value="159">
+                                                                                                   HE 700 AA
+                                                                                                   <option value="160">
+                                                                                                    HE 700 x 166
+                                                                                                    <option value="161">
+                                                                                                     HE 700 A
+                                                                                                     <option value="162">
+                                                                                                      HE 700 B
+                                                                                                      <option value="163">
+                                                                                                       HE 700 M
+                                                                                                       <option value="164">
+                                                                                                        HE 800 AA
+                                                                                                        <option value="165">
+                                                                                                         HE 800 A
+                                                                                                         <option value="166">
+                                                                                                          HE 800 B
+                                                                                                          <option value="167">
+                                                                                                           HE 800 M
+                                                                                                           <option value="168">
+                                                                                                            HE 900 AA
+                                                                                                            <option value="169">
+                                                                                                             HE 900 A
+                                                                                                             <option value="170">
+                                                                                                              HE 900 B
+                                                                                                              <option value="171">
+                                                                                                               HE 900 M
+                                                                                                               <option value="172">
+                                                                                                                HE 1000 A
+                                                                                                                <option value="173">
+                                                                                                                 HE 1000 A
+                                                                                                                 <option value="174">
+                                                                                                                  HE 1000 B
+                                                                                                                  <option value="175">HE 1000 M</option>
+                                                                                                                 </option>
+                                                                                                                </option>
                                                                                                                </option>
                                                                                                               </option>
                                                                                                              </option>
@@ -404,69 +409,69 @@
            </option>
           </option>
          </option>
-        </option>
-       </option>
+        </select>
+       </p>
+       <p id="section" style="display:none;">
+        <span class="eq">
+         <var>id</var>
+         =
+         <u class="input-191">22</u>
+        </span>
+       </p>
+       <table>
+        <tr>
+         <td style="padding-right: 10px;">
+          <span class="eq">
+           <var>h</var>
+           = 237
+           <i>mm</i>
+          </span>
+         </td>
+         <td>
+          <span class="eq">
+           <var>t</var>
+           <sub>w</sub>
+           = 5.2
+           <i>mm</i>
+          </span>
+         </td>
+        </tr>
+        <tr>
+         <td style="padding-right: 10px;">
+          <span class="eq">
+           <var>b</var>
+           = 120
+           <i>mm</i>
+          </span>
+         </td>
+         <td>
+          <span class="eq">
+           <var>t</var>
+           <sub>f</sub>
+           = 8.3
+           <i>mm</i>
+          </span>
+         </td>
+        </tr>
+        <tr>
+         <td style="padding-right: 10px;">
+          <span class="eq">
+           <var>r</var>
+           = 15
+           <i>mm</i>
+          </span>
+         </td>
+         <td>
+          <span class="eq">
+           <var>d</var>
+           = 190.4
+           <i>mm</i>
+          </span>
+         </td>
+        </tr>
+       </table>
       </select>
      </p>
-     <p id="section" style="display:none;">
-      <span class="eq">
-       <var>id</var>
-       =
-       <u class="input-191">22</u>
-      </span>
-     </p>
-     <table>
-      <tr>
-       <td style="padding-right: 10px;">
-        <span class="eq">
-         <var>h</var>
-         = 237
-         <i>mm</i>
-        </span>
-       </td>
-       <td>
-        <span class="eq">
-         <var>t</var>
-         <sub>w</sub>
-         = 5.2
-         <i>mm</i>
-        </span>
-       </td>
-      </tr>
-      <tr>
-       <td style="padding-right: 10px;">
-        <span class="eq">
-         <var>b</var>
-         = 120
-         <i>mm</i>
-        </span>
-       </td>
-       <td>
-        <span class="eq">
-         <var>t</var>
-         <sub>f</sub>
-         = 8.3
-         <i>mm</i>
-        </span>
-       </td>
-      </tr>
-      <tr>
-       <td style="padding-right: 10px;">
-        <span class="eq">
-         <var>r</var>
-         = 15
-         <i>mm</i>
-        </span>
-       </td>
-       <td>
-        <span class="eq">
-         <var>d</var>
-         = 190.4
-         <i>mm</i>
-        </span>
-       </td>
-      </tr>
-     </table>
     </td>
     <td>
      <img alt="i-profile.png" src="./i-profile.png" style="height:165pt; width:111pt;"/>

--- a/Examples/Structural/Steel/I-Section Properties and Drawing.html.stub
+++ b/Examples/Structural/Steel/I-Section Properties and Drawing.html.stub
@@ -9,570 +9,587 @@
    : EN 1993-1-1
   </small>
  </h3>
- <p>
- </p>
- <table>
-  <tr>
-   <td>
-    <h4>Dimensions</h4>
-    <p>
-     Section type -
-     <select data-target="section" style="font-weight:bold; border:none; background: none; color: black; box-shadow:none; appearance: none;">
-      <option value="100;4.1;55;5.7;55;5.7;7;0">IPE 100</option>
-      <option value="120;4.4;64;6.3;64;6.3;7;0">IPE 120</option>
-      <option value="137.4;3.8;73;5.6;73;5.6;7;0">IPE 140 A</option>
-      <option value="140;4.7;73;6.9;73;6.9;7;0">IPE 140</option>
-      <option value="142;5.3;72;7.8;72;7.8;7;0">IPE 140 R</option>
-      <option value="157;4;82;5.9;82;5.9;9;0">IPE 160 A</option>
-      <option value="160;5;82;7.4;82;7.4;9;0">IPE 160</option>
-      <option value="162;5.6;81;8.5;81;8.5;9;0">IPE 160 R</option>
-      <option value="177;4.3;91;6.5;91;6.5;9;0">IPE 180 A</option>
-      <option value="180;5.3;91;8;91;8;9;0">IPE 180</option>
-      <option value="182;6;92;9;92;9;9;0">IPE 180 O</option>
-      <option value="183;6.4;89;9.5;89;9.5;9;0">IPE 180 R</option>
-      <option value="197;4.5;100;7;100;7;12;0">IPE 200 A</option>
-      <option value="200;5.6;100;8.5;100;8.5;12;0">IPE 200</option>
-      <option value="202;6.2;102;9.5;102;9.5;12;0">IPE 200 O</option>
-      <option value="204;6.6;98;10.5;98;10.5;12;0">IPE 200 R</option>
-      <option value="217;5;110;7.7;110;7.7;12;0">IPE 220 A</option>
-      <option value="220;5.9;110;9.2;110;9.2;12;0">IPE 220</option>
-      <option value="222;6.6;112;10.2;112;10.2;12;0">IPE 220 O</option>
-      <option value="225;6.7;108;11.8;108;11.8;12;0">IPE 220 R</option>
-      <option value="237;5.2;120;8.3;120;8.3;15;0">IPE 240 A</option>
-      <option value="240;6.2;120;9.8;120;9.8;15;0">IPE 240</option>
-      <option value="242;7;122;10.8;122;10.8;15;0">IPE 240 O</option>
-      <option value="245;7.5;118;12.3;118;12.3;15;0">IPE 240 R</option>
-      <option value="267;5.5;135;8.7;135;8.7;15;0">IPE 270 A</option>
-      <option value="270;6.6;135;10.2;135;10.2;15;0">IPE 270</option>
-      <option value="274;7.5;136;12.2;136;12.2;15;0">IPE 270 O</option>
-      <option value="276;7.7;133;13.1;133;13.1;15;0">IPE 270 R</option>
-      <option value="297;6.1;150;9.2;150;9.2;15;0">IPE 300 A</option>
-      <option value="300;7.1;150;10.7;150;10.7;15;0">IPE 300</option>
-      <option value="304;8;152;12.7;152;12.7;15;0">IPE 300 O</option>
-      <option value="306;8.5;147;13.7;147;13.7;15;0">IPE 300 R</option>
-      <option value="327;6.5;160;10;160;10;18;0">IPE 330 A</option>
-      <option value="330;7.5;160;11.5;160;11.5;18;0">IPE 330</option>
-      <option value="334;8.5;162;13.5;162;13.5;18;0">IPE 330 O</option>
-      <option value="336;9.2;158;14.5;158;14.5;18;0">IPE 330 R</option>
-      <option value="357.6;6.6;170;11.5;170;11.5;18;0">IPE 360 A</option>
-      <option value="360;8;170;12.7;170;12.7;18;0">IPE 360</option>
-      <option value="364;9.2;172;14.7;172;14.7;18;0">IPE 360 O</option>
-      <option value="366;9.9;168;16;168;16;18;0">IPE 360 R</option>
-      <option value="397;7;180;12;180;12;21;0">IPE 400 A</option>
-      <option value="400;8.6;180;13.5;180;13.5;21;0">IPE 400</option>
-      <option value="404;9.7;182;15.5;182;15.5;21;0">IPE 400 O</option>
-      <option value="407;10.6;178;17;178;17;21;0">IPE 400 R</option>
-      <option value="408;10.6;182;17.5;182;17.5;21;0">IPE 400 V</option>
-      <option value="447;7.6;190;13.1;190;13.1;21;0">IPE 450 A</option>
-      <option value="450;9.4;190;14.6;190;14.6;21;0">IPE 450</option>
-      <option value="456;11;192;17.6;192;17.6;21;0">IPE 450 O</option>
-      <option value="458;11.3;188;18.6;188;18.6;21;0">IPE 450 R</option>
-      <option value="460;12.4;194;19.6;194;19.6;21;0">IPE 450 V</option>
-      <option value="497;8.4;200;14.5;200;14.5;21;0">IPE 500 A</option>
-      <option value="500;10.2;200;16;200;16;21;0">IPE 500</option>
-      <option value="506;12;202;19;202;19;21;0">IPE 500 O</option>
-      <option value="508;12.6;198;20;198;20;21;0">IPE 500 R</option>
-      <option value="514;14.2;204;23;204;23;21;0">IPE 500 V</option>
-      <option value="547;9;210;15.7;210;15.7;24;0">IPE 550 A</option>
-      <option value="550;11.1;210;17.2;210;17.2;24;0">IPE 550</option>
-      <option value="556;12.7;212;20.2;212;20.2;24;0">IPE 550 O</option>
-      <option value="560;14;210;22.2;210;22.2;24;0">IPE 550 R</option>
-      <option value="566;17.1;216;25.2;216;25.2;24;0">IPE 550 V</option>
-      <option value="597;9.8;220;17.5;220;17.5;24;0">IPE 600 A</option>
-      <option value="600;12;220;19;220;19;24;0">IPE 600</option>
-      <option value="610;15;224;24;224;24;24;0">IPE 600 O</option>
-      <option value="608;14;218;23;218;23;24;0">IPE 600 R</option>
-      <option value="618;18;228;28;228;28;24;0">IPE 600 V</option>
-      <option value="753;11.5;263;17;263;17;17;0">IPE 750 x 137</option>
-      <option value="753;13.2;265;17;265;17;17;0">IPE 750 x 147</option>
-      <option value="758;13.8;266;19.3;266;19.3;17;0">IPE 750 x 161</option>
-      <option value="762;14.4;267;21.6;267;21.6;17;0">IPE 750 x 174</option>
-      <option value="766;14.9;267;23.6;267;23.6;17;0">IPE 750 x185</option>
-      <option value="770;15.6;268;25.4;268;25.4;17;0">IPE 750 x 197</option>
-      <option value="775;16;268;28;268;28;17;0">IPE 750 x 210</option>
-      <option value="778;17;269;29.5;269;29.5;17;0">IPE 750 x 223</option>
-      <option value="96;5;100;8;100;8;12;0">HE 100 A</option>
-      <option value="96;5;100;8;100;8;12;0">HE 100 A</option>
-      <option value="100;6;100;10;100;10;12;0">HE 100 B</option>
-      <option value="109;4.2;120;5.5;120;5.5;12;0">HE 120 AA</option>
-      <option value="114;5;120;8;120;8;12;0">HE 120 A</option>
-      <option value="120;6.5;120;11;120;11;12;0">HE 120 B</option>
-      <option value="128;4.3;140;6;140;6;12;0">HE 140 AA</option>
-      <option value="133;5.5;140;8.5;140;8.5;12;0">HE 140 A</option>
-      <option value="140;7;140;12;140;12;12;0">HE 140 B</option>
-      <option value="148;4.5;160;7;160;7;15;0">HE 160 AA</option>
-      <option value="152;6;160;9;160;9;15;0">HE 160 A</option>
-      <option value="160;8;160;13;160;13;15;0">HE 160 B</option>
-      <option value="180;14;166;23;166;23;15;0">HE 160 M</option>
-      <option value="167;5;180;7.5;180;7.5;15;0">HE 180 AA</option>
-      <option value="171;6;180;9.5;180;9.5;15;0">HE 180 A</option>
-      <option value="180;8.5;180;14;180;14;15;0">HE 180 B</option>
-      <option value="200;14.5;186;24;186;24;15;0">HE 180 M</option>
-      <option value="186;5.5;200;8;200;8;18;0">HE 200 AA</option>
-      <option value="190;6.5;200;10;200;10;18;0">HE 200 A</option>
-      <option value="200;9;200;15;200;15;18;0">HE 200 B</option>
-      <option value="220;15;206;25;206;25;18;0">HE 200 M</option>
-      <option value="205;6;220;8.5;220;8.5;18;0">HE 220 AA</option>
-      <option value="210;7;220;11;220;11;18;0">HE 220 A</option>
-      <option value="220;9.5;220;16;220;16;18;0">HE 220 B</option>
-      <option value="240;15.5;226;26;226;26;18;0">HE 220 M</option>
-      <option value="224;6.5;240;9;240;9;21;0">HE 240 AA</option>
-      <option value="230;7.5;240;12;240;12;21;0">HE 240 A</option>
-      <option value="240;10;240;17;240;17;21;0">HE 240 B</option>
-      <option value="270;18;248;32;248;32;21;0">HE 240 M</option>
-      <option value="244;6.5;260;9.5;260;9.5;24;0">HE 260 AA</option>
-      <option value="250;7.5;260;12.5;260;12.5;24;0">HE 260 A</option>
-      <option value="260;10;260;17.5;260;17.5;24;0">HE 260 B</option>
-      <option value="290;18;268;32.5;268;32.5;24;0">HE 260 M</option>
-      <option value="264;7;280;10;280;10;24;0">HE 280 AA</option>
-      <option value="270;8;280;13;280;13;24;0">HE 280 A</option>
-      <option value="280;10.5;280;18;280;18;24;0">HE 280 B</option>
-      <option value="310;18.5;288;33;288;33;24;0">HE 280 M</option>
-      <option value="283;7.5;300;10.5;300;10.5;27;0">HE 300 AA</option>
-      <option value="290;8.5;300;14;300;14;27;0">HE 300 A</option>
-      <option value="300;11;300;19;300;19;27;0">HE 300 B</option>
-      <option value="320;16;305;29;305;29;27;0">HE 300 C</option>
-      <option value="340;21;310;39;310;39;27;0">HE 300 M</option>
-      <option value="301;8;300;11;300;11;27;0">HE 320 AA</option>
-      <option value="310;9;300;15.5;300;15.5;27;0">HE 320 A</option>
-      <option value="320;11.5;300;20.5;300;20.5;27;0">HE 320 B</option>
-      <option value="359;21;309;40;309;40;27;0">HE 320 M</option>
-      <option value="320;8.5;300;11.5;300;11.5;27;0">HE 340 AA</option>
-      <option value="330;9.5;300;16.5;300;16.5;27;0">HE 340 A</option>
-      <option value="340;12;300;21.5;300;21.5;27;0">HE 340 B</option>
-      <option value="377;21;309;40;309;40;27;0">HE 340 M</option>
-      <option value="339;9;300;12;300;12;27;0">HE 360 AA</option>
-      <option value="350;10;300;17.5;300;17.5;27;0">HE 360 A</option>
-      <option value="360;12.5;300;22.5;300;22.5;27;0">HE 360 B</option>
-      <option value="395;21;308;40;308;40;27;0">HE 360 M</option>
-      <option value="378;9.5;300;13;300;13;27;0">HE 400 AA</option>
-      <option value="384;10;297;16;297;16;27;0">HE 400 x 107</option>
-      <option value="390;11;300;19;300;19;27;0">HE 400 A</option>
-      <option value="400;13.5;300;24;300;24;27;0">HE 400 B</option>
-      <option value="432;21;307;40;307;40;27;0">HE 400 M</option>
-      <option value="425;10;300;13.5;300;13.5;27;0">HE 450 AA</option>
-      <option value="435;10.2;300;18.5;300;18.5;27;0">HE 450 x 124</option>
-      <option value="440;11.5;300;21;300;21;27;0">HE 450 A</option>
-      <option value="450;14;300;26;300;26;27;0">HE 450 B</option>
-      <option value="478;21;307;40;307;40;27;0">HE 450 M</option>
-      <option value="472;10.5;300;14;300;14;27;0">HE 500 AA</option>
-      <option value="490;12;300;23;300;23;27;0">HE 500 A</option>
-      <option value="500;14.5;300;28;300;28;27;0">HE 500 B</option>
-      <option value="524;21;306;40;306;40;27;0">HE 500 M</option>
-      <option value="522;11.5;300;15;300;15;27;0">HE 550 AA</option>
-      <option value="540;12.5;300;24;300;24;27;0">HE 550 A</option>
-      <option value="550;15;300;29;300;29;27;0">HE 550 B</option>
-      <option value="572;21;306;40;306;40;27;0">HE 550 M</option>
-      <option value="571;12;300;15.5;300;15.5;27;0">HE 600 AA</option>
-      <option value="575;11.8;300;17.5;300;17.5;27;0">HE 600 x 137</option>
-      <option value="582;11.6;300;20.6;300;20.6;27;0">HE 600 x 151</option>
-      <option value="588;13.6;300;23.9;300;23.9;27;0">HE 600 x 175</option>
-      <option value="590;13;300;25;300;25;27;0">HE 600 A</option>
-      <option value="600;15.5;300;30;300;30;27;0">HE 600 B</option>
-      <option value="620;21;305;40;305;40;27;0">HE 600 M</option>
-      <option value="620;12.5;300;16;300;16;27;0">HE 650 AA</option>
-      <option value="640;13.5;300;26;300;26;27;0">HE 650 A</option>
-      <option value="650;16;300;31;300;31;27;0">HE 650 B</option>
-      <option value="668;21;305;40;305;40;27;0">HE 650 M</option>
-      <option value="670;13;300;17;300;17;27;0">HE 700 AA</option>
-      <option value="678;12.5;300;21;300;21;27;0">HE 700 x 166</option>
-      <option value="690;14.5;300;27;300;27;27;0">HE 700 A</option>
-      <option value="700;17;300;32;300;32;27;0">HE 700 B</option>
-      <option value="716;21;304;40;304;40;27;0">HE 700 M</option>
-      <option value="770;14;300;18;300;18;30;0">HE 800 AA</option>
-      <option value="790;15;300;28;300;28;30;0">HE 800 A</option>
-      <option value="800;17.5;300;33;300;33;30;0">HE 800 B</option>
-      <option value="814;21;303;40;303;40;30;0">HE 800 M</option>
-      <option value="870;15;300;20;300;20;30;0">HE 900 AA</option>
-      <option value="890;16;300;30;300;30;30;0">HE 900 A</option>
-      <option value="900;18.5;300;35;300;35;30;0">HE 900 B</option>
-      <option value="910;21;302;40;302;40;30;0">HE 900 M</option>
-      <option value="970;16;300;21;300;21;30;0">HE 1000 A</option>
-      <option value="990;16.5;300;31;300;31;30;0">HE 1000 A</option>
-      <option value="1000;19;300;36;300;36;30;0">HE 1000 B</option>
-      <option value="1008;21;302;40;302;40;30;0">HE 1000 M</option>
-     </select>
-    </p>
-    <table id="section">
-     <tr>
-      <td style="padding-right: 10px;">
-       <span class="eq">
-        <var>h</var>
-        =
-        <u class="input-192">180</u>
-       </span>
-       mm,
-      </td>
-      <td>
-       <span class="eq">
-        <var>t</var>
-        <sub>w</sub>
-        =
-        <u class="input-192">5.3</u>
-       </span>
-       mm
-      </td>
-     </tr>
-     <tr>
-      <td style="padding-right: 10px;">
-       <span class="eq">
-        <var>b</var>
-        <sub>f1</sub>
-        =
-        <u class="input-193">91</u>
-       </span>
-       mm,
-      </td>
-      <td>
-       <span class="eq">
-        <var>t</var>
-        <sub>f1</sub>
-        =
-        <u class="input-193">8</u>
-       </span>
-       mm
-      </td>
-     </tr>
-     <tr>
-      <td style="padding-right: 10px;">
-       <span class="eq">
-        <var>b</var>
-        <sub>f2</sub>
-        =
-        <u class="input-194">91</u>
-       </span>
-       mm,
-      </td>
-      <td>
-       <span class="eq">
-        <var>t</var>
-        <sub>f2</sub>
-        =
-        <u class="input-194">8</u>
-       </span>
-       mm
-      </td>
-     </tr>
-     <tr>
-      <td style="padding-right: 10px;">
-       <span class="eq">
-        <var>r</var>
-        =
-        <u class="input-195">9</u>
-       </span>
-       mm,
-      </td>
-      <td style="display:none">
-       <span class="eq">
-        <var>r</var>
-        <sub>2</sub>
-        =
-        <u class="input-195">0</u>
-       </span>
-       mm
-      </td>
-     </tr>
-    </table>
-    <p>
+ <div style="max-width:150mm; padding-left:5mm; background:#f0f0ee; border: solid 1pt #e4e4e0; border-radius:6pt; box-shadow: 3pt 3pt 6pt rgba(0, 0, 0, 0.4)">
+  <p>
+  </p>
+  <table>
+   <tr>
+    <td>
+     <h4>Dimensions</h4>
+     <p>
+      Select section -
+      <select data-target="section">
+       <p>
+        Section type -
+        <select data-target="section" style="font-weight:bold; border:none; background: none; color: black; box-shadow:none; appearance: none;">
+         <option value="100;4.1;55;5.7;55;5.7;7;0">IPE 100</option>
+         <option value="120;4.4;64;6.3;64;6.3;7;0">IPE 120</option>
+         <option value="137.4;3.8;73;5.6;73;5.6;7;0">IPE 140 A</option>
+         <option value="140;4.7;73;6.9;73;6.9;7;0">IPE 140</option>
+         <option value="142;5.3;72;7.8;72;7.8;7;0">IPE 140 R</option>
+         <option value="157;4;82;5.9;82;5.9;9;0">IPE 160 A</option>
+         <option value="160;5;82;7.4;82;7.4;9;0">IPE 160</option>
+         <option value="162;5.6;81;8.5;81;8.5;9;0">IPE 160 R</option>
+         <option value="177;4.3;91;6.5;91;6.5;9;0">IPE 180 A</option>
+         <option value="180;5.3;91;8;91;8;9;0">IPE 180</option>
+         <option value="182;6;92;9;92;9;9;0">IPE 180 O</option>
+         <option value="183;6.4;89;9.5;89;9.5;9;0">IPE 180 R</option>
+         <option value="197;4.5;100;7;100;7;12;0">IPE 200 A</option>
+         <option value="200;5.6;100;8.5;100;8.5;12;0">IPE 200</option>
+         <option value="202;6.2;102;9.5;102;9.5;12;0">IPE 200 O</option>
+         <option value="204;6.6;98;10.5;98;10.5;12;0">IPE 200 R</option>
+         <option value="217;5;110;7.7;110;7.7;12;0">IPE 220 A</option>
+         <option value="220;5.9;110;9.2;110;9.2;12;0">IPE 220</option>
+         <option value="222;6.6;112;10.2;112;10.2;12;0">IPE 220 O</option>
+         <option value="225;6.7;108;11.8;108;11.8;12;0">IPE 220 R</option>
+         <option value="237;5.2;120;8.3;120;8.3;15;0">IPE 240 A</option>
+         <option value="240;6.2;120;9.8;120;9.8;15;0">IPE 240</option>
+         <option value="242;7;122;10.8;122;10.8;15;0">IPE 240 O</option>
+         <option value="245;7.5;118;12.3;118;12.3;15;0">IPE 240 R</option>
+         <option value="267;5.5;135;8.7;135;8.7;15;0">IPE 270 A</option>
+         <option value="270;6.6;135;10.2;135;10.2;15;0">IPE 270</option>
+         <option value="274;7.5;136;12.2;136;12.2;15;0">IPE 270 O</option>
+         <option value="276;7.7;133;13.1;133;13.1;15;0">IPE 270 R</option>
+         <option value="297;6.1;150;9.2;150;9.2;15;0">IPE 300 A</option>
+         <option value="300;7.1;150;10.7;150;10.7;15;0">IPE 300</option>
+         <option value="304;8;152;12.7;152;12.7;15;0">IPE 300 O</option>
+         <option value="306;8.5;147;13.7;147;13.7;15;0">IPE 300 R</option>
+         <option value="327;6.5;160;10;160;10;18;0">IPE 330 A</option>
+         <option value="330;7.5;160;11.5;160;11.5;18;0">IPE 330</option>
+         <option value="334;8.5;162;13.5;162;13.5;18;0">IPE 330 O</option>
+         <option value="336;9.2;158;14.5;158;14.5;18;0">IPE 330 R</option>
+         <option value="357.6;6.6;170;11.5;170;11.5;18;0">IPE 360 A</option>
+         <option value="360;8;170;12.7;170;12.7;18;0">IPE 360</option>
+         <option value="364;9.2;172;14.7;172;14.7;18;0">IPE 360 O</option>
+         <option value="366;9.9;168;16;168;16;18;0">IPE 360 R</option>
+         <option value="397;7;180;12;180;12;21;0">IPE 400 A</option>
+         <option value="400;8.6;180;13.5;180;13.5;21;0">IPE 400</option>
+         <option value="404;9.7;182;15.5;182;15.5;21;0">IPE 400 O</option>
+         <option value="407;10.6;178;17;178;17;21;0">IPE 400 R</option>
+         <option value="408;10.6;182;17.5;182;17.5;21;0">IPE 400 V</option>
+         <option value="447;7.6;190;13.1;190;13.1;21;0">IPE 450 A</option>
+         <option value="450;9.4;190;14.6;190;14.6;21;0">IPE 450</option>
+         <option value="456;11;192;17.6;192;17.6;21;0">IPE 450 O</option>
+         <option value="458;11.3;188;18.6;188;18.6;21;0">IPE 450 R</option>
+         <option value="460;12.4;194;19.6;194;19.6;21;0">IPE 450 V</option>
+         <option value="497;8.4;200;14.5;200;14.5;21;0">IPE 500 A</option>
+         <option value="500;10.2;200;16;200;16;21;0">IPE 500</option>
+         <option value="506;12;202;19;202;19;21;0">IPE 500 O</option>
+         <option value="508;12.6;198;20;198;20;21;0">IPE 500 R</option>
+         <option value="514;14.2;204;23;204;23;21;0">IPE 500 V</option>
+         <option value="547;9;210;15.7;210;15.7;24;0">IPE 550 A</option>
+         <option value="550;11.1;210;17.2;210;17.2;24;0">IPE 550</option>
+         <option value="556;12.7;212;20.2;212;20.2;24;0">IPE 550 O</option>
+         <option value="560;14;210;22.2;210;22.2;24;0">IPE 550 R</option>
+         <option value="566;17.1;216;25.2;216;25.2;24;0">IPE 550 V</option>
+         <option value="597;9.8;220;17.5;220;17.5;24;0">IPE 600 A</option>
+         <option value="600;12;220;19;220;19;24;0">IPE 600</option>
+         <option value="610;15;224;24;224;24;24;0">IPE 600 O</option>
+         <option value="608;14;218;23;218;23;24;0">IPE 600 R</option>
+         <option value="618;18;228;28;228;28;24;0">IPE 600 V</option>
+         <option value="753;11.5;263;17;263;17;17;0">IPE 750 x 137</option>
+         <option value="753;13.2;265;17;265;17;17;0">IPE 750 x 147</option>
+         <option value="758;13.8;266;19.3;266;19.3;17;0">IPE 750 x 161</option>
+         <option value="762;14.4;267;21.6;267;21.6;17;0">IPE 750 x 174</option>
+         <option value="766;14.9;267;23.6;267;23.6;17;0">IPE 750 x185</option>
+         <option value="770;15.6;268;25.4;268;25.4;17;0">IPE 750 x 197</option>
+         <option value="775;16;268;28;268;28;17;0">IPE 750 x 210</option>
+         <option value="778;17;269;29.5;269;29.5;17;0">IPE 750 x 223</option>
+         <option value="96;5;100;8;100;8;12;0">HE 100 A</option>
+         <option value="96;5;100;8;100;8;12;0">HE 100 A</option>
+         <option value="100;6;100;10;100;10;12;0">HE 100 B</option>
+         <option value="109;4.2;120;5.5;120;5.5;12;0">HE 120 AA</option>
+         <option value="114;5;120;8;120;8;12;0">HE 120 A</option>
+         <option value="120;6.5;120;11;120;11;12;0">HE 120 B</option>
+         <option value="128;4.3;140;6;140;6;12;0">HE 140 AA</option>
+         <option value="133;5.5;140;8.5;140;8.5;12;0">HE 140 A</option>
+         <option value="140;7;140;12;140;12;12;0">HE 140 B</option>
+         <option value="148;4.5;160;7;160;7;15;0">HE 160 AA</option>
+         <option value="152;6;160;9;160;9;15;0">HE 160 A</option>
+         <option value="160;8;160;13;160;13;15;0">HE 160 B</option>
+         <option value="180;14;166;23;166;23;15;0">HE 160 M</option>
+         <option value="167;5;180;7.5;180;7.5;15;0">HE 180 AA</option>
+         <option value="171;6;180;9.5;180;9.5;15;0">HE 180 A</option>
+         <option value="180;8.5;180;14;180;14;15;0">HE 180 B</option>
+         <option value="200;14.5;186;24;186;24;15;0">HE 180 M</option>
+         <option value="186;5.5;200;8;200;8;18;0">HE 200 AA</option>
+         <option value="190;6.5;200;10;200;10;18;0">HE 200 A</option>
+         <option value="200;9;200;15;200;15;18;0">HE 200 B</option>
+         <option value="220;15;206;25;206;25;18;0">HE 200 M</option>
+         <option value="205;6;220;8.5;220;8.5;18;0">HE 220 AA</option>
+         <option value="210;7;220;11;220;11;18;0">HE 220 A</option>
+         <option value="220;9.5;220;16;220;16;18;0">HE 220 B</option>
+         <option value="240;15.5;226;26;226;26;18;0">HE 220 M</option>
+         <option value="224;6.5;240;9;240;9;21;0">HE 240 AA</option>
+         <option value="230;7.5;240;12;240;12;21;0">HE 240 A</option>
+         <option value="240;10;240;17;240;17;21;0">HE 240 B</option>
+         <option value="270;18;248;32;248;32;21;0">HE 240 M</option>
+         <option value="244;6.5;260;9.5;260;9.5;24;0">HE 260 AA</option>
+         <option value="250;7.5;260;12.5;260;12.5;24;0">HE 260 A</option>
+         <option value="260;10;260;17.5;260;17.5;24;0">HE 260 B</option>
+         <option value="290;18;268;32.5;268;32.5;24;0">HE 260 M</option>
+         <option value="264;7;280;10;280;10;24;0">HE 280 AA</option>
+         <option value="270;8;280;13;280;13;24;0">HE 280 A</option>
+         <option value="280;10.5;280;18;280;18;24;0">HE 280 B</option>
+         <option value="310;18.5;288;33;288;33;24;0">HE 280 M</option>
+         <option value="283;7.5;300;10.5;300;10.5;27;0">HE 300 AA</option>
+         <option value="290;8.5;300;14;300;14;27;0">HE 300 A</option>
+         <option value="300;11;300;19;300;19;27;0">HE 300 B</option>
+         <option value="320;16;305;29;305;29;27;0">HE 300 C</option>
+         <option value="340;21;310;39;310;39;27;0">HE 300 M</option>
+         <option value="301;8;300;11;300;11;27;0">HE 320 AA</option>
+         <option value="310;9;300;15.5;300;15.5;27;0">HE 320 A</option>
+         <option value="320;11.5;300;20.5;300;20.5;27;0">HE 320 B</option>
+         <option value="359;21;309;40;309;40;27;0">HE 320 M</option>
+         <option value="320;8.5;300;11.5;300;11.5;27;0">HE 340 AA</option>
+         <option value="330;9.5;300;16.5;300;16.5;27;0">HE 340 A</option>
+         <option value="340;12;300;21.5;300;21.5;27;0">HE 340 B</option>
+         <option value="377;21;309;40;309;40;27;0">HE 340 M</option>
+         <option value="339;9;300;12;300;12;27;0">HE 360 AA</option>
+         <option value="350;10;300;17.5;300;17.5;27;0">HE 360 A</option>
+         <option value="360;12.5;300;22.5;300;22.5;27;0">HE 360 B</option>
+         <option value="395;21;308;40;308;40;27;0">HE 360 M</option>
+         <option value="378;9.5;300;13;300;13;27;0">HE 400 AA</option>
+         <option value="384;10;297;16;297;16;27;0">HE 400 x 107</option>
+         <option value="390;11;300;19;300;19;27;0">HE 400 A</option>
+         <option value="400;13.5;300;24;300;24;27;0">HE 400 B</option>
+         <option value="432;21;307;40;307;40;27;0">HE 400 M</option>
+         <option value="425;10;300;13.5;300;13.5;27;0">HE 450 AA</option>
+         <option value="435;10.2;300;18.5;300;18.5;27;0">HE 450 x 124</option>
+         <option value="440;11.5;300;21;300;21;27;0">HE 450 A</option>
+         <option value="450;14;300;26;300;26;27;0">HE 450 B</option>
+         <option value="478;21;307;40;307;40;27;0">HE 450 M</option>
+         <option value="472;10.5;300;14;300;14;27;0">HE 500 AA</option>
+         <option value="490;12;300;23;300;23;27;0">HE 500 A</option>
+         <option value="500;14.5;300;28;300;28;27;0">HE 500 B</option>
+         <option value="524;21;306;40;306;40;27;0">HE 500 M</option>
+         <option value="522;11.5;300;15;300;15;27;0">HE 550 AA</option>
+         <option value="540;12.5;300;24;300;24;27;0">HE 550 A</option>
+         <option value="550;15;300;29;300;29;27;0">HE 550 B</option>
+         <option value="572;21;306;40;306;40;27;0">HE 550 M</option>
+         <option value="571;12;300;15.5;300;15.5;27;0">HE 600 AA</option>
+         <option value="575;11.8;300;17.5;300;17.5;27;0">HE 600 x 137</option>
+         <option value="582;11.6;300;20.6;300;20.6;27;0">HE 600 x 151</option>
+         <option value="588;13.6;300;23.9;300;23.9;27;0">HE 600 x 175</option>
+         <option value="590;13;300;25;300;25;27;0">HE 600 A</option>
+         <option value="600;15.5;300;30;300;30;27;0">HE 600 B</option>
+         <option value="620;21;305;40;305;40;27;0">HE 600 M</option>
+         <option value="620;12.5;300;16;300;16;27;0">HE 650 AA</option>
+         <option value="640;13.5;300;26;300;26;27;0">HE 650 A</option>
+         <option value="650;16;300;31;300;31;27;0">HE 650 B</option>
+         <option value="668;21;305;40;305;40;27;0">HE 650 M</option>
+         <option value="670;13;300;17;300;17;27;0">HE 700 AA</option>
+         <option value="678;12.5;300;21;300;21;27;0">HE 700 x 166</option>
+         <option value="690;14.5;300;27;300;27;27;0">HE 700 A</option>
+         <option value="700;17;300;32;300;32;27;0">HE 700 B</option>
+         <option value="716;21;304;40;304;40;27;0">HE 700 M</option>
+         <option value="770;14;300;18;300;18;30;0">HE 800 AA</option>
+         <option value="790;15;300;28;300;28;30;0">HE 800 A</option>
+         <option value="800;17.5;300;33;300;33;30;0">HE 800 B</option>
+         <option value="814;21;303;40;303;40;30;0">HE 800 M</option>
+         <option value="870;15;300;20;300;20;30;0">HE 900 AA</option>
+         <option value="890;16;300;30;300;30;30;0">HE 900 A</option>
+         <option value="900;18.5;300;35;300;35;30;0">HE 900 B</option>
+         <option value="910;21;302;40;302;40;30;0">HE 900 M</option>
+         <option value="970;16;300;21;300;21;30;0">HE 1000 A</option>
+         <option value="990;16.5;300;31;300;31;30;0">HE 1000 A</option>
+         <option value="1000;19;300;36;300;36;30;0">HE 1000 B</option>
+         <option value="1008;21;302;40;302;40;30;0">HE 1000 M</option>
+        </select>
+       </p>
+       <table id="section">
+        <tr>
+         <td style="padding-right: 10px;">
+          <span class="eq">
+           <var>h</var>
+           =
+           <u class="input-192">180</u>
+          </span>
+          mm,
+         </td>
+         <td>
+          <span class="eq">
+           <var>t</var>
+           <sub>w</sub>
+           =
+           <u class="input-192">5.3</u>
+          </span>
+          mm
+         </td>
+        </tr>
+        <tr>
+         <td style="padding-right: 10px;">
+          <span class="eq">
+           <var>b</var>
+           <sub>f1</sub>
+           =
+           <u class="input-193">91</u>
+          </span>
+          mm,
+         </td>
+         <td>
+          <span class="eq">
+           <var>t</var>
+           <sub>f1</sub>
+           =
+           <u class="input-193">8</u>
+          </span>
+          mm
+         </td>
+        </tr>
+        <tr>
+         <td style="padding-right: 10px;">
+          <span class="eq">
+           <var>b</var>
+           <sub>f2</sub>
+           =
+           <u class="input-194">91</u>
+          </span>
+          mm,
+         </td>
+         <td>
+          <span class="eq">
+           <var>t</var>
+           <sub>f2</sub>
+           =
+           <u class="input-194">8</u>
+          </span>
+          mm
+         </td>
+        </tr>
+        <tr>
+         <td style="padding-right: 10px;">
+          <span class="eq">
+           <var>r</var>
+           =
+           <u class="input-195">9</u>
+          </span>
+          mm,
+         </td>
+         <td style="display:none">
+          <span class="eq">
+           <var>r</var>
+           <sub>2</sub>
+           =
+           <u class="input-195">0</u>
+          </span>
+          mm
+         </td>
+        </tr>
+       </table>
+       <p>
+        <span class="eq">
+         <var>h</var>
+         <sub>w</sub>
+         =
+         <var>h</var>
+         −
+         <var>t</var>
+         <sub>f1</sub>
+         −
+         <var>t</var>
+         <sub>f2</sub>
+         = 180 − 8 − 8 = 164
+        </span>
+        mm
+       </p>
+       <p>
+        Section type -
+        <select data-target="rolled">
+         <option value="1">Rolled</option>
+         <option value="0">Welded</option>
+        </select>
+       </p>
+       <p id="rolled" style="display:none;">
+        <span class="eq">
+         <var>rolled</var>
+         =
+         <u class="input-205">1</u>
+        </span>
+       </p>
+       <p>Section type - Rolled</p>
+       <p>
+       </p>
+       <p>
+       </p>
+       <h4>Steel properties</h4>
+       <p>
+        Yield strength -
+        <span class="eq">
+         <var>f</var>
+         <sub>y</sub>
+         =
+         <u class="input-216">235</u>
+        </span>
+        MPa
+       </p>
+       <p>
+        Tensile strength -
+        <span class="eq">
+         <var>f</var>
+         <sub>u</sub>
+         =
+         <u class="input-217">360</u>
+        </span>
+        MPa
+       </p>
+       <p>
+       </p>
+       <p>
+        Modulus of elasticity -
+        <span class="eq">
+         <var>E</var>
+         = 210000
+        </span>
+        MPa
+       </p>
+       <p>Private factors of safety:</p>
+       <p>
+        <span class="eq">
+         <var>γ</var>
+         <sub>M0</sub>
+         = 1.05
+        </span>
+        ,
+        <span class="eq">
+         <var>γ</var>
+         <sub>M2</sub>
+         = 1.25
+        </span>
+       </p>
+      </select>
+     </p>
+    </td>
+    <td>
+     <img alt="I-section.svg" src="./i-section.svg"/>
+     <!-- SVG drawing macros included by the steel I-section worksheets to render the cross-section with its flange widths, web thickness and root radius. -->
+     <svg height="260pt" style="font-size:9pt;" viewbox="-95.5 -50 191 280" width="171pt" xmlns="http://www.w3.org/2000/svg">
+      <path d="M-45.5,0H45.5V8H11.65A9,9 0 0 0 2.65,17V163A9,9 0 0 0 11.65,172H45.5V180H-45.5V172H-11.65A9,9 0 0 0 -2.65,163V17A9,9 0 0 0 -11.65,8H-45.5Z" fill="LightSkyBlue" fill-opacity="0.6" stroke="#4ac" stroke-width="1.5">
+      </path>
+      <line stroke-dasharray="14.4,4.8,1.6,4.8" style="stroke:limegreen; stroke-width:0.8" x1="-80.5" x2="80.5" y1="90" y2="90">
+      </line>
+      <text text-anchor="middle" x="-85.5" y="90">y</text>
+      <text text-anchor="middle" x="85.5" y="90">y</text>
+      <line stroke-dasharray="14.4,4.8,1.6,4.8" style="stroke:limegreen; stroke-width:0.8" x1="0" x2="0" y1="-35" y2="215">
+      </line>
+      <text text-anchor="middle" x="0" y="-40">z</text>
+      <text text-anchor="middle" x="0" y="225">z</text>
+      <line style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod" x1="-66.5" x2="-54.5" y1="0" y2="0">
+      </line>
+      <line style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod" x1="-66.5" x2="-54.5" y1="180" y2="180">
+      </line>
+      <line style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod" x1="-60.5" x2="-60.5" y1="-6" y2="186">
+      </line>
+      <circle cx="-60.5" cy="0" r="1.8" style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod">
+      </circle>
+      <circle cx="-60.5" cy="180" r="1.8" style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod">
+      </circle>
+      <text text-anchor="middle" transform="rotate(-90,-65,90)" x="-65" y="90">180</text>
+      <line style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod" x1="64.5" x2="76.5" y1="0" y2="0">
+      </line>
+      <line style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod" x1="64.5" x2="76.5" y1="8" y2="8">
+      </line>
+      <line style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod" x1="70.5" x2="70.5" y1="-6" y2="14">
+      </line>
+      <circle cx="70.5" cy="0" r="1.8" style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod">
+      </circle>
+      <circle cx="70.5" cy="8" r="1.8" style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod">
+      </circle>
+      <text text-anchor="middle" transform="rotate(-90,66,4)" x="66" y="4">8</text>
+      <line style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod" x1="64.5" x2="76.5" y1="172" y2="172">
+      </line>
+      <line style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod" x1="64.5" x2="76.5" y1="180" y2="180">
+      </line>
+      <line style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod" x1="70.5" x2="70.5" y1="166" y2="186">
+      </line>
+      <circle cx="70.5" cy="172" r="1.8" style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod">
+      </circle>
+      <circle cx="70.5" cy="180" r="1.8" style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod">
+      </circle>
+      <text text-anchor="middle" transform="rotate(-90,66,176)" x="66" y="176">8</text>
+      <line style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod" x1="-45.5" x2="-45.5" y1="199" y2="211">
+      </line>
+      <line style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod" x1="45.5" x2="45.5" y1="199" y2="211">
+      </line>
+      <line style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod" x1="-51.5" x2="51.5" y1="205" y2="205">
+      </line>
+      <circle cx="45.5" cy="205" r="1.8" style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod">
+      </circle>
+      <circle cx="-45.5" cy="205" r="1.8" style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod">
+      </circle>
+      <text text-anchor="middle" x="0" y="200.5">91</text>
+      <line style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod" x1="-45.5" x2="-45.5" y1="-21" y2="-9">
+      </line>
+      <line style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod" x1="45.5" x2="45.5" y1="-21" y2="-9">
+      </line>
+      <line style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod" x1="-51.5" x2="51.5" y1="-15" y2="-15">
+      </line>
+      <circle cx="45.5" cy="-15" r="1.8" style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod">
+      </circle>
+      <circle cx="-45.5" cy="-15" r="1.8" style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod">
+      </circle>
+      <text text-anchor="middle" x="0" y="-19.5">91</text>
+      <line style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod" x1="-2.65" x2="-2.65" y1="69" y2="81">
+      </line>
+      <line style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod" x1="2.65" x2="2.65" y1="69" y2="81">
+      </line>
+      <line style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod" x1="-8.65" x2="8.65" y1="75" y2="75">
+      </line>
+      <circle cx="2.65" cy="75" r="1.8" style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod">
+      </circle>
+      <circle cx="-2.65" cy="75" r="1.8" style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod">
+      </circle>
+      <text text-anchor="middle" x="0" y="70.5">
+      </text>
+      <text text-anchor="middle" x="17.65" y="70">5.3</text>
+      <line style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod" x1="5.29" x2="36.65" y1="169.36" y2="138">
+      </line>
+      <line style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod" x1="36.65" x2="46.65" y1="138" y2="138">
+      </line>
+      <text text-anchor="middle" x="56.65" y="143">9</text>
+     </svg>
+    </td>
+   </tr>
+  </table>
+  <p>
+  </p>
+  <p>
+  </p>
+  <h4>Section properties</h4>
+  <table style="width:100%">
+   <tr>
+    <td>
      <span class="eq">
-      <var>h</var>
-      <sub>w</sub>
-      =
-      <var>h</var>
-      −
-      <var>t</var>
-      <sub>f1</sub>
-      −
-      <var>t</var>
-      <sub>f2</sub>
-      = 180 − 8 − 8 = 164
+      <var>A</var>
+      = 2394.73
      </span>
      mm
-    </p>
-    <p id="rolled" style="display:none;">
+     <sup>2</sup>
+    </td>
+    <td>
      <span class="eq">
-      <var>rolled</var>
-      =
-      <u class="input-205">1</u>
+      <var>y</var>
+      <sub>c</sub>
+      = 45.5
      </span>
-    </p>
-    <p>Section type - Rolled</p>
-    <p>
-    </p>
-    <p>
-    </p>
-    <h4>Steel properties</h4>
-    <p>
-     Yield strength -
+     mm
+    </td>
+    <td>
      <span class="eq">
-      <var>f</var>
+      <var>z</var>
+      <sub>c</sub>
+      = 90
+     </span>
+     mm
+    </td>
+    <td>
+    </td>
+   </tr>
+   <tr>
+    <td>
+     <span class="eq">
+      <var>I</var>
       <sub>y</sub>
-      =
-      <u class="input-216">235</u>
+      = 13169590
      </span>
-     MPa
-    </p>
-    <p>
-     Tensile strength -
+     mm
+     <sup>4</sup>
+    </td>
+    <td>
      <span class="eq">
-      <var>f</var>
-      <sub>u</sub>
-      =
-      <u class="input-217">360</u>
+      <var>r</var>
+      <sub>y</sub>
+      = 74.16
      </span>
-     MPa
-    </p>
-    <p>
-     Modulus of elasticity -
+     mm
+    </td>
+    <td>
      <span class="eq">
-      <var>E</var>
-      = 210000
+      <var>W</var>
+      <sub>el_y</sub>
+      = 146329
      </span>
-     MPa
-    </p>
-    <p>Private factors of safety:</p>
-    <p>
+     mm
+     <sup>3</sup>
+    </td>
+    <td>
      <span class="eq">
-      <var>γ</var>
-      <sub>M0</sub>
-      = 1.05
+      <var>W</var>
+      <sub>pl_y</sub>
+      = 166415
      </span>
-     ,
+     mm
+     <sup>3</sup>
+    </td>
+   </tr>
+   <tr>
+    <td>
      <span class="eq">
-      <var>γ</var>
-      <sub>M2</sub>
-      = 1.25
+      <var>I</var>
+      <sub>z</sub>
+      = 1008504
      </span>
-    </p>
-   </td>
-   <td>
-    <!-- SVG drawing macros included by the steel I-section worksheets to render the cross-section with its flange widths, web thickness and root radius. -->
-    <svg height="260pt" style="font-size:9pt;" viewbox="-95.5 -50 191 280" width="171pt" xmlns="http://www.w3.org/2000/svg">
-     <path d="M-45.5,0H45.5V8H11.65A9,9 0 0 0 2.65,17V163A9,9 0 0 0 11.65,172H45.5V180H-45.5V172H-11.65A9,9 0 0 0 -2.65,163V17A9,9 0 0 0 -11.65,8H-45.5Z" fill="LightSkyBlue" fill-opacity="0.6" stroke="#4ac" stroke-width="1.5">
-     </path>
-     <line stroke-dasharray="14.4,4.8,1.6,4.8" style="stroke:limegreen; stroke-width:0.8" x1="-80.5" x2="80.5" y1="90" y2="90">
-     </line>
-     <text text-anchor="middle" x="-85.5" y="90">y</text>
-     <text text-anchor="middle" x="85.5" y="90">y</text>
-     <line stroke-dasharray="14.4,4.8,1.6,4.8" style="stroke:limegreen; stroke-width:0.8" x1="0" x2="0" y1="-35" y2="215">
-     </line>
-     <text text-anchor="middle" x="0" y="-40">z</text>
-     <text text-anchor="middle" x="0" y="225">z</text>
-     <line style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod" x1="-66.5" x2="-54.5" y1="0" y2="0">
-     </line>
-     <line style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod" x1="-66.5" x2="-54.5" y1="180" y2="180">
-     </line>
-     <line style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod" x1="-60.5" x2="-60.5" y1="-6" y2="186">
-     </line>
-     <circle cx="-60.5" cy="0" r="1.8" style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod">
-     </circle>
-     <circle cx="-60.5" cy="180" r="1.8" style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod">
-     </circle>
-     <text text-anchor="middle" transform="rotate(-90,-65,90)" x="-65" y="90">180</text>
-     <line style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod" x1="64.5" x2="76.5" y1="0" y2="0">
-     </line>
-     <line style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod" x1="64.5" x2="76.5" y1="8" y2="8">
-     </line>
-     <line style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod" x1="70.5" x2="70.5" y1="-6" y2="14">
-     </line>
-     <circle cx="70.5" cy="0" r="1.8" style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod">
-     </circle>
-     <circle cx="70.5" cy="8" r="1.8" style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod">
-     </circle>
-     <text text-anchor="middle" transform="rotate(-90,66,4)" x="66" y="4">8</text>
-     <line style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod" x1="64.5" x2="76.5" y1="172" y2="172">
-     </line>
-     <line style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod" x1="64.5" x2="76.5" y1="180" y2="180">
-     </line>
-     <line style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod" x1="70.5" x2="70.5" y1="166" y2="186">
-     </line>
-     <circle cx="70.5" cy="172" r="1.8" style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod">
-     </circle>
-     <circle cx="70.5" cy="180" r="1.8" style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod">
-     </circle>
-     <text text-anchor="middle" transform="rotate(-90,66,176)" x="66" y="176">8</text>
-     <line style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod" x1="-45.5" x2="-45.5" y1="199" y2="211">
-     </line>
-     <line style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod" x1="45.5" x2="45.5" y1="199" y2="211">
-     </line>
-     <line style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod" x1="-51.5" x2="51.5" y1="205" y2="205">
-     </line>
-     <circle cx="45.5" cy="205" r="1.8" style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod">
-     </circle>
-     <circle cx="-45.5" cy="205" r="1.8" style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod">
-     </circle>
-     <text text-anchor="middle" x="0" y="200.5">91</text>
-     <line style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod" x1="-45.5" x2="-45.5" y1="-21" y2="-9">
-     </line>
-     <line style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod" x1="45.5" x2="45.5" y1="-21" y2="-9">
-     </line>
-     <line style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod" x1="-51.5" x2="51.5" y1="-15" y2="-15">
-     </line>
-     <circle cx="45.5" cy="-15" r="1.8" style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod">
-     </circle>
-     <circle cx="-45.5" cy="-15" r="1.8" style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod">
-     </circle>
-     <text text-anchor="middle" x="0" y="-19.5">91</text>
-     <line style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod" x1="-2.65" x2="-2.65" y1="69" y2="81">
-     </line>
-     <line style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod" x1="2.65" x2="2.65" y1="69" y2="81">
-     </line>
-     <line style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod" x1="-8.65" x2="8.65" y1="75" y2="75">
-     </line>
-     <circle cx="2.65" cy="75" r="1.8" style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod">
-     </circle>
-     <circle cx="-2.65" cy="75" r="1.8" style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod">
-     </circle>
-     <text text-anchor="middle" x="0" y="70.5">
-     </text>
-     <text text-anchor="middle" x="17.65" y="70">5.3</text>
-     <line style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod" x1="5.29" x2="36.65" y1="169.36" y2="138">
-     </line>
-     <line style="stroke:goldenrod; stroke-width:0.6; fill:goldenrod" x1="36.65" x2="46.65" y1="138" y2="138">
-     </line>
-     <text text-anchor="middle" x="56.65" y="143">9</text>
-    </svg>
-   </td>
-  </tr>
- </table>
- <p>
- </p>
- <p>
- </p>
- <h4>Section properties</h4>
- <table style="width:100%">
-  <tr>
-   <td>
-    <span class="eq">
-     <var>A</var>
-     = 2394.73
-    </span>
-    mm
-    <sup>2</sup>
-   </td>
-   <td>
-    <span class="eq">
-     <var>y</var>
-     <sub>c</sub>
-     = 45.5
-    </span>
-    mm
-   </td>
-   <td>
-    <span class="eq">
-     <var>z</var>
-     <sub>c</sub>
-     = 90
-    </span>
-    mm
-   </td>
-   <td>
-   </td>
-  </tr>
-  <tr>
-   <td>
-    <span class="eq">
-     <var>I</var>
-     <sub>y</sub>
-     = 13169590
-    </span>
-    mm
-    <sup>4</sup>
-   </td>
-   <td>
-    <span class="eq">
-     <var>r</var>
-     <sub>y</sub>
-     = 74.16
-    </span>
-    mm
-   </td>
-   <td>
-    <span class="eq">
-     <var>W</var>
-     <sub>el_y</sub>
-     = 146329
-    </span>
-    mm
-    <sup>3</sup>
-   </td>
-   <td>
-    <span class="eq">
-     <var>W</var>
-     <sub>pl_y</sub>
-     = 166415
-    </span>
-    mm
-    <sup>3</sup>
-   </td>
-  </tr>
-  <tr>
-   <td>
-    <span class="eq">
-     <var>I</var>
-     <sub>z</sub>
-     = 1008504
-    </span>
-    mm
-    <sup>4</sup>
-   </td>
-   <td>
-    <span class="eq">
-     <var>r</var>
-     <sub>z</sub>
-     = 20.52
-    </span>
-    mm
-   </td>
-   <td>
-    <span class="eq">
-     <var>W</var>
-     <sub>el_z</sub>
-     = 22164.9
-    </span>
-    mm
-    <sup>3</sup>
-   </td>
-   <td>
-    <span class="eq">
-     <var>W</var>
-     <sub>pl_z</sub>
-     = 34599.7
-    </span>
-    mm
-    <sup>3</sup>
-   </td>
-  </tr>
-  <tr>
-   <td>
-    <span class="eq">
-     <var>I</var>
-     <sub>t</sub>
-     = 48103.5
-    </span>
-    mm
-    <sup>4</sup>
-   </td>
-   <td>
-    <span class="eq">
-     <var>I</var>
-     <sub>w</sub>
-     = 7431214821
-    </span>
-    mm
-    <sup>6</sup>
-   </td>
-   <td>
-    <span class="eq">
-     <var>W</var>
-     <sub>t</sub>
-     = 3086.9
-    </span>
-    mm
-    <sup>3</sup>
-   </td>
-   <td>
-   </td>
-  </tr>
- </table>
+     mm
+     <sup>4</sup>
+    </td>
+    <td>
+     <span class="eq">
+      <var>r</var>
+      <sub>z</sub>
+      = 20.52
+     </span>
+     mm
+    </td>
+    <td>
+     <span class="eq">
+      <var>W</var>
+      <sub>el_z</sub>
+      = 22164.9
+     </span>
+     mm
+     <sup>3</sup>
+    </td>
+    <td>
+     <span class="eq">
+      <var>W</var>
+      <sub>pl_z</sub>
+      = 34599.7
+     </span>
+     mm
+     <sup>3</sup>
+    </td>
+   </tr>
+   <tr>
+    <td>
+     <span class="eq">
+      <var>I</var>
+      <sub>t</sub>
+      = 48103.5
+     </span>
+     mm
+     <sup>4</sup>
+    </td>
+    <td>
+     <span class="eq">
+      <var>I</var>
+      <sub>w</sub>
+      = 7431214821
+     </span>
+     mm
+     <sup>6</sup>
+    </td>
+    <td>
+     <span class="eq">
+      <var>W</var>
+      <sub>t</sub>
+      = 3086.9
+     </span>
+     mm
+     <sup>3</sup>
+    </td>
+    <td>
+    </td>
+   </tr>
+  </table>
+ </div>
 </div>

--- a/Examples/Structural/Steel/I-Section Properties.html.stub
+++ b/Examples/Structural/Steel/I-Section Properties.html.stub
@@ -17,312 +17,324 @@
     <td>
      <h4>Dimensions</h4>
      <p>
-      Section type -
-      <select data-target="section" style="font-weight:bold; border:none; background: none; color: black; box-shadow:none; appearance: none;">
-       <option value="80;3.9;42;5.9;42;5.9;3.9;2.3">IPN 80</option>
-       <option value="100;4.5;50;6.8;50;6.8;4.5;2.7">IPN 100</option>
-       <option value="120;5.1;58;7.7;58;7.7;5.1;3.1">IPN 120</option>
-       <option value="140;5.7;66;8.6;66;8.6;5.7;3.4">IPN 140</option>
-       <option value="160;6.3;74;9.5;74;9.5;6.3;3.8">IPN 160</option>
-       <option value="180;6.9;82;10.4;82;10.4;6.9;4.1">IPN 180</option>
-       <option value="200;7.5;90;11.3;90;11.3;7.5;4.5">IPN 200</option>
-       <option value="220;8.1;98;12.2;98;12.2;8.1;4.9">IPN 220</option>
-       <option value="240;8.7;106;13.1;106;13.1;8.7;5.2">IPN 240</option>
-       <option value="260;9.4;113;14.1;113;14.1;9.4;5.6">IPN 260</option>
-       <option value="280;10.1;119;15.2;119;15.2;10.1;6.1">IPN 280</option>
-       <option value="300;10.8;125;16.2;125;16.2;10.8;6.5">IPN 300</option>
-       <option value="320;11.5;131;17.3;131;17.3;11.5;6.9">IPN 320</option>
-       <option value="340;12.2;137;18.3;137;18.3;12.2;7.3">IPN 340</option>
-       <option value="360;13;143;19.5;143;19.5;13;7.8">IPN 360</option>
-       <option value="380;13.7;149;20.5;149;20.5;13.7;8.2">IPN 380</option>
-       <option value="400;14.4;155;21.6;155;21.6;14.4;8.6">IPN 400</option>
-       <option value="450;16.2;170;24.3;170;24.3;16.2;9.7">IPN 450</option>
-       <option value="500;18;185;27;185;27;18;10.8">IPN 500</option>
-       <option value="550;19;200;30;200;30;19;11.9">IPN 550</option>
-       <option value="100;4.1;55;5.7;55;5.7;7;0">IPE 100</option>
-       <option value="120;4.4;64;6.3;64;6.3;7;0">IPE 120</option>
-       <option value="137.4;3.8;73;5.6;73;5.6;7;0">IPE 140 A</option>
-       <option value="140;4.7;73;6.9;73;6.9;7;0">IPE 140</option>
-       <option value="142;5.3;72;7.8;72;7.8;7;0">IPE 140 R</option>
-       <option value="157;4;82;5.9;82;5.9;9;0">IPE 160 A</option>
-       <option value="160;5;82;7.4;82;7.4;9;0">IPE 160</option>
-       <option value="162;5.6;81;8.5;81;8.5;9;0">IPE 160 R</option>
-       <option value="177;4.3;91;6.5;91;6.5;9;0">IPE 180 A</option>
-       <option value="180;5.3;91;8;91;8;9;0">IPE 180</option>
-       <option value="182;6;92;9;92;9;9;0">IPE 180 O</option>
-       <option value="183;6.4;89;9.5;89;9.5;9;0">IPE 180 R</option>
-       <option value="197;4.5;100;7;100;7;12;0">IPE 200 A</option>
-       <option value="200;5.6;100;8.5;100;8.5;12;0">IPE 200</option>
-       <option value="202;6.2;102;9.5;102;9.5;12;0">IPE 200 O</option>
-       <option value="204;6.6;98;10.5;98;10.5;12;0">IPE 200 R</option>
-       <option value="217;5;110;7.7;110;7.7;12;0">IPE 220 A</option>
-       <option value="220;5.9;110;9.2;110;9.2;12;0">IPE 220</option>
-       <option value="222;6.6;112;10.2;112;10.2;12;0">IPE 220 O</option>
-       <option value="225;6.7;108;11.8;108;11.8;12;0">IPE 220 R</option>
-       <option value="237;5.2;120;8.3;120;8.3;15;0">IPE 240 A</option>
-       <option value="240;6.2;120;9.8;120;9.8;15;0">IPE 240</option>
-       <option value="242;7;122;10.8;122;10.8;15;0">IPE 240 O</option>
-       <option value="245;7.5;118;12.3;118;12.3;15;0">IPE 240 R</option>
-       <option value="267;5.5;135;8.7;135;8.7;15;0">IPE 270 A</option>
-       <option value="270;6.6;135;10.2;135;10.2;15;0">IPE 270</option>
-       <option value="274;7.5;136;12.2;136;12.2;15;0">IPE 270 O</option>
-       <option value="276;7.7;133;13.1;133;13.1;15;0">IPE 270 R</option>
-       <option value="297;6.1;150;9.2;150;9.2;15;0">IPE 300 A</option>
-       <option value="300;7.1;150;10.7;150;10.7;15;0">IPE 300</option>
-       <option value="304;8;152;12.7;152;12.7;15;0">IPE 300 O</option>
-       <option value="306;8.5;147;13.7;147;13.7;15;0">IPE 300 R</option>
-       <option value="327;6.5;160;10;160;10;18;0">IPE 330 A</option>
-       <option value="330;7.5;160;11.5;160;11.5;18;0">IPE 330</option>
-       <option value="334;8.5;162;13.5;162;13.5;18;0">IPE 330 O</option>
-       <option value="336;9.2;158;14.5;158;14.5;18;0">IPE 330 R</option>
-       <option value="357.6;6.6;170;11.5;170;11.5;18;0">IPE 360 A</option>
-       <option value="360;8;170;12.7;170;12.7;18;0">IPE 360</option>
-       <option value="364;9.2;172;14.7;172;14.7;18;0">IPE 360 O</option>
-       <option value="366;9.9;168;16;168;16;18;0">IPE 360 R</option>
-       <option value="397;7;180;12;180;12;21;0">IPE 400 A</option>
-       <option value="400;8.6;180;13.5;180;13.5;21;0">IPE 400</option>
-       <option value="404;9.7;182;15.5;182;15.5;21;0">IPE 400 O</option>
-       <option value="407;10.6;178;17;178;17;21;0">IPE 400 R</option>
-       <option value="408;10.6;182;17.5;182;17.5;21;0">IPE 400 V</option>
-       <option value="447;7.6;190;13.1;190;13.1;21;0">IPE 450 A</option>
-       <option value="450;9.4;190;14.6;190;14.6;21;0">IPE 450</option>
-       <option value="456;11;192;17.6;192;17.6;21;0">IPE 450 O</option>
-       <option value="458;11.3;188;18.6;188;18.6;21;0">IPE 450 R</option>
-       <option value="460;12.4;194;19.6;194;19.6;21;0">IPE 450 V</option>
-       <option value="497;8.4;200;14.5;200;14.5;21;0">IPE 500 A</option>
-       <option value="500;10.2;200;16;200;16;21;0">IPE 500</option>
-       <option value="506;12;202;19;202;19;21;0">IPE 500 O</option>
-       <option value="508;12.6;198;20;198;20;21;0">IPE 500 R</option>
-       <option value="514;14.2;204;23;204;23;21;0">IPE 500 V</option>
-       <option value="547;9;210;15.7;210;15.7;24;0">IPE 550 A</option>
-       <option value="550;11.1;210;17.2;210;17.2;24;0">IPE 550</option>
-       <option value="556;12.7;212;20.2;212;20.2;24;0">IPE 550 O</option>
-       <option value="560;14;210;22.2;210;22.2;24;0">IPE 550 R</option>
-       <option value="566;17.1;216;25.2;216;25.2;24;0">IPE 550 V</option>
-       <option value="597;9.8;220;17.5;220;17.5;24;0">IPE 600 A</option>
-       <option value="600;12;220;19;220;19;24;0">IPE 600</option>
-       <option value="610;15;224;24;224;24;24;0">IPE 600 O</option>
-       <option value="608;14;218;23;218;23;24;0">IPE 600 R</option>
-       <option value="618;18;228;28;228;28;24;0">IPE 600 V</option>
-       <option value="753;11.5;263;17;263;17;17;0">IPE 750 x 137</option>
-       <option value="753;13.2;265;17;265;17;17;0">IPE 750 x 147</option>
-       <option value="758;13.8;266;19.3;266;19.3;17;0">IPE 750 x 161</option>
-       <option value="762;14.4;267;21.6;267;21.6;17;0">IPE 750 x 174</option>
-       <option value="766;14.9;267;23.6;267;23.6;17;0">IPE 750 x185</option>
-       <option value="770;15.6;268;25.4;268;25.4;17;0">IPE 750 x 197</option>
-       <option value="775;16;268;28;268;28;17;0">IPE 750 x 210</option>
-       <option value="778;17;269;29.5;269;29.5;17;0">IPE 750 x 223</option>
-       <option value="96;5;100;8;100;8;12;0">HE 100 A</option>
-       <option value="96;5;100;8;100;8;12;0">HE 100 A</option>
-       <option value="100;6;100;10;100;10;12;0">HE 100 B</option>
-       <option value="109;4.2;120;5.5;120;5.5;12;0">HE 120 AA</option>
-       <option value="114;5;120;8;120;8;12;0">HE 120 A</option>
-       <option value="120;6.5;120;11;120;11;12;0">HE 120 B</option>
-       <option value="128;4.3;140;6;140;6;12;0">HE 140 AA</option>
-       <option value="133;5.5;140;8.5;140;8.5;12;0">HE 140 A</option>
-       <option value="140;7;140;12;140;12;12;0">HE 140 B</option>
-       <option value="148;4.5;160;7;160;7;15;0">HE 160 AA</option>
-       <option value="152;6;160;9;160;9;15;0">HE 160 A</option>
-       <option value="160;8;160;13;160;13;15;0">HE 160 B</option>
-       <option value="180;14;166;23;166;23;15;0">HE 160 M</option>
-       <option value="167;5;180;7.5;180;7.5;15;0">HE 180 AA</option>
-       <option value="171;6;180;9.5;180;9.5;15;0">HE 180 A</option>
-       <option value="180;8.5;180;14;180;14;15;0">HE 180 B</option>
-       <option value="200;14.5;186;24;186;24;15;0">HE 180 M</option>
-       <option value="186;5.5;200;8;200;8;18;0">HE 200 AA</option>
-       <option value="190;6.5;200;10;200;10;18;0">HE 200 A</option>
-       <option value="200;9;200;15;200;15;18;0">HE 200 B</option>
-       <option value="220;15;206;25;206;25;18;0">HE 200 M</option>
-       <option value="205;6;220;8.5;220;8.5;18;0">HE 220 AA</option>
-       <option value="210;7;220;11;220;11;18;0">HE 220 A</option>
-       <option value="220;9.5;220;16;220;16;18;0">HE 220 B</option>
-       <option value="240;15.5;226;26;226;26;18;0">HE 220 M</option>
-       <option value="224;6.5;240;9;240;9;21;0">HE 240 AA</option>
-       <option value="230;7.5;240;12;240;12;21;0">HE 240 A</option>
-       <option value="240;10;240;17;240;17;21;0">HE 240 B</option>
-       <option value="270;18;248;32;248;32;21;0">HE 240 M</option>
-       <option value="244;6.5;260;9.5;260;9.5;24;0">HE 260 AA</option>
-       <option value="250;7.5;260;12.5;260;12.5;24;0">HE 260 A</option>
-       <option value="260;10;260;17.5;260;17.5;24;0">HE 260 B</option>
-       <option value="290;18;268;32.5;268;32.5;24;0">HE 260 M</option>
-       <option value="264;7;280;10;280;10;24;0">HE 280 AA</option>
-       <option value="270;8;280;13;280;13;24;0">HE 280 A</option>
-       <option value="280;10.5;280;18;280;18;24;0">HE 280 B</option>
-       <option value="310;18.5;288;33;288;33;24;0">HE 280 M</option>
-       <option value="283;7.5;300;10.5;300;10.5;27;0">HE 300 AA</option>
-       <option value="290;8.5;300;14;300;14;27;0">HE 300 A</option>
-       <option value="300;11;300;19;300;19;27;0">HE 300 B</option>
-       <option value="320;16;305;29;305;29;27;0">HE 300 C</option>
-       <option value="340;21;310;39;310;39;27;0">HE 300 M</option>
-       <option value="301;8;300;11;300;11;27;0">HE 320 AA</option>
-       <option value="310;9;300;15.5;300;15.5;27;0">HE 320 A</option>
-       <option value="320;11.5;300;20.5;300;20.5;27;0">HE 320 B</option>
-       <option value="359;21;309;40;309;40;27;0">HE 320 M</option>
-       <option value="320;8.5;300;11.5;300;11.5;27;0">HE 340 AA</option>
-       <option value="330;9.5;300;16.5;300;16.5;27;0">HE 340 A</option>
-       <option value="340;12;300;21.5;300;21.5;27;0">HE 340 B</option>
-       <option value="377;21;309;40;309;40;27;0">HE 340 M</option>
-       <option value="339;9;300;12;300;12;27;0">HE 360 AA</option>
-       <option value="350;10;300;17.5;300;17.5;27;0">HE 360 A</option>
-       <option value="360;12.5;300;22.5;300;22.5;27;0">HE 360 B</option>
-       <option value="395;21;308;40;308;40;27;0">HE 360 M</option>
-       <option value="378;9.5;300;13;300;13;27;0">HE 400 AA</option>
-       <option value="384;10;297;16;297;16;27;0">HE 400 x 107</option>
-       <option value="390;11;300;19;300;19;27;0">HE 400 A</option>
-       <option value="400;13.5;300;24;300;24;27;0">HE 400 B</option>
-       <option value="432;21;307;40;307;40;27;0">HE 400 M</option>
-       <option value="425;10;300;13.5;300;13.5;27;0">HE 450 AA</option>
-       <option value="435;10.2;300;18.5;300;18.5;27;0">HE 450 x 124</option>
-       <option value="440;11.5;300;21;300;21;27;0">HE 450 A</option>
-       <option value="450;14;300;26;300;26;27;0">HE 450 B</option>
-       <option value="478;21;307;40;307;40;27;0">HE 450 M</option>
-       <option value="472;10.5;300;14;300;14;27;0">HE 500 AA</option>
-       <option value="490;12;300;23;300;23;27;0">HE 500 A</option>
-       <option value="500;14.5;300;28;300;28;27;0">HE 500 B</option>
-       <option value="524;21;306;40;306;40;27;0">HE 500 M</option>
-       <option value="522;11.5;300;15;300;15;27;0">HE 550 AA</option>
-       <option value="540;12.5;300;24;300;24;27;0">HE 550 A</option>
-       <option value="550;15;300;29;300;29;27;0">HE 550 B</option>
-       <option value="572;21;306;40;306;40;27;0">HE 550 M</option>
-       <option value="571;12;300;15.5;300;15.5;27;0">HE 600 AA</option>
-       <option value="575;11.8;300;17.5;300;17.5;27;0">HE 600 x 137</option>
-       <option value="582;11.6;300;20.6;300;20.6;27;0">HE 600 x 151</option>
-       <option value="588;13.6;300;23.9;300;23.9;27;0">HE 600 x 175</option>
-       <option value="590;13;300;25;300;25;27;0">HE 600 A</option>
-       <option value="600;15.5;300;30;300;30;27;0">HE 600 B</option>
-       <option value="620;21;305;40;305;40;27;0">HE 600 M</option>
-       <option value="620;12.5;300;16;300;16;27;0">HE 650 AA</option>
-       <option value="640;13.5;300;26;300;26;27;0">HE 650 A</option>
-       <option value="650;16;300;31;300;31;27;0">HE 650 B</option>
-       <option value="668;21;305;40;305;40;27;0">HE 650 M</option>
-       <option value="670;13;300;17;300;17;27;0">HE 700 AA</option>
-       <option value="678;12.5;300;21;300;21;27;0">HE 700 x 166</option>
-       <option value="690;14.5;300;27;300;27;27;0">HE 700 A</option>
-       <option value="700;17;300;32;300;32;27;0">HE 700 B</option>
-       <option value="716;21;304;40;304;40;27;0">HE 700 M</option>
-       <option value="770;14;300;18;300;18;30;0">HE 800 AA</option>
-       <option value="790;15;300;28;300;28;30;0">HE 800 A</option>
-       <option value="800;17.5;300;33;300;33;30;0">HE 800 B</option>
-       <option value="814;21;303;40;303;40;30;0">HE 800 M</option>
-       <option value="870;15;300;20;300;20;30;0">HE 900 AA</option>
-       <option value="890;16;300;30;300;30;30;0">HE 900 A</option>
-       <option value="900;18.5;300;35;300;35;30;0">HE 900 B</option>
-       <option value="910;21;302;40;302;40;30;0">HE 900 M</option>
-       <option value="970;16;300;21;300;21;30;0">HE 1000 A</option>
-       <option value="990;16.5;300;31;300;31;30;0">HE 1000 A</option>
-       <option value="1000;19;300;36;300;36;30;0">HE 1000 B</option>
-       <option value="1008;21;302;40;302;40;30;0">HE 1000 M</option>
-      </select>
-     </p>
-     <table id="section">
-      <tr>
-       <td style="padding-right: 10px;">
+      Select section -
+      <select data-target="section">
+       <p>
+        Section type -
+        <select data-target="section" style="font-weight:bold; border:none; background: none; color: black; box-shadow:none; appearance: none;">
+         <option value="80;3.9;42;5.9;42;5.9;3.9;2.3">IPN 80</option>
+         <option value="100;4.5;50;6.8;50;6.8;4.5;2.7">IPN 100</option>
+         <option value="120;5.1;58;7.7;58;7.7;5.1;3.1">IPN 120</option>
+         <option value="140;5.7;66;8.6;66;8.6;5.7;3.4">IPN 140</option>
+         <option value="160;6.3;74;9.5;74;9.5;6.3;3.8">IPN 160</option>
+         <option value="180;6.9;82;10.4;82;10.4;6.9;4.1">IPN 180</option>
+         <option value="200;7.5;90;11.3;90;11.3;7.5;4.5">IPN 200</option>
+         <option value="220;8.1;98;12.2;98;12.2;8.1;4.9">IPN 220</option>
+         <option value="240;8.7;106;13.1;106;13.1;8.7;5.2">IPN 240</option>
+         <option value="260;9.4;113;14.1;113;14.1;9.4;5.6">IPN 260</option>
+         <option value="280;10.1;119;15.2;119;15.2;10.1;6.1">IPN 280</option>
+         <option value="300;10.8;125;16.2;125;16.2;10.8;6.5">IPN 300</option>
+         <option value="320;11.5;131;17.3;131;17.3;11.5;6.9">IPN 320</option>
+         <option value="340;12.2;137;18.3;137;18.3;12.2;7.3">IPN 340</option>
+         <option value="360;13;143;19.5;143;19.5;13;7.8">IPN 360</option>
+         <option value="380;13.7;149;20.5;149;20.5;13.7;8.2">IPN 380</option>
+         <option value="400;14.4;155;21.6;155;21.6;14.4;8.6">IPN 400</option>
+         <option value="450;16.2;170;24.3;170;24.3;16.2;9.7">IPN 450</option>
+         <option value="500;18;185;27;185;27;18;10.8">IPN 500</option>
+         <option value="550;19;200;30;200;30;19;11.9">IPN 550</option>
+         <option value="100;4.1;55;5.7;55;5.7;7;0">IPE 100</option>
+         <option value="120;4.4;64;6.3;64;6.3;7;0">IPE 120</option>
+         <option value="137.4;3.8;73;5.6;73;5.6;7;0">IPE 140 A</option>
+         <option value="140;4.7;73;6.9;73;6.9;7;0">IPE 140</option>
+         <option value="142;5.3;72;7.8;72;7.8;7;0">IPE 140 R</option>
+         <option value="157;4;82;5.9;82;5.9;9;0">IPE 160 A</option>
+         <option value="160;5;82;7.4;82;7.4;9;0">IPE 160</option>
+         <option value="162;5.6;81;8.5;81;8.5;9;0">IPE 160 R</option>
+         <option value="177;4.3;91;6.5;91;6.5;9;0">IPE 180 A</option>
+         <option value="180;5.3;91;8;91;8;9;0">IPE 180</option>
+         <option value="182;6;92;9;92;9;9;0">IPE 180 O</option>
+         <option value="183;6.4;89;9.5;89;9.5;9;0">IPE 180 R</option>
+         <option value="197;4.5;100;7;100;7;12;0">IPE 200 A</option>
+         <option value="200;5.6;100;8.5;100;8.5;12;0">IPE 200</option>
+         <option value="202;6.2;102;9.5;102;9.5;12;0">IPE 200 O</option>
+         <option value="204;6.6;98;10.5;98;10.5;12;0">IPE 200 R</option>
+         <option value="217;5;110;7.7;110;7.7;12;0">IPE 220 A</option>
+         <option value="220;5.9;110;9.2;110;9.2;12;0">IPE 220</option>
+         <option value="222;6.6;112;10.2;112;10.2;12;0">IPE 220 O</option>
+         <option value="225;6.7;108;11.8;108;11.8;12;0">IPE 220 R</option>
+         <option value="237;5.2;120;8.3;120;8.3;15;0">IPE 240 A</option>
+         <option value="240;6.2;120;9.8;120;9.8;15;0">IPE 240</option>
+         <option value="242;7;122;10.8;122;10.8;15;0">IPE 240 O</option>
+         <option value="245;7.5;118;12.3;118;12.3;15;0">IPE 240 R</option>
+         <option value="267;5.5;135;8.7;135;8.7;15;0">IPE 270 A</option>
+         <option value="270;6.6;135;10.2;135;10.2;15;0">IPE 270</option>
+         <option value="274;7.5;136;12.2;136;12.2;15;0">IPE 270 O</option>
+         <option value="276;7.7;133;13.1;133;13.1;15;0">IPE 270 R</option>
+         <option value="297;6.1;150;9.2;150;9.2;15;0">IPE 300 A</option>
+         <option value="300;7.1;150;10.7;150;10.7;15;0">IPE 300</option>
+         <option value="304;8;152;12.7;152;12.7;15;0">IPE 300 O</option>
+         <option value="306;8.5;147;13.7;147;13.7;15;0">IPE 300 R</option>
+         <option value="327;6.5;160;10;160;10;18;0">IPE 330 A</option>
+         <option value="330;7.5;160;11.5;160;11.5;18;0">IPE 330</option>
+         <option value="334;8.5;162;13.5;162;13.5;18;0">IPE 330 O</option>
+         <option value="336;9.2;158;14.5;158;14.5;18;0">IPE 330 R</option>
+         <option value="357.6;6.6;170;11.5;170;11.5;18;0">IPE 360 A</option>
+         <option value="360;8;170;12.7;170;12.7;18;0">IPE 360</option>
+         <option value="364;9.2;172;14.7;172;14.7;18;0">IPE 360 O</option>
+         <option value="366;9.9;168;16;168;16;18;0">IPE 360 R</option>
+         <option value="397;7;180;12;180;12;21;0">IPE 400 A</option>
+         <option value="400;8.6;180;13.5;180;13.5;21;0">IPE 400</option>
+         <option value="404;9.7;182;15.5;182;15.5;21;0">IPE 400 O</option>
+         <option value="407;10.6;178;17;178;17;21;0">IPE 400 R</option>
+         <option value="408;10.6;182;17.5;182;17.5;21;0">IPE 400 V</option>
+         <option value="447;7.6;190;13.1;190;13.1;21;0">IPE 450 A</option>
+         <option value="450;9.4;190;14.6;190;14.6;21;0">IPE 450</option>
+         <option value="456;11;192;17.6;192;17.6;21;0">IPE 450 O</option>
+         <option value="458;11.3;188;18.6;188;18.6;21;0">IPE 450 R</option>
+         <option value="460;12.4;194;19.6;194;19.6;21;0">IPE 450 V</option>
+         <option value="497;8.4;200;14.5;200;14.5;21;0">IPE 500 A</option>
+         <option value="500;10.2;200;16;200;16;21;0">IPE 500</option>
+         <option value="506;12;202;19;202;19;21;0">IPE 500 O</option>
+         <option value="508;12.6;198;20;198;20;21;0">IPE 500 R</option>
+         <option value="514;14.2;204;23;204;23;21;0">IPE 500 V</option>
+         <option value="547;9;210;15.7;210;15.7;24;0">IPE 550 A</option>
+         <option value="550;11.1;210;17.2;210;17.2;24;0">IPE 550</option>
+         <option value="556;12.7;212;20.2;212;20.2;24;0">IPE 550 O</option>
+         <option value="560;14;210;22.2;210;22.2;24;0">IPE 550 R</option>
+         <option value="566;17.1;216;25.2;216;25.2;24;0">IPE 550 V</option>
+         <option value="597;9.8;220;17.5;220;17.5;24;0">IPE 600 A</option>
+         <option value="600;12;220;19;220;19;24;0">IPE 600</option>
+         <option value="610;15;224;24;224;24;24;0">IPE 600 O</option>
+         <option value="608;14;218;23;218;23;24;0">IPE 600 R</option>
+         <option value="618;18;228;28;228;28;24;0">IPE 600 V</option>
+         <option value="753;11.5;263;17;263;17;17;0">IPE 750 x 137</option>
+         <option value="753;13.2;265;17;265;17;17;0">IPE 750 x 147</option>
+         <option value="758;13.8;266;19.3;266;19.3;17;0">IPE 750 x 161</option>
+         <option value="762;14.4;267;21.6;267;21.6;17;0">IPE 750 x 174</option>
+         <option value="766;14.9;267;23.6;267;23.6;17;0">IPE 750 x185</option>
+         <option value="770;15.6;268;25.4;268;25.4;17;0">IPE 750 x 197</option>
+         <option value="775;16;268;28;268;28;17;0">IPE 750 x 210</option>
+         <option value="778;17;269;29.5;269;29.5;17;0">IPE 750 x 223</option>
+         <option value="96;5;100;8;100;8;12;0">HE 100 A</option>
+         <option value="96;5;100;8;100;8;12;0">HE 100 A</option>
+         <option value="100;6;100;10;100;10;12;0">HE 100 B</option>
+         <option value="109;4.2;120;5.5;120;5.5;12;0">HE 120 AA</option>
+         <option value="114;5;120;8;120;8;12;0">HE 120 A</option>
+         <option value="120;6.5;120;11;120;11;12;0">HE 120 B</option>
+         <option value="128;4.3;140;6;140;6;12;0">HE 140 AA</option>
+         <option value="133;5.5;140;8.5;140;8.5;12;0">HE 140 A</option>
+         <option value="140;7;140;12;140;12;12;0">HE 140 B</option>
+         <option value="148;4.5;160;7;160;7;15;0">HE 160 AA</option>
+         <option value="152;6;160;9;160;9;15;0">HE 160 A</option>
+         <option value="160;8;160;13;160;13;15;0">HE 160 B</option>
+         <option value="180;14;166;23;166;23;15;0">HE 160 M</option>
+         <option value="167;5;180;7.5;180;7.5;15;0">HE 180 AA</option>
+         <option value="171;6;180;9.5;180;9.5;15;0">HE 180 A</option>
+         <option value="180;8.5;180;14;180;14;15;0">HE 180 B</option>
+         <option value="200;14.5;186;24;186;24;15;0">HE 180 M</option>
+         <option value="186;5.5;200;8;200;8;18;0">HE 200 AA</option>
+         <option value="190;6.5;200;10;200;10;18;0">HE 200 A</option>
+         <option value="200;9;200;15;200;15;18;0">HE 200 B</option>
+         <option value="220;15;206;25;206;25;18;0">HE 200 M</option>
+         <option value="205;6;220;8.5;220;8.5;18;0">HE 220 AA</option>
+         <option value="210;7;220;11;220;11;18;0">HE 220 A</option>
+         <option value="220;9.5;220;16;220;16;18;0">HE 220 B</option>
+         <option value="240;15.5;226;26;226;26;18;0">HE 220 M</option>
+         <option value="224;6.5;240;9;240;9;21;0">HE 240 AA</option>
+         <option value="230;7.5;240;12;240;12;21;0">HE 240 A</option>
+         <option value="240;10;240;17;240;17;21;0">HE 240 B</option>
+         <option value="270;18;248;32;248;32;21;0">HE 240 M</option>
+         <option value="244;6.5;260;9.5;260;9.5;24;0">HE 260 AA</option>
+         <option value="250;7.5;260;12.5;260;12.5;24;0">HE 260 A</option>
+         <option value="260;10;260;17.5;260;17.5;24;0">HE 260 B</option>
+         <option value="290;18;268;32.5;268;32.5;24;0">HE 260 M</option>
+         <option value="264;7;280;10;280;10;24;0">HE 280 AA</option>
+         <option value="270;8;280;13;280;13;24;0">HE 280 A</option>
+         <option value="280;10.5;280;18;280;18;24;0">HE 280 B</option>
+         <option value="310;18.5;288;33;288;33;24;0">HE 280 M</option>
+         <option value="283;7.5;300;10.5;300;10.5;27;0">HE 300 AA</option>
+         <option value="290;8.5;300;14;300;14;27;0">HE 300 A</option>
+         <option value="300;11;300;19;300;19;27;0">HE 300 B</option>
+         <option value="320;16;305;29;305;29;27;0">HE 300 C</option>
+         <option value="340;21;310;39;310;39;27;0">HE 300 M</option>
+         <option value="301;8;300;11;300;11;27;0">HE 320 AA</option>
+         <option value="310;9;300;15.5;300;15.5;27;0">HE 320 A</option>
+         <option value="320;11.5;300;20.5;300;20.5;27;0">HE 320 B</option>
+         <option value="359;21;309;40;309;40;27;0">HE 320 M</option>
+         <option value="320;8.5;300;11.5;300;11.5;27;0">HE 340 AA</option>
+         <option value="330;9.5;300;16.5;300;16.5;27;0">HE 340 A</option>
+         <option value="340;12;300;21.5;300;21.5;27;0">HE 340 B</option>
+         <option value="377;21;309;40;309;40;27;0">HE 340 M</option>
+         <option value="339;9;300;12;300;12;27;0">HE 360 AA</option>
+         <option value="350;10;300;17.5;300;17.5;27;0">HE 360 A</option>
+         <option value="360;12.5;300;22.5;300;22.5;27;0">HE 360 B</option>
+         <option value="395;21;308;40;308;40;27;0">HE 360 M</option>
+         <option value="378;9.5;300;13;300;13;27;0">HE 400 AA</option>
+         <option value="384;10;297;16;297;16;27;0">HE 400 x 107</option>
+         <option value="390;11;300;19;300;19;27;0">HE 400 A</option>
+         <option value="400;13.5;300;24;300;24;27;0">HE 400 B</option>
+         <option value="432;21;307;40;307;40;27;0">HE 400 M</option>
+         <option value="425;10;300;13.5;300;13.5;27;0">HE 450 AA</option>
+         <option value="435;10.2;300;18.5;300;18.5;27;0">HE 450 x 124</option>
+         <option value="440;11.5;300;21;300;21;27;0">HE 450 A</option>
+         <option value="450;14;300;26;300;26;27;0">HE 450 B</option>
+         <option value="478;21;307;40;307;40;27;0">HE 450 M</option>
+         <option value="472;10.5;300;14;300;14;27;0">HE 500 AA</option>
+         <option value="490;12;300;23;300;23;27;0">HE 500 A</option>
+         <option value="500;14.5;300;28;300;28;27;0">HE 500 B</option>
+         <option value="524;21;306;40;306;40;27;0">HE 500 M</option>
+         <option value="522;11.5;300;15;300;15;27;0">HE 550 AA</option>
+         <option value="540;12.5;300;24;300;24;27;0">HE 550 A</option>
+         <option value="550;15;300;29;300;29;27;0">HE 550 B</option>
+         <option value="572;21;306;40;306;40;27;0">HE 550 M</option>
+         <option value="571;12;300;15.5;300;15.5;27;0">HE 600 AA</option>
+         <option value="575;11.8;300;17.5;300;17.5;27;0">HE 600 x 137</option>
+         <option value="582;11.6;300;20.6;300;20.6;27;0">HE 600 x 151</option>
+         <option value="588;13.6;300;23.9;300;23.9;27;0">HE 600 x 175</option>
+         <option value="590;13;300;25;300;25;27;0">HE 600 A</option>
+         <option value="600;15.5;300;30;300;30;27;0">HE 600 B</option>
+         <option value="620;21;305;40;305;40;27;0">HE 600 M</option>
+         <option value="620;12.5;300;16;300;16;27;0">HE 650 AA</option>
+         <option value="640;13.5;300;26;300;26;27;0">HE 650 A</option>
+         <option value="650;16;300;31;300;31;27;0">HE 650 B</option>
+         <option value="668;21;305;40;305;40;27;0">HE 650 M</option>
+         <option value="670;13;300;17;300;17;27;0">HE 700 AA</option>
+         <option value="678;12.5;300;21;300;21;27;0">HE 700 x 166</option>
+         <option value="690;14.5;300;27;300;27;27;0">HE 700 A</option>
+         <option value="700;17;300;32;300;32;27;0">HE 700 B</option>
+         <option value="716;21;304;40;304;40;27;0">HE 700 M</option>
+         <option value="770;14;300;18;300;18;30;0">HE 800 AA</option>
+         <option value="790;15;300;28;300;28;30;0">HE 800 A</option>
+         <option value="800;17.5;300;33;300;33;30;0">HE 800 B</option>
+         <option value="814;21;303;40;303;40;30;0">HE 800 M</option>
+         <option value="870;15;300;20;300;20;30;0">HE 900 AA</option>
+         <option value="890;16;300;30;300;30;30;0">HE 900 A</option>
+         <option value="900;18.5;300;35;300;35;30;0">HE 900 B</option>
+         <option value="910;21;302;40;302;40;30;0">HE 900 M</option>
+         <option value="970;16;300;21;300;21;30;0">HE 1000 A</option>
+         <option value="990;16.5;300;31;300;31;30;0">HE 1000 A</option>
+         <option value="1000;19;300;36;300;36;30;0">HE 1000 B</option>
+         <option value="1008;21;302;40;302;40;30;0">HE 1000 M</option>
+        </select>
+       </p>
+       <table id="section">
+        <tr>
+         <td style="padding-right: 10px;">
+          <span class="eq">
+           <var>h</var>
+           =
+           <u class="input-210">550</u>
+          </span>
+          mm,
+         </td>
+         <td>
+          <span class="eq">
+           <var>t</var>
+           <sub>w</sub>
+           =
+           <u class="input-210">19</u>
+          </span>
+          mm
+         </td>
+        </tr>
+        <tr>
+         <td style="padding-right: 10px;">
+          <span class="eq">
+           <var>b</var>
+           <sub>f1</sub>
+           =
+           <u class="input-211">200</u>
+          </span>
+          mm,
+         </td>
+         <td>
+          <span class="eq">
+           <var>t</var>
+           <sub>f1</sub>
+           =
+           <u class="input-211">30</u>
+          </span>
+          mm
+         </td>
+        </tr>
+        <tr>
+         <td style="padding-right: 10px;">
+          <span class="eq">
+           <var>b</var>
+           <sub>f2</sub>
+           =
+           <u class="input-212">200</u>
+          </span>
+          mm,
+         </td>
+         <td>
+          <span class="eq">
+           <var>t</var>
+           <sub>f2</sub>
+           =
+           <u class="input-212">30</u>
+          </span>
+          mm
+         </td>
+        </tr>
+        <tr>
+         <td style="padding-right: 10px;">
+          <span class="eq">
+           <var>r</var>
+           =
+           <u class="input-213">19</u>
+          </span>
+          mm,
+         </td>
+         <td style="display:none">
+          <span class="eq">
+           <var>r</var>
+           <sub>2</sub>
+           =
+           <u class="input-213">11.9</u>
+          </span>
+          mm
+         </td>
+        </tr>
+       </table>
+       <p>
         <span class="eq">
          <var>h</var>
-         =
-         <u class="input-210">550</u>
-        </span>
-        mm,
-       </td>
-       <td>
-        <span class="eq">
-         <var>t</var>
          <sub>w</sub>
          =
-         <u class="input-210">19</u>
-        </span>
-        mm
-       </td>
-      </tr>
-      <tr>
-       <td style="padding-right: 10px;">
-        <span class="eq">
-         <var>b</var>
-         <sub>f1</sub>
-         =
-         <u class="input-211">200</u>
-        </span>
-        mm,
-       </td>
-       <td>
-        <span class="eq">
+         <var>h</var>
+         −
          <var>t</var>
          <sub>f1</sub>
-         =
-         <u class="input-211">30</u>
-        </span>
-        mm
-       </td>
-      </tr>
-      <tr>
-       <td style="padding-right: 10px;">
-        <span class="eq">
-         <var>b</var>
-         <sub>f2</sub>
-         =
-         <u class="input-212">200</u>
-        </span>
-        mm,
-       </td>
-       <td>
-        <span class="eq">
+         −
          <var>t</var>
          <sub>f2</sub>
-         =
-         <u class="input-212">30</u>
+         = 550 − 30 − 30 = 490
         </span>
         mm
-       </td>
-      </tr>
-      <tr>
-       <td style="padding-right: 10px;">
+       </p>
+       <p>
+        Section type -
+        <select data-target="rolled">
+         <option value="1">Rolled</option>
+         <option value="0">Welded</option>
+        </select>
+       </p>
+       <p id="rolled" style="display:none;">
         <span class="eq">
-         <var>r</var>
+         <var>rolled</var>
          =
-         <u class="input-213">19</u>
+         <u class="input-223">1</u>
         </span>
-        mm,
-       </td>
-       <td style="display:none">
-        <span class="eq">
-         <var>r</var>
-         <sub>2</sub>
-         =
-         <u class="input-213">11.9</u>
-        </span>
-        mm
-       </td>
-      </tr>
-     </table>
-     <p>
-      <span class="eq">
-       <var>h</var>
-       <sub>w</sub>
-       =
-       <var>h</var>
-       −
-       <var>t</var>
-       <sub>f1</sub>
-       −
-       <var>t</var>
-       <sub>f2</sub>
-       = 550 − 30 − 30 = 490
-      </span>
-      mm
+       </p>
+       <p>Section type - Rolled</p>
+       <p>
+       </p>
+       <p>
+       </p>
+       <h4>Steel properties</h4>
+      </select>
      </p>
-     <p id="rolled" style="display:none;">
-      <span class="eq">
-       <var>rolled</var>
-       =
-       <u class="input-223">1</u>
-      </span>
-     </p>
-     <p>Section type - Rolled</p>
-     <p>
-     </p>
-     <p>
-     </p>
-     <h4>Steel properties</h4>
     </td>
     <td>
      <img alt="I-section.png" src="./i-section.png" width="160"/>


### PR DESCRIPTION
Updates:
- Add #UI directive for interactive input controls (entry, dropdown, radio, checkbox, datagrid), with loop-aware control identities and value overrides for re-rendering saved input as a report
- #settings shares validation with #UI via a new common DirectiveDto base class
- Add #ProjectPath/#LibraryPath directives and {project}/{library}/{user} path tokens, unifying path resolution across #include, #read/#write, and image references (new PathRoots/ImageReferences)
- Portable/bundled cdpz worksheets: inline #read data into literal assignments and locate file-path spans for rewriting
- Fix thread-safety bugs from static mutable state (Unit.IsUs, MacroParser's macro table) that could race across concurrent server requests
- Rework #hide/#show/#pre/#post/#val/#equ/#noc visibility directives to support conditions and proper nesting via #end counterparts

A few notes for the review:
- I also refactored MacroParser and ExpressionParser to remove magic numbers.
- It is intentional that using #include with a file containing #LibraryPath or #ProjectPath in a #global scope uses the #included file's path for relative paths, not the file calling the #include. This is to allow using `#ProjectPath .` to define the project path to the folder you place a ProjectPath.cpd file in, and multiple files can include this. The changes to Api/Cli are to get this behavior. Note that if you want a different testing #ProjectPath, the best option is to put it in a #local scope. This will be documented and provided in the examples in a future PR.
- I could have split this up better into multiple PRs, but there was a lot of file overlap so I did it in one to avoid dealing with merges. I will submit the Calcpad.Web, Calcpad.Tests, and changes to other files/folders as separate PRs to make this easier to review (and as I may need to update those if any changes are needed here).

This is the last set of changes to Core (assuming no cleanup is needed) before the initial release of Calcpad.Web.