### PR TITLE
Calcpad.Core Bug Fixes

### DIFF
--- a/Calcpad.Core/Exceptions.cs
+++ b/Calcpad.Core/Exceptions.cs
@@ -376,6 +376,9 @@ namespace Calcpad.Core
         internal static MathParserException MatirixSizeLimit() =>
             new(string.Format(Messages.Matrix_size_cannot_exceed_0, Matrix.MaxSize));
 
+        internal static MathParserException DatagridSizeLimit() =>
+            new(string.Format(Messages.Datagrid_size_cannot_exceed_0_cells, UiDto.MaxSize));
+
         internal static MathParserException MatrixNotHigh() =>
             new(Messages.The_number_of_matrix_rows_must_be_greater_than_or_equal_to_the_number_of_columns);
 

--- a/Calcpad.Core/Messages.Designer.cs
+++ b/Calcpad.Core/Messages.Designer.cs
@@ -1726,6 +1726,15 @@ namespace Calcpad.Core {
         }
 
         // / <summary>
+        // /   Looks up a localized string similar to #UI datagrid size cannot exceed {0} cells. Use #Read to import larger data sets from a file instead..
+        // / </summary>
+        public static string Datagrid_size_cannot_exceed_0_cells {
+            get {
+                return ResourceManager.GetString("Datagrid_size_cannot_exceed_0_cells", resourceCulture);
+            }
+        }
+
+        // / <summary>
         // /   Looks up a localized string similar to A #UI value has the wrong type..
         // / </summary>
         public static string A_UI_value_has_the_wrong_type {

--- a/Calcpad.Core/Messages.resx
+++ b/Calcpad.Core/Messages.resx
@@ -613,6 +613,9 @@
   <data name="The_UI_0_has_1_entries_but_the_grid_has_2_3" xml:space="preserve">
     <value>#UI '{0}' has {1} entries but the grid has {2} {3}.</value>
   </data>
+  <data name="Datagrid_size_cannot_exceed_0_cells" xml:space="preserve">
+    <value>#UI datagrid size cannot exceed {0} cells. Use #Read to import larger data sets from a file instead.</value>
+  </data>
   <data name="A_UI_value_has_the_wrong_type" xml:space="preserve">
     <value>A #UI value has the wrong type.</value>
   </data>

--- a/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.UI.cs
+++ b/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.UI.cs
@@ -106,6 +106,8 @@ namespace Calcpad.Core
                     else
                         AutoDetectGridSizeFromFunction(assignment.Rhs, ref rows, ref columns);
                 }
+                if (type == "datagrid")
+                    CheckGridSize(rows, columns);
 
                 var (declarationKey, key) = GetUiKey(assignment.Name);
                 _lineUiControls.Add(new UiPropertyMetadata
@@ -226,6 +228,12 @@ namespace Calcpad.Core
             return rest.Length > 0 && rest[0] == '(';
         }
 
+        private static void CheckGridSize(int rows, int columns)
+        {
+            if ((long)rows * columns > UiDto.MaxSize)
+                throw Exceptions.DatagridSizeLimit();
+        }
+
         private static void AutoDetectGridSize(ReadOnlySpan<char> rhs, ref int rows, ref int columns)
         {
             var bracketStart = rhs.IndexOf('[');
@@ -272,7 +280,10 @@ namespace Calcpad.Core
         private void ResolveDatagridShape(UiPropertyMetadata ui)
         {
             if (ui.Rows > 0 && ui.Columns > 0)
+            {
+                CheckGridSize(ui.Rows, ui.Columns);
                 return;
+            }
 
             var (rows, columns) = _parser.GetVariableShape(ui.VariableName);
             if (ui.Rows == 0)
@@ -280,6 +291,8 @@ namespace Calcpad.Core
 
             if (ui.Columns == 0)
                 ui.Columns = columns;
+
+            CheckGridSize(ui.Rows, ui.Columns);
         }
 
         private void ResolveShapeFromSizingCall(UiPropertyMetadata ui, string expression)
@@ -312,6 +325,8 @@ namespace Calcpad.Core
 
                     if (ui.Columns == 0)
                         ui.Columns = n;
+
+                    CheckGridSize(ui.Rows, ui.Columns);
                 }
                 return;
             }
@@ -328,6 +343,8 @@ namespace Calcpad.Core
 
                 if (ui.Columns == 0)
                     ui.Columns = k;
+
+                CheckGridSize(ui.Rows, ui.Columns);
             }
         }
 

--- a/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.cs
+++ b/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.cs
@@ -222,7 +222,8 @@ namespace Calcpad.Core
             catch (Exception ex)
             {
                 var msg = string.Format(Messages.Unexpected_error_0_Please_check_the_expression_consistency, ex.Message);
-                _sb.Append(ErrHtml(msg, _currentLine));
+                if (_isVisible)
+                    _sb.Append(ErrHtml(msg, _currentLine));
                 RecordError(_currentLine, msg, Debug);
             }
             finally
@@ -423,8 +424,16 @@ namespace Calcpad.Core
                             foreach (var ui in _lineUiControls)
                                 if (ui.Type == "datagrid")
                                 {
-                                    ResolveDatagridShape(ui);
-                                    _sb.AppendLine(BuildUiDatagrid(ui));
+                                    try
+                                    {
+                                        ResolveDatagridShape(ui);
+                                        _sb.AppendLine(BuildUiDatagrid(ui));
+                                    }
+                                    catch (MathParserException ex)
+                                    {
+                                        _sb.Append(ErrHtml(ex.Message, _currentLine));
+                                        RecordError(_currentLine, ex.Message, Debug);
+                                    }
                                 }
                         }
                     }
@@ -630,7 +639,8 @@ namespace Calcpad.Core
                         else
                             errText = HttpUtility.HtmlEncode(token.Value);
                         errText = FormatError(errText, ex.Message, _currentLine);
-                        _sb.Append($"<span class=\"err\"{Id(_currentLine)}>{errText}</span>");
+                        if (isOutput)
+                            _sb.Append($"<span class=\"err\"{Id(_currentLine)}>{errText}</span>");
                         RecordError(_currentLine, ex.Message, Debug);
 
                         if (++_errorCount == 40)
@@ -645,14 +655,16 @@ namespace Calcpad.Core
         void AppendError(string lineContent, string text, int line)
         {
             string s = lineContent.Replace("<", "&lt;").Replace(">", "&gt;");
-            _sb.Append(ErrHtml(FormatError(s, text, line), line));
+            if (_isVisible)
+                _sb.Append(ErrHtml(FormatError(s, text, line), line));
             RecordError(line, text, Debug);
         }
 
         private void RecordError(int line, string message, bool enabled)
         {
             if (!enabled) return;
-            _errors.Enqueue(line);
+            if (_isVisible)
+                _errors.Enqueue(line);
             var sourceLine = _parser?.Line > 0 ? _parser.Line : line + 1;
             _errorList.Add(new CalcpadError
             {

--- a/Calcpad.Core/UiDto.cs
+++ b/Calcpad.Core/UiDto.cs
@@ -38,6 +38,9 @@ namespace Calcpad.Core
         public static readonly IReadOnlyList<string> KnownTypes =
             ["entry", "datagrid", "dropdown", "radio", "checkbox"];
 
+        /// <summary>Maximum number of cells (rows × columns) in a datagrid before rejecting as too large for UI interaction.</summary>
+        internal const int MaxSize = 100_000;
+
         /// <summary>True for the types whose choices come from the paired keys and values arrays.</summary>
         public bool HasOptions => Type is "dropdown" or "radio";
 

--- a/Calcpad.Tests/ExpressionParser/VisibilityDirectiveTests.cs
+++ b/Calcpad.Tests/ExpressionParser/VisibilityDirectiveTests.cs
@@ -1,0 +1,154 @@
+namespace Calcpad.Tests
+{
+    public class VisibilityDirectiveTests
+    {
+        private static string Render(string source, bool forPrint = false, bool enableUi = false, bool showHiddenOutput = false)
+        {
+            var settings = new Settings();
+            settings.Math.ShowHiddenOutput = showHiddenOutput;
+            var parser = new ExpressionParser { Settings = settings, ForPrint = forPrint, EnableUi = enableUi };
+            parser.Parse(source, true, false);
+            return parser.HtmlResult;
+        }
+
+        [Fact]
+        public void EndHide_RestoresPriorState()
+        {
+            var html = Render("aaa1 = 1\n#hide\nbbb2 = 2\n#end hide\nccc3 = 3");
+            Assert.Contains("aaa1", html);
+            Assert.DoesNotContain("bbb2", html);
+            Assert.Contains("ccc3", html);
+        }
+
+        [Fact]
+        public void EndPre_Nested_RestoresPreHiddenState_NotDefault()
+        {
+            // #pre (hidden under ForPrint) -> #hide -> #end hide must restore to
+            // #pre's hidden state, not to the document default (visible).
+            var html = Render(
+                "aaa1 = 1\n#pre\nbbb2 = 2\n#hide\nccc3 = 3\n#end hide\nddd4 = 4\n#end pre\neee5 = 5",
+                forPrint: true);
+
+            Assert.Contains("aaa1", html);
+            Assert.DoesNotContain("bbb2", html);
+            Assert.DoesNotContain("ccc3", html);
+            Assert.DoesNotContain("ddd4", html); // still hidden: #end hide restored #pre's state
+            Assert.Contains("eee5", html);
+        }
+
+        [Fact]
+        public void EndHide_WithEmptyStack_FallsBackToVisible()
+        {
+            var html = Render("#hide\naaa1 = 1\n#end hide\n#end hide\nbbb2 = 2");
+            Assert.DoesNotContain("aaa1", html);
+            Assert.Contains("bbb2", html);
+        }
+
+        [Fact]
+        public void HideCondition_True_Hides()
+        {
+            var html = Render("x = 5\n#hide x ≡ 5\naaa1 = 1\n#end hide\nbbb2 = 2");
+            Assert.DoesNotContain("aaa1", html);
+            Assert.Contains("bbb2", html);
+        }
+
+        [Fact]
+        public void HideCondition_False_LeavesStateUntouched()
+        {
+            // Nested inside #hide so a false condition on #show must leave the
+            // (hidden) state alone rather than making it visible.
+            var html = Render("x = 5\n#hide\n#show x ≡ 3\naaa1 = 1\n#end show\n#end hide\nbbb2 = 2");
+            Assert.DoesNotContain("aaa1", html);
+            Assert.Contains("bbb2", html);
+        }
+
+        [Fact]
+        public void ShowCondition_True_MakesVisible_WhenNestedInsideHide()
+        {
+            var html = Render("x = 5\n#hide\n#show x ≡ 5\naaa1 = 1\n#end show\n#end hide\nbbb2 = 2");
+            Assert.Contains("aaa1", html);
+            Assert.Contains("bbb2", html);
+        }
+
+        private const string PrePostSource = "#pre\naaa1 = 1\n#end pre\n#post\nbbb2 = 2\n#end post";
+
+        [Fact]
+        public void Pre_HidesOnPrint_ShowsOnScreen()
+        {
+            var onScreen = Render(PrePostSource, forPrint: false);
+            Assert.Contains("aaa1", onScreen);
+            Assert.Contains("bbb2", onScreen);
+
+            var forPrint = Render(PrePostSource, forPrint: true);
+            Assert.DoesNotContain("aaa1", forPrint);
+            Assert.Contains("bbb2", forPrint);
+        }
+
+        [Fact]
+        public void Post_HidesInUiMode()
+        {
+            // #pre is the input form, #post is the report; only one of them shows at a time.
+            var uiMode = Render(PrePostSource, enableUi: true);
+            Assert.Contains("aaa1", uiMode);
+            Assert.DoesNotContain("bbb2", uiMode);
+        }
+
+        [Fact]
+        public void Hide_InsideFalseIfBranch_DoesNotTakeEffect()
+        {
+            var html = Render("#if 0\n#hide\n#end if\naaa1 = 1");
+            Assert.Contains("aaa1", html);
+        }
+
+        [Fact]
+        public void ShowHiddenOutput_IgnoresHide()
+        {
+            var html = Render("aaa1 = 1\n#hide\nbbb2 = 2\n#end hide\nccc3 = 3", showHiddenOutput: true);
+            Assert.Contains("aaa1", html);
+            Assert.Contains("bbb2", html);
+            Assert.Contains("ccc3", html);
+        }
+
+        [Fact]
+        public void ShowHiddenOutput_DoesNotOverrideEnclosingPre()
+        {
+            // #hide is ignored, but it must not un-hide content the surrounding
+            // #pre already hid for print.
+            var html = Render(
+                "#pre\naaa1 = 1\n#hide\nbbb2 = 2\n#end hide\n#end pre\nccc3 = 3",
+                forPrint: true, showHiddenOutput: true);
+
+            Assert.DoesNotContain("aaa1", html);
+            Assert.DoesNotContain("bbb2", html);
+            Assert.Contains("ccc3", html);
+        }
+
+        [Fact]
+        public void ShowHiddenOutput_SetByDirective()
+        {
+            var html = Render("#settings {\"showHiddenOutput\": true}\n#hide\naaa1 = 1\n#end hide\nbbb2 = 2");
+            Assert.Contains("aaa1", html);
+            Assert.Contains("bbb2", html);
+        }
+
+        [Fact]
+        public void HideCondition_BadExpression_RecordsErrorAndLeavesStateUnchanged()
+        {
+            var parser = new ExpressionParser { Settings = new Settings() };
+            parser.Parse("#hide 1/0\naaa1 = 1", true, false);
+            Assert.Contains("err", parser.HtmlResult);
+            Assert.Contains("aaa1", parser.HtmlResult);
+        }
+
+        [Fact]
+        public void Hide_ExpressionError_DoesNotLeakToHtml_ButIsRecorded()
+        {
+            var parser = new ExpressionParser { Settings = new Settings(), Debug = true };
+            parser.Parse("#hide\nbad\n#end hide\naaa1 = 1", true, false);
+            Assert.DoesNotContain("err", parser.HtmlResult);
+            Assert.Contains("aaa1", parser.HtmlResult);
+            Assert.Single(parser.Errors);
+            Assert.Contains("bad", parser.Errors[0].Message);
+        }
+    }
+}

--- a/Calcpad.Tests/UI/UiDirectiveTests.cs
+++ b/Calcpad.Tests/UI/UiDirectiveTests.cs
@@ -1,0 +1,668 @@
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Calcpad.Tests
+{
+    public partial class UiDirectiveTests
+    {
+        [GeneratedRegex(@"(?m)^(\s*)#UI\s*(\{[^}]*\})?\s*")]
+        private static partial Regex UiPrefix();
+
+        private static string Render(string source, bool enableUi, Dictionary<string, string> overrides = null)
+        {
+            var parser = new ExpressionParser
+            {
+                Settings = new Settings(),
+                EnableUi = enableUi,
+                UiOverrides = overrides,
+                // Mirrors CalcpadService's default (hideErrorLines ?? enableUi): input mode
+                // has no source editor for "on line [N]" to point at.
+                ShowErrorLines = !enableUi
+            };
+            parser.Parse(source, true, false);
+            return parser.HtmlResult;
+        }
+
+        /// <summary>
+        /// Renders the source in report mode and compares it against the same source with
+        /// every #UI prefix removed. The two must be identical - in report mode the keyword
+        /// is a no-op.
+        /// </summary>
+        private static void AssertReportMatchesPlainSource(string source)
+        {
+            var plain = UiPrefix().Replace(source, "$1");
+            Assert.Equal(Render(plain, enableUi: false), Render(source, enableUi: false));
+        }
+
+        [Theory]
+        [InlineData("#UI L = 10m\nA = L * 2m")]
+        [InlineData("#UI {\"type\": \"checkbox\"} flag = 1\nflag * 2")]
+        [InlineData("#UI {\"type\": \"dropdown\", \"keys\": [\"Low\", \"High\"], \"values\": [\"1\", \"3\"]} grade = 1")]
+        [InlineData("#UI {\"type\": \"radio\", \"keys\": [\"Steel\", \"Concrete\"], \"values\": [\"200GPa\", \"25GPa\"]} E = 200GPa")]
+        [InlineData("#UI v = [1; 2; 3]")]
+        [InlineData("#UI M = [1; 2; 3 | 4; 5; 6]")]
+        [InlineData("#UI Z = vector(5)")]
+        [InlineData("#UI G = matrix(3; 4)")]
+        [InlineData("#UI {\"type\": \"datagrid\", \"rows\": 3, \"columns\": 4} M = [1; 2; 3 | 4; 5; 6]")]
+        public void ReportMode_IsIdenticalToSourceWithoutTheKeyword(string source) =>
+            AssertReportMatchesPlainSource(source);
+
+        [Fact]
+        public void ReportMode_EmitsNoUiMarkup()
+        {
+            var html = Render("#UI {\"type\": \"checkbox\"} flag = 1\n#UI v = [1; 2; 3]", enableUi: false);
+            Assert.DoesNotContain("calcpad-ui", html);
+            Assert.DoesNotContain("data-ui-", html);
+            Assert.DoesNotContain("<input", html);
+        }
+
+        [Fact]
+        public void ReportStyle_AddsClass_AndIsTheOnlyDifference()
+        {
+            var styled = Render("#UI {\"reportStyle\": \"boxed\"} P = 25kN", enableUi: false);
+            var plain = Render("P = 25kN", enableUi: false);
+            Assert.Contains("class=\"boxed\"", styled);
+            Assert.Equal(plain, styled.Replace(" class=\"boxed\"", ""));
+        }
+
+        [Fact]
+        public void ReportStyle_IsNotEmittedInUiMode() =>
+            Assert.DoesNotContain("boxed", Render("#UI {\"reportStyle\": \"boxed\"} P = 25kN", enableUi: true));
+
+        [Fact]
+        public void Entry_IsAutoDetected_AndKeepsTheUnitOutsideTheInput()
+        {
+            var html = Render("#UI L = 10m", enableUi: true);
+            Assert.Contains("class=\"calcpad-ui-input\"", html);
+            Assert.Contains("data-ui-var=\"L:1\"", html);
+            Assert.Contains("value=\"10\"", html);
+            Assert.DoesNotContain("value=\"10 m\"", html);
+        }
+
+        /// <summary>
+        /// Only the number belongs in the input. A compound unit wraps its parts in a span
+        /// and the angle units carry no markup at all, so neither the first tag nor the
+        /// first &lt;i&gt; marks where the value ends.
+        /// </summary>
+        [Theory]
+        [InlineData("#UI q = 3kN/m", "3")]
+        [InlineData("#UI a = 9.81m/s^2", "9.81")]
+        [InlineData("#UI T = 20°C", "20")]
+        [InlineData("#UI t = 12°", "12")]
+        [InlineData("#UI r = 50%", "50")]
+        [InlineData("#UI z = -3.5", "-3.5")]
+        [InlineData("#UI n = 4", "4")]
+        public void Entry_HoldsTheValueWithoutAnyOfTheUnit(string source, string value)
+        {
+            var html = Render(source, enableUi: true);
+            Assert.Contains($"value=\"{value}\"", html);
+            // Unit markup that ended up inside the attribute would arrive encoded.
+            Assert.DoesNotContain("&lt;", html);
+        }
+
+        /// <summary>
+        /// A control overwrites the right hand side with what was entered, so it can only
+        /// annotate a literal value - never something computed.
+        /// </summary>
+        [Theory]
+        [InlineData("#UI {\"type\": \"entry\"} k = sin(2)")]
+        [InlineData("#UI k = 1 + 2")]
+        [InlineData("#UI k = 2*L\nL = 1m")]
+        [InlineData("#UI v = [1; sqrt(4)]")]
+        public void AssignedExpression_IsAnError(string source)
+        {
+            var html = Render(source, enableUi: true);
+            Assert.Contains("do not support expressions", html);
+            Assert.DoesNotContain("calcpad-ui", html);
+        }
+
+        [Fact]
+        public void InlineComment_IsNotMistakenForTheAssignment()
+        {
+            // A control is often labelled with an inline comment that contains its own
+            // '=', as in Circle.cpd. Taking the first '=' made the label the variable
+            // name, and that name became the control key written back to the document.
+            var html = Render("#UI '2&middot;<i>r</i> ='d = 1", enableUi: true);
+            Assert.Contains("data-ui-var=\"d:1\"", html);
+            Assert.DoesNotContain("data-ui-var=\"'2", html);
+        }
+
+        [Theory]
+        [InlineData("#UI 'label ='x = 1", "x:1")]
+        [InlineData("#UI \"label =\"y = 2", "y:1")]
+        [InlineData("#UI 'a ='  z  = 3", "z:1")]
+        public void InlineComment_IsStrippedFromTheVariableName(string source, string key) =>
+            Assert.Contains($"data-ui-var=\"{key}\"", Render(source, enableUi: true));
+
+        [Fact]
+        public void InlineComment_LeavesTheReportUnchanged() =>
+            AssertReportMatchesPlainSource("#UI '2&middot;<i>r</i> ='d = 1\nA = d*2");
+
+        [Fact]
+        public void InlineComment_DoesNotBreakOverrides()
+        {
+            var overrides = new Dictionary<string, string> { ["d:1"] = "4" };
+            var html = Render("#UI '2&middot;<i>r</i> ='d = 1\nA = d*2", enableUi: false, overrides);
+            Assert.Contains("8", html);
+        }
+
+        [Fact]
+        public void MultipleAssignments_EachGetTheirOwnControl()
+        {
+            var html = Render("#UI '2&middot;<i>r</i> ='d = 1','x = 2'", enableUi: true);
+            Assert.Contains("data-ui-var=\"d:1\"", html);
+            Assert.Contains("data-ui-var=\"x:1\"", html);
+            Assert.Equal(2, Regex.Matches(html, "calcpad-ui-input").Count);
+        }
+
+        [Fact]
+        public void MultipleAssignments_ShareTheJsonProperties()
+        {
+            var html = Render("#UI {\"type\": \"checkbox\", \"style\": \"sw\"} a = 1', 'b = 0", enableUi: true);
+            Assert.Equal(2, Regex.Matches(html, "class=\"calcpad-ui-checkbox sw\"").Count);
+        }
+
+        [Fact]
+        public void MultipleAssignments_AreOverriddenSeparately()
+        {
+            var overrides = new Dictionary<string, string> { ["x:1"] = "9" };
+            var html = Render("#UI d = 1', 'x = 2\nS = d + x", enableUi: false, overrides);
+            // d keeps its default, only x is replaced: 1 + 9.
+            Assert.Contains("10", html);
+        }
+
+        [Fact]
+        public void SameNameTwiceOnOneLine_GetsTwoKeys()
+        {
+            var html = Render("#UI d = 1', 'd = 2", enableUi: true);
+            Assert.Contains("data-ui-var=\"d:1\"", html);
+            Assert.Contains("data-ui-var=\"d:2\"", html);
+        }
+
+        [Fact]
+        public void MultipleAssignments_LeaveTheReportUnchanged() =>
+            AssertReportMatchesPlainSource("#UI '2&middot;<i>r</i> ='d = 1','x = 2'\nA = d*x");
+
+        [Fact]
+        public void MultipleAssignments_SkipSegmentsThatAssignNothing()
+        {
+            // The trailing 'd' is an output expression, not a declaration.
+            var html = Render("#UI d = 1', 'd", enableUi: true);
+            Assert.Single(Regex.Matches(html, "calcpad-ui-input"));
+        }
+
+        [Fact]
+        public void MultipleDatagrids_EachEmitTheirOwnContainer()
+        {
+            var html = Render("#UI v = [1; 2]', 'w = [3; 4; 5]", enableUi: true);
+            Assert.Contains("data-ui-values=\"1;2\"", html);
+            Assert.Contains("data-ui-values=\"3;4;5\"", html);
+            Assert.Equal(2, Regex.Matches(html, "class=\"calcpad-ui-datagrid\"").Count);
+        }
+
+        [Fact]
+        public void ControlBinding_ReportsTheSourceLine()
+        {
+            // A host writes an edited value back to this line, so it has to be the
+            // 1 based source line the rest of the markup uses, not the output index.
+            var html = Render("'first\n'second\n#UI L = 10m", enableUi: true);
+            Assert.Contains("data-ui-var=\"L:1\" data-ui-line=\"3\"", html);
+        }
+
+        [Fact]
+        public void Style_IsAppendedToTheControlClass() =>
+            Assert.Contains("class=\"calcpad-ui-input highlight\"",
+                Render("#UI {\"style\": \"highlight\"} d = 2m", enableUi: true));
+
+        /// <summary>
+        /// Only an entry shows its variable name - it labels the number in the box. The
+        /// other controls stand on their own, so the author labels them with plain text.
+        /// </summary>
+        [Theory]
+        [InlineData("#UI {\"type\": \"checkbox\"} flag = 1", "flag")]
+        [InlineData("#UI {\"type\": \"dropdown\", \"keys\": [\"Low\"], \"values\": [\"1\"]} grade = 1", "grade")]
+        [InlineData("#UI {\"type\": \"radio\", \"keys\": [\"Steel\"], \"values\": [\"200GPa\"]} E = 200GPa", "E")]
+        [InlineData("#UI v = [1; 2; 3]", "v")]
+        public void Control_HidesTheVariableNameInUiMode(string source, string name)
+        {
+            var html = Render(source, enableUi: true);
+            Assert.DoesNotContain($">{name}<", html);
+            Assert.DoesNotContain(" = ", html);
+        }
+
+        [Fact]
+        public void Entry_KeepsTheVariableNameInUiMode() =>
+            Assert.Contains(" = ", Render("#UI L = 10m", enableUi: true));
+
+        [Fact]
+        public void Radio_DropsTheUnitOfTheSelectedValue() =>
+            Assert.DoesNotContain("<i>",
+                Render("#UI {\"type\": \"radio\", \"keys\": [\"Steel\"], \"values\": [\"200GPa\"]} E = 200GPa", enableUi: true));
+
+        [Fact]
+        public void Datagrid_LeavesNoEquationBehindInUiMode() =>
+            Assert.DoesNotContain("<span class=\"eq\">", Render("#UI v = [1; 2; 3]", enableUi: true));
+
+        [Fact]
+        public void Checkbox_IsCheckedWhenTheValueIsOne()
+        {
+            Assert.Contains("type=\"checkbox\" class=\"calcpad-ui-checkbox\" data-ui-var=\"flag:1\" data-ui-line=\"1\" checked",
+                Render("#UI {\"type\": \"checkbox\"} flag = 1", enableUi: true));
+            Assert.DoesNotContain("checked",
+                Render("#UI {\"type\": \"checkbox\"} flag = 0", enableUi: true));
+        }
+
+        [Fact]
+        public void Dropdown_MarksTheMatchingOptionSelected()
+        {
+            var html = Render("#UI {\"type\": \"dropdown\", \"keys\": [\"Low\", \"Med\"], \"values\": [\"1\", \"2\"]} grade = 2", enableUi: true);
+            Assert.Contains("<option value=\"1\">Low</option>", html);
+            Assert.Contains("<option value=\"2\" selected>Med</option>", html);
+        }
+
+        [Fact]
+        public void Radio_GroupsByControlKey()
+        {
+            var html = Render("#UI {\"type\": \"radio\", \"keys\": [\"A\", \"B\"], \"values\": [\"1\", \"2\"]} r = 1", enableUi: true);
+            Assert.Contains("name=\"ui-radio-r:1\" value=\"1\" checked", html);
+            Assert.Contains("name=\"ui-radio-r:1\" value=\"2\"", html);
+        }
+
+        [Fact]
+        public void Radio_ChecksTheOptionMatchingAUnitValue()
+        {
+            var html = Render("#UI {\"type\": \"radio\", \"keys\": [\"Steel\", \"Concrete\"], \"values\": [\"200GPa\", \"25GPa\"]} E = 200GPa", enableUi: true);
+            Assert.DoesNotContain("Error", html);
+            Assert.Contains("value=\"200GPa\" checked", html);
+            Assert.Contains("value=\"25GPa\">", html);
+        }
+
+        [Fact]
+        public void Radio_OverrideReplacesTheWholeValueWithItsUnit()
+        {
+            var overrides = new Dictionary<string, string> { ["E:1"] = "25GPa" };
+            var html = Render("#UI {\"type\": \"radio\", \"keys\": [\"Steel\", \"Concrete\"], \"values\": [\"200GPa\", \"25GPa\"]} E = 200GPa\nE", enableUi: true, overrides);
+            Assert.DoesNotContain("Error", html);
+            Assert.Contains("value=\"25GPa\" checked", html);
+        }
+
+        [Fact]
+        public void Dropdown_OverrideReplacesTheWholeValueWithItsUnit()
+        {
+            var overrides = new Dictionary<string, string> { ["E:1"] = "25GPa" };
+            var html = Render("#UI {\"type\": \"dropdown\", \"keys\": [\"Steel\", \"Concrete\"], \"values\": [\"200GPa\", \"25GPa\"]} E = 200GPa\nE", enableUi: true, overrides);
+            Assert.DoesNotContain("Error", html);
+            Assert.Contains("<option value=\"25GPa\" selected>", html);
+        }
+
+        [Theory]
+        [InlineData("#UI v = [1; 2; 3]", 1, 3, "1;2;3")]
+        [InlineData("#UI M = [1; 2; 3 | 4; 5; 6]", 2, 3, "1;2;3|4;5;6")]
+        [InlineData("#UI Z = vector(5)", 1, 5, "0;0;0;0;0")]
+        [InlineData("#UI G = matrix(3; 4)", 3, 4, "0;0;0;0|0;0;0;0|0;0;0;0")]
+        public void Datagrid_AutoDetectsShapeAndValues(string source, int rows, int columns, string values)
+        {
+            var html = Render(source, enableUi: true);
+            Assert.Contains($"data-ui-rows=\"{rows}\" data-ui-columns=\"{columns}\"", html);
+            Assert.Contains($"data-ui-values=\"{values}\"", html);
+        }
+
+        [Theory]
+        [InlineData("#UI r = 3\n#UI c = 4\n#UI {\"type\": \"datagrid\"} G = matrix(r; c)", 3, 4)]
+        [InlineData("x = [1; 2; 3]\ny = [1; 2]\n#UI G = matrix(len(x); len(y))", 3, 2)]
+        [InlineData("n = 5\n#UI Z = vector(n)", 1, 5)]
+        public void Datagrid_ComputedSize_TakesItsShapeFromTheValue(string source, int rows, int columns)
+        {
+            var html = Render(source, enableUi: true);
+            Assert.DoesNotContain("Error", html);
+            Assert.Contains($"data-ui-rows=\"{rows}\" data-ui-columns=\"{columns}\"", html);
+        }
+
+        [Fact]
+        public void Datagrid_ComputedSize_KeepsTheEnteredValues()
+        {
+            // There is no literal in the source to write into, so the entered one replaces
+            // the whole constructor call.
+            var overrides = new Dictionary<string, string> { ["G:1"] = "[1; 2 | 3; 4]" };
+            var html = Render("#UI r = 2\n#UI {\"type\": \"datagrid\"} G = matrix(r; r)\nG", enableUi: true, overrides);
+            Assert.DoesNotContain("Error", html);
+            Assert.Contains("data-ui-values=\"1;2|3;4\"", html);
+        }
+
+        /// <summary>
+        /// The source sizes the grid, even once values have been entered - the entered ones are
+        /// fitted to the shape it asks for. Without this the saved literal, which replaces the
+        /// whole constructor call, would go on deciding the shape and editing the source would
+        /// stop resizing the grid.
+        /// </summary>
+        [Theory]
+        // Shrinks: the cells outside the new shape are trimmed off.
+        [InlineData(2, 2, "[1; 2; 3; 4 | 5; 6; 7; 8 | 9; 10; 11; 12]", "1;2|5;6")]
+        [InlineData(1, 2, "[1; 2; 3; 4 | 5; 6; 7; 8 | 9; 10; 11; 12]", "1;2")]
+        // Grows: the written values stay put and the new cells come in as zeros.
+        [InlineData(3, 3, "[1; 2 | 3; 4]", "1;2;0|3;4;0|0;0;0")]
+        public void Datagrid_ComputedSize_FitsTheEnteredValuesToTheSourceShape(int rows, int columns, string saved, string values)
+        {
+            var overrides = new Dictionary<string, string>
+            {
+                ["x:1"] = rows.ToString(),
+                ["y:1"] = columns.ToString(),
+                ["M:1"] = saved
+            };
+            var html = Render("#UI x = 3\n#UI y = 4\n#UI M = matrix(x; y)", enableUi: true, overrides);
+            Assert.DoesNotContain("Error", html);
+            Assert.Contains($"data-ui-rows=\"{rows}\" data-ui-columns=\"{columns}\"", html);
+            Assert.Contains($"data-ui-values=\"{values}\"", html);
+        }
+
+        [Fact]
+        public void Datagrid_LiteralSize_FitsTheEnteredValuesToTheSourceShape()
+        {
+            var overrides = new Dictionary<string, string> { ["M:1"] = "[1; 2; 3 | 4; 5; 6]" };
+            var html = Render("#UI {\"type\": \"datagrid\"} M = matrix(1; 2)", enableUi: true, overrides);
+            Assert.Contains("data-ui-rows=\"1\" data-ui-columns=\"2\"", html);
+            Assert.Contains("data-ui-values=\"1;2\"", html);
+        }
+
+        [Fact]
+        public void Datagrid_ComputedSize_FitsTheEnteredValuesOfAVector()
+        {
+            var overrides = new Dictionary<string, string> { ["n:1"] = "2", ["Z:1"] = "[7; 8; 9]" };
+            var html = Render("#UI n = 3\n#UI Z = vector(n)", enableUi: true, overrides);
+            Assert.DoesNotContain("Error", html);
+            Assert.Contains("data-ui-rows=\"1\" data-ui-columns=\"2\"", html);
+            Assert.Contains("data-ui-values=\"7;8\"", html);
+        }
+
+        /// <summary>
+        /// The trimmed values are what the document calculates with, in a report as much as in
+        /// a form - the grid and the results it feeds cannot disagree about the matrix.
+        /// </summary>
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Datagrid_FittedOverride_DrivesTheResults(bool enableUi)
+        {
+            var overrides = new Dictionary<string, string>
+            {
+                ["x:1"] = "2",
+                ["y:1"] = "2",
+                ["M:1"] = "[1; 2; 3; 4 | 5; 6; 7; 8 | 9; 10; 11; 12]"
+            };
+            var html = Render("#UI x = 3\n#UI y = 4\n#UI M = matrix(x; y)\ns = sum(M)", enableUi, overrides);
+            Assert.DoesNotContain("Error", html);
+            Assert.Contains("14", html);
+        }
+
+        [Fact]
+        public void Datagrid_EmitsTheContainerOutsideTheParagraph()
+        {
+            var html = Render("#UI v = [1; 2; 3]", enableUi: true);
+            Assert.Matches(@"</p>\s*<div class=""calcpad-ui-datagrid""", html);
+        }
+
+        [Theory]
+        // Grows: the written values stay put and the new cells come in as zeros.
+        [InlineData(2, 3, "[1; 2; 3 | 4; 5; 6]", "1;2;3|4;5;6")]
+        [InlineData(3, 4, "[1; 2; 3 | 4; 5; 6]", "1;2;3;0|4;5;6;0|0;0;0;0")]
+        [InlineData(2, 2, "[1; 2; 3]", "1;2|0;0")]
+        // Shrinks: the cells outside the declared shape are dropped.
+        [InlineData(1, 2, "[1; 2; 3 | 4; 5; 6]", "1;2")]
+        [InlineData(2, 2, "[1; 2; 3 | 4; 5; 6]", "1;2|4;5")]
+        public void Datagrid_DeclaredShape_PadsAndTruncatesTheLiteral(int rows, int columns, string literal, string values)
+        {
+            var html = Render(
+                $"#UI {{\"type\": \"datagrid\", \"rows\": {rows}, \"columns\": {columns}}} T = {literal}",
+                enableUi: true);
+            Assert.Contains($"data-ui-rows=\"{rows}\" data-ui-columns=\"{columns}\"", html);
+            Assert.Contains($"data-ui-values=\"{values}\"", html);
+        }
+
+        [Fact]
+        public void Datagrid_DeclaredShape_DoesNotReshapeTheReport()
+        {
+            // The shape describes the grid the form draws, not the document. A report
+            // renders the literal exactly as written, same as any other mode.
+            AssertReportMatchesPlainSource(
+                "#UI {\"type\": \"datagrid\", \"rows\": 3, \"columns\": 4} M = [1; 2; 3 | 4; 5; 6]\nM");
+        }
+
+        [Fact]
+        public void Datagrid_EmitsHeaders()
+        {
+            var html = Render(
+                "#UI {\"type\": \"datagrid\", \"columnHeaders\": [\"a\", \"b\"], \"rowHeaders\": [\"r1\"]} T = [1; 2]",
+                enableUi: true);
+            Assert.Contains("data-ui-col-headers=\"a,b\"", html);
+            Assert.Contains("data-ui-row-headers=\"r1\"", html);
+        }
+
+        [Fact]
+        public void Override_ReplacesTheValueAndPropagatesToDependents()
+        {
+            var overrides = new Dictionary<string, string> { ["L"] = "12" };
+            var html = Render("#UI L = 10m\nA = L * 2m", enableUi: true, overrides);
+            Assert.Contains("value=\"12\"", html);
+            Assert.Contains("24", html);
+        }
+
+        [Fact]
+        public void Override_PreservesTheUnit() =>
+            Assert.DoesNotContain("10",
+                Render("#UI L = 10m\nL", enableUi: true, new Dictionary<string, string> { ["L"] = "12" }));
+
+        [Fact]
+        public void Override_AppliesInReportModeToo() =>
+            Assert.Contains("24",
+                Render("#UI L = 10m\nA = L * 2m", enableUi: false, new Dictionary<string, string> { ["L"] = "12" }));
+
+        [Fact]
+        public void Override_ReplacesTheWholeDatagridLiteral()
+        {
+            var overrides = new Dictionary<string, string> { ["v"] = "[7; 8; 9]" };
+            Assert.Contains("data-ui-values=\"7;8;9\"", Render("#UI v = [1; 2; 3]", enableUi: true, overrides));
+        }
+
+        [Theory]
+        [InlineData("#UI {\"type\": \"dropdown\", \"keys\": [\"A\"]} x = 1")]
+        [InlineData("#UI {\"type\": \"radio\", \"values\": [\"1\"]} x = 1")]
+        [InlineData("#UI {\"type\": \"dropdown\", \"keys\": [\"A\", \"B\"], \"values\": [\"1\"]} x = 1")]
+        [InlineData("#UI {\"type\": \"entry\" x = 1")]
+        [InlineData("#UI {not json} x = 1")]
+        [InlineData("#UI {\"mode\": \"string\"} x = 1")]
+        [InlineData("#UI name$ = 1")]
+        [InlineData("#UI x")]
+        [InlineData("#UI {\"type\": \"slider\"} x = 1")]
+        [InlineData("#UI {\"rows\": -1} x = 1")]
+        [InlineData("#UI {\"type\": \"datagrid\", \"columns\": 2, \"columnHeaders\": [\"a\", \"b\", \"c\"]} T = [1; 2]")]
+        [InlineData("#UI {\"rows\": \"two\"} x = 1")]
+        [InlineData("#UI {\"style\": 5} x = 1")]
+        public void InvalidDirective_ReportsAnError(string source) =>
+            Assert.Contains("err", Render(source, enableUi: true));
+
+        /// <summary>
+        /// A rejected payload must not leave a half configured control behind - the line
+        /// renders as it would without the keyword, plus the error.
+        /// </summary>
+        [Fact]
+        public void InvalidDirective_RendersNoControl() =>
+            Assert.DoesNotContain("calcpad-ui-", Render("#UI {\"type\": \"slider\"} x = 1", enableUi: true));
+
+        [Fact]
+        public void ParserAndLinter_RejectTheSameProperties()
+        {
+            var properties = new UiDto { Type = "slider", Rows = -1, Mode = "string" };
+            var messages = properties.Validate().Select(e => e.Message).ToArray();
+            Assert.Equal(3, messages.Length);
+            foreach (var message in messages)
+                Assert.Contains(message, Render("#UI {\"type\": \"slider\", \"rows\": -1, \"mode\": \"string\"} x = 1", enableUi: true));
+        }
+
+        [Fact]
+        public void InactiveConditionalBranch_RendersNoControl()
+        {
+            var html = Render("#if 0\n#UI L = 10m\n#end if", enableUi: true);
+            Assert.DoesNotContain("calcpad-ui-input", html);
+        }
+
+        [Fact]
+        public void ActiveConditionalBranch_RendersTheControl() =>
+            Assert.Contains("calcpad-ui-input", Render("#if 1\n#UI L = 10m\n#end if", enableUi: true));
+
+        [Fact]
+        public void SkippedUiLine_DoesNotAttachItsControlToTheNextLine()
+        {
+            var html = Render("#if 0\n#UI L = 10m\n#end if\nW = 5m", enableUi: true);
+            Assert.DoesNotContain("data-ui-", html);
+            Assert.DoesNotContain("<input", html);
+        }
+
+        [Fact]
+        public void RedefinedVariable_GetsADistinctKeyPerOccurrence()
+        {
+            var html = Render("#UI x = 1\nx = x + 1\n#UI x = 5", enableUi: true);
+            Assert.Contains("data-ui-var=\"x:1\"", html);
+            Assert.Contains("data-ui-var=\"x:2\"", html);
+        }
+
+        [Fact]
+        public void KeyedOverride_AppliesToThatOccurrenceOnly()
+        {
+            var overrides = new Dictionary<string, string> { ["x:2"] = "50" };
+            var html = Render("#UI x = 1\n#UI x = 5", enableUi: true, overrides);
+            Assert.Contains("value=\"1\"", html);
+            Assert.Contains("value=\"50\"", html);
+            Assert.DoesNotContain("value=\"5\"", html);
+        }
+
+        [Fact]
+        public void BareOverride_AppliesToEveryOccurrenceOfThatName()
+        {
+            var overrides = new Dictionary<string, string> { ["x"] = "7" };
+            var html = Render("#UI x = 1\n#UI x = 5", enableUi: true, overrides);
+            Assert.Equal(2, Regex.Matches(html, "value=\"7\"").Count);
+        }
+
+        [Fact]
+        public void LoopedControl_GetsOneKeyPerPass()
+        {
+            var html = Render("#repeat 3\n#UI x = 1\n#loop", enableUi: true);
+            Assert.Contains("data-ui-var=\"x:1:1\"", html);
+            Assert.Contains("data-ui-var=\"x:1:2\"", html);
+            Assert.Contains("data-ui-var=\"x:1:3\"", html);
+        }
+
+        [Fact]
+        public void NestedLoops_JoinThePassNumbers()
+        {
+            var html = Render("#repeat 2\n#repeat 2\n#UI x = 1\n#loop\n#loop", enableUi: true);
+            Assert.Contains("data-ui-var=\"x:1:1.1\"", html);
+            Assert.Contains("data-ui-var=\"x:1:1.2\"", html);
+            Assert.Contains("data-ui-var=\"x:1:2.1\"", html);
+            Assert.Contains("data-ui-var=\"x:1:2.2\"", html);
+        }
+
+        [Fact]
+        public void ControlNumbering_IsUnaffectedByLoopIterationCount()
+        {
+            // The declaration ordinal is keyed on the source line, so re-running the line
+            // must not advance the count for whatever follows the loop.
+            Assert.Contains("data-ui-var=\"b:1\"", Render("#repeat 2\n#UI a = 1\n#loop\n#UI b = 2", enableUi: true));
+            Assert.Contains("data-ui-var=\"b:1\"", Render("#repeat 9\n#UI a = 1\n#loop\n#UI b = 2", enableUi: true));
+        }
+
+        [Fact]
+        public void DeclarationOverride_CoversEveryPassOfALoop()
+        {
+            var overrides = new Dictionary<string, string> { ["x:1"] = "4" };
+            var html = Render("#repeat 3\n#UI x = 1\n#loop", enableUi: true, overrides);
+            Assert.Equal(3, Regex.Matches(html, "value=\"4\"").Count);
+        }
+
+        [Fact]
+        public void PassOverride_AppliesToThatIterationOnly()
+        {
+            var overrides = new Dictionary<string, string> { ["x:1:2"] = "4" };
+            var html = Render("#repeat 3\n#UI x = 1\n#loop", enableUi: true, overrides);
+            Assert.Single(Regex.Matches(html, "value=\"4\""));
+            Assert.Equal(2, Regex.Matches(html, "value=\"1\"").Count);
+        }
+
+        [Fact]
+        public void ControlNumbering_IsStableAcrossConditionalBranches()
+        {
+            const string source = "#if {0}\n#UI a = 1\n#end if\n#UI b = 2";
+            Assert.Contains("data-ui-var=\"b:1\"", Render(string.Format(source, "1"), enableUi: true));
+            Assert.Contains("data-ui-var=\"b:1\"", Render(string.Format(source, "0"), enableUi: true));
+        }
+
+        [Fact]
+        public void UiStateDoesNotLeakToTheFollowingLine()
+        {
+            var html = Render("#UI L = 10m\nW = 5m", enableUi: true);
+            Assert.Contains("data-ui-var=\"L:1\"", html);
+            Assert.DoesNotContain("data-ui-var=\"W:1\"", html);
+            Assert.Single(Regex.Matches(html, "calcpad-ui-input"));
+        }
+
+        [Fact]
+        public void ErrorLine_IsHiddenInInputModeAndShownInReportMode()
+        {
+            const string source = "#UI x = y";
+            var uiHtml = Render(source, enableUi: true);
+            Assert.Contains("Error in", uiHtml);
+            Assert.DoesNotContain("on line", uiHtml);
+            Assert.DoesNotContain("data-text=", uiHtml);
+
+            var reportHtml = Render(source, enableUi: false);
+            Assert.Contains("Error in", reportHtml);
+            Assert.Contains("on line", reportHtml);
+            Assert.Contains("data-text=", reportHtml);
+        }
+
+        [Fact]
+        public void Datagrid_SizeLimit_ExplicitlyDeclaredSizeTooLarge()
+        {
+            var html = Render("#UI {\"type\": \"datagrid\", \"rows\": 100001, \"columns\": 1} x = vector(100001)", enableUi: true);
+            Assert.Contains("Error", html);
+            Assert.Contains("datagrid size cannot exceed", html);
+            Assert.Contains("100000", html);
+            Assert.DoesNotContain("calcpad-ui-datagrid", html);
+        }
+
+        [Fact]
+        public void Datagrid_SizeLimit_AutoDetectedLiteralTooLarge()
+        {
+            var html = Render("#UI M = matrix(1000; 1000)", enableUi: true);
+            Assert.Contains("Error", html);
+            Assert.Contains("datagrid size cannot exceed", html);
+            Assert.Contains("#Read", html);
+            Assert.DoesNotContain("calcpad-ui-datagrid", html);
+        }
+
+        [Fact]
+        public void Datagrid_SizeLimit_ComputedSizeTooLarge()
+        {
+            var html = Render("#UI M = matrix(500; 300)", enableUi: true);
+            Assert.Contains("Error", html);
+            Assert.Contains("datagrid size cannot exceed", html);
+            Assert.DoesNotContain("calcpad-ui-datagrid", html);
+        }
+
+        [Fact]
+        public void Datagrid_SizeLimit_ExactLimitIsAllowed()
+        {
+            var html = Render("#UI M = matrix(316; 316)", enableUi: true);
+            Assert.DoesNotContain("Error", html);
+            Assert.Contains("data-ui-rows=\"316\" data-ui-columns=\"316\"", html);
+        }
+
+        [Fact]
+        public void Datagrid_SizeLimit_UnderLimitIsAllowed()
+        {
+            var html = Render("#UI M = matrix(300; 300)", enableUi: true);
+            Assert.DoesNotContain("Error", html);
+            Assert.Contains("data-ui-rows=\"300\" data-ui-columns=\"300\"", html);
+        }
+    }
+}


### PR DESCRIPTION
- Fix #hide not hiding errors in preview HTML
- Adding grid size limit to #UI datagrid to avoid memory overloading