### PR TITLE
Core Updates and Bug Fixes

### DIFF
--- a/Calcpad.Core/Exceptions.cs
+++ b/Calcpad.Core/Exceptions.cs
@@ -376,6 +376,9 @@ namespace Calcpad.Core
         internal static MathParserException MatirixSizeLimit() =>
             new(string.Format(Messages.Matrix_size_cannot_exceed_0, Matrix.MaxSize));
 
+        internal static MathParserException EmbeddedDataSizeLimit() =>
+            new(string.Format(Messages.Embedded_data_cannot_exceed_0_MB, ExpressionParser.MaxEmbeddedDataSize / (1024 * 1024)));
+
         internal static MathParserException DatagridSizeLimit() =>
             new(string.Format(Messages.Datagrid_size_cannot_exceed_0_cells, UiDto.MaxSize));
 

--- a/Calcpad.Core/Messages.Designer.cs
+++ b/Calcpad.Core/Messages.Designer.cs
@@ -1735,6 +1735,15 @@ namespace Calcpad.Core {
         }
 
         // / <summary>
+        // /   Looks up a localized string similar to Data embedded in a compiled worksheet cannot exceed {0} MB..
+        // / </summary>
+        public static string Embedded_data_cannot_exceed_0_MB {
+            get {
+                return ResourceManager.GetString("Embedded_data_cannot_exceed_0_MB", resourceCulture);
+            }
+        }
+
+        // / <summary>
         // /   Looks up a localized string similar to A #UI value has the wrong type..
         // / </summary>
         public static string A_UI_value_has_the_wrong_type {

--- a/Calcpad.Core/Messages.resx
+++ b/Calcpad.Core/Messages.resx
@@ -616,6 +616,9 @@
   <data name="Datagrid_size_cannot_exceed_0_cells" xml:space="preserve">
     <value>#UI datagrid size cannot exceed {0} cells. Use #Read to import larger data sets from a file instead.</value>
   </data>
+  <data name="Embedded_data_cannot_exceed_0_MB" xml:space="preserve">
+    <value>Data embedded in a compiled worksheet cannot exceed {0} MB.</value>
+  </data>
   <data name="A_UI_value_has_the_wrong_type" xml:space="preserve">
     <value>A #UI value has the wrong type.</value>
   </data>

--- a/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.DataExchange.cs
+++ b/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.DataExchange.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using Calcpad.OpenXml;
 
 namespace Calcpad.Core
@@ -11,6 +12,9 @@ namespace Calcpad.Core
         {
             internal static string[][] Read(ReadWriteOptions options)
             {
+                if (!options.Data.IsEmpty)
+                    return ReadEmbedded(options);
+
                 var fileName = $"{options.Path}.{options.Ext}";
                 if (fileName == ".")
                     throw Exceptions.MissingFileName();
@@ -23,7 +27,7 @@ namespace Calcpad.Core
                 {
                     if (options.IsExcel)
                     {
-                        if (!options.Ext.Equals("xlsx", StringComparison.OrdinalIgnoreCase) && !options.Ext.Equals("xlsm", StringComparison.OrdinalIgnoreCase))
+                        if (!ExcelData.IsExcelFile(options.Ext.ToString()))
                             throw Exceptions.FileFormatNotSupported(options.Ext.ToString());
 
                         return ReadExcel(options);
@@ -34,6 +38,50 @@ namespace Calcpad.Core
                 {
                     throw new MathParserException(e.Message);
                 }
+            }
+
+            /// <summary>
+            /// Reads the data the directive carries itself, taking the same sheet and range as a
+            /// file would. Everything past this point is what a read off the disk does.
+            /// </summary>
+            private static string[][] ReadEmbedded(ReadWriteOptions options)
+            {
+                var bytes = new byte[options.Data.Length / 4 * 3];
+                if (!Convert.TryFromBase64Chars(options.Data, bytes, out var length))
+                    throw Exceptions.InvalidSyntax(DataUri);
+
+                try
+                {
+                    if (options.IsExcel)
+                        return ExcelData.ReadFromMemory(bytes[..length], options.Sheet.ToString(),
+                            options.Start.ToString(), options.End.ToString());
+
+                    return ReadCSVFromString(options, Encoding.UTF8.GetString(bytes, 0, length));
+                }
+                catch (Exception e)
+                {
+                    throw new MathParserException(e.Message);
+                }
+            }
+
+            private static string[][] ReadCSVFromString(ReadWriteOptions options, string content)
+            {
+                int i = 0;
+                var (start, end) = ParseBounds(options.Start, options.End);
+                var lines = new List<string>();
+                using var reader = new StringReader(content);
+                while (reader.ReadLine() is string line)
+                {
+                    ++i;
+                    if (i >= start.row)
+                    {
+                        if (end.row > 0 && i > end.row)
+                            break;
+
+                        lines.Add(line);
+                    }
+                }
+                return FormatCSVData(options, lines, start, end);
             }
 
             private static string[][] ReadCSV(ReadWriteOptions options)
@@ -54,10 +102,15 @@ namespace Calcpad.Core
                         lines.Add(line);
                     }
                 }
+                return FormatCSVData(options, lines, start, end);
+            }
+
+            private static string[][] FormatCSVData(ReadWriteOptions options, List<string> lines, (int row, int col) start, (int row, int col) end)
+            {
                 string[][] data = new string[lines.Count][];
                 var j0 = Math.Max(0, start.col - 1);
                 var n = lines.Count;
-                for (i = 0; i < n; ++i)
+                for (int i = 0; i < n; ++i)
                 {
                     if (start.col == 0 && end.col == 0)
                         data[i] = lines[i].Split(options.Separator, StringSplitOptions.TrimEntries);

--- a/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.Keywords.cs
+++ b/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.Keywords.cs
@@ -29,6 +29,9 @@ namespace Calcpad.Core
             NoSub,
             NoVar,
             VarSub,
+            End_NoSub,
+            End_NoVar,
+            End_VarSub,
             Const,
             Split,
             Wrap,
@@ -160,14 +163,15 @@ namespace Calcpad.Core
                 case Keyword.End_Noc:
                     _isVal = _outputModeStack.Count > 0 ? _outputModeStack.Pop() : 0;
                     break;
-                case Keyword.NoSub:
-                    _parser.VariableSubstitution = MathParser.VariableSubstitutionOptions.VariablesOnly;
-                    break;
-                case Keyword.NoVar:
-                    _parser.VariableSubstitution = MathParser.VariableSubstitutionOptions.SubstitutionsOnly;
-                    break;
-                case Keyword.VarSub:
-                    _parser.VariableSubstitution = MathParser.VariableSubstitutionOptions.VariablesAndSubstitutions;
+                case Keyword.NoSub: SetSubstitution(s, keyword, MathParser.VariableSubstitutionOptions.VariablesOnly); break;
+                case Keyword.NoVar: SetSubstitution(s, keyword, MathParser.VariableSubstitutionOptions.SubstitutionsOnly); break;
+                case Keyword.VarSub: SetSubstitution(s, keyword, MathParser.VariableSubstitutionOptions.VariablesAndSubstitutions); break;
+                case Keyword.End_NoSub:
+                case Keyword.End_NoVar:
+                case Keyword.End_VarSub:
+                    _parser.VariableSubstitution = _substitutionStack.Count > 0 ?
+                        _substitutionStack.Pop() :
+                        MathParser.VariableSubstitutionOptions.VariablesAndSubstitutions;
                     break;
                 case Keyword.Const:
                     _parser.IsConst = true;
@@ -257,6 +261,13 @@ namespace Calcpad.Core
             _outputModeStack.Push(_isVal);
             if (IsDirectiveConditionMet(s, keyword))
                 _isVal = value;
+        }
+
+        private void SetSubstitution(ReadOnlySpan<char> s, Keyword keyword, MathParser.VariableSubstitutionOptions value)
+        {
+            _substitutionStack.Push(_parser.VariableSubstitution);
+            if (IsDirectiveConditionMet(s, keyword))
+                _parser.VariableSubstitution = value;
         }
 
         private bool IsDirectiveConditionMet(ReadOnlySpan<char> s, Keyword keyword)
@@ -935,10 +946,19 @@ namespace Calcpad.Core
 
         private void ReportDataExchageResult(ReadWriteOptions options, string command)
         {
-            var url = $"file:///{options.FullPath.Replace('\\', '/')}";
             _sb.Append($"<p{HtmlId}>")
                .Append($"Matrix <span class=\"eq\">{new HtmlWriter(Settings.Math, false).FormatVariable(options.Name.ToString(), string.Empty, true)}</span>")
-               .Append($" was successfully {command} <a href=\"{url}\">{options.Path}.{options.Ext}</a>");
+               .Append($" was successfully {command} ");
+
+            // Embedded data has no file to name, and no link to it that would lead anywhere.
+            if (options.Data.IsEmpty)
+            {
+                var url = $"file:///{options.FullPath.Replace('\\', '/')}";
+                _sb.Append($"<a href=\"{url}\">{options.Path}.{options.Ext}</a>");
+            }
+            else
+                _sb.Append("embedded data");
+
             if (options.IsExcel)
             {
                 if (!options.Sheet.IsEmpty)

--- a/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.Portable.cs
+++ b/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.Portable.cs
@@ -1,22 +1,38 @@
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Calcpad.Core
 {
     public partial class ExpressionParser
     {
-        public static string InlineReadDirective(ReadOnlySpan<char> line, string sourceFilePath, PathRoots pathRoots = null)
+        /// <summary>How much data a compiled worksheet may carry, per source and in total.</summary>
+        public const int MaxEmbeddedDataSize = 10 * 1024 * 1024;
+
+        /// <summary>
+        /// The same <c>#read</c>, carrying the file it names instead of pointing at it. Only the
+        /// source is rewritten, so the recipient's read takes the path the author's did. The file
+        /// is read here too, so one that cannot be read stops the compile. <paramref name="size"/>
+        /// returns the bytes embedded, for the caller to total against the same limit.
+        /// </summary>
+        public static string EmbedReadDirective(ReadOnlySpan<char> line, string sourceFilePath, PathRoots pathRoots, out int size)
         {
+            size = 0;
+            var s = line.Trim();
             var sourceDir = string.IsNullOrEmpty(sourceFilePath)
                 ? null
                 : System.IO.Path.GetDirectoryName(sourceFilePath);
-            var options = new ReadWriteOptions(line.Trim(), 0, sourceDir, pathRoots);
-            if (options.Name.IsEmpty)
+            var options = new ReadWriteOptions(s, 0, sourceDir, pathRoots);
+            if (options.Name.IsEmpty || !options.Data.IsEmpty || !TryGetDataPath(s, out var start, out var length))
                 return null;
 
-            var literal = DataLiteral(DataExchange.Read(options), options.Type);
-            return literal is null ? null : $"{options.Name} = {literal}";
+            var file = new System.IO.FileInfo(options.FullPath);
+            if (file.Exists && file.Length > MaxEmbeddedDataSize)
+                throw Exceptions.EmbeddedDataSizeLimit();
+
+            DataExchange.Read(options);
+            var bytes = System.IO.File.ReadAllBytes(options.FullPath);
+            size = bytes.Length;
+            var uri = $"{DataUri}{ExtensionMime(options.Ext)};base64,{Convert.ToBase64String(bytes)}";
+            return $"{s[..start]}{uri}{s[(start + length)..]}";
         }
 
         public static bool TryGetDataPath(ReadOnlySpan<char> line, out int start, out int length)
@@ -45,6 +61,10 @@ namespace Calcpad.Core
                     return false;
             }
 
+            // An embedded source is not a path, and the dots in its MIME type would read as one.
+            if (line[i..].StartsWith(DataUri, StringComparison.OrdinalIgnoreCase))
+                return false;
+
             var dot = line.LastIndexOf('.');
             if (dot < i)
                 return false;
@@ -62,110 +82,6 @@ namespace Calcpad.Core
             start = i;
             length = end - i;
             return length > 0;
-        }
-
-        private static string DataLiteral(string[][] data, char type)
-        {
-            var rows = data?.Length ?? 0;
-            if (rows == 0 || (data[0]?.Length ?? 0) == 0)
-                return null;
-
-            if (type == 'V')
-                return Brackets(Flatten(data));
-
-            var cols = 0;
-            for (var i = 0; i < rows; ++i)
-                cols = Math.Max(cols, data[i]?.Length ?? 0);
-
-            if ((type == 'C' || type == 'D') && cols != 1 && rows != 1)
-                throw Exceptions.IndexOutOfRange($"{rows}, {cols}");
-
-            return type switch
-            {
-                'R' => Rows(data),
-                'C' => $"vec2col({Brackets(Axis(data))})",
-                'D' => $"vec2diag({Brackets(Axis(data))})",
-                'L' => $"copy({Rows(data)}; ltriang({rows}); 1; 1)",
-                'U' => $"copy({Rows(Skyline(data))}; utriang({rows}); 1; 1)",
-                'S' => $"copy({Rows(Skyline(data))}; symmetric({rows}); 1; 1)",
-                _ => throw Exceptions.InvalidType(type),
-            };
-        }
-
-        private static string Rows(string[][] data)
-        {
-            var sb = new StringBuilder("[");
-            for (int i = 0, n = data.Length; i < n; ++i)
-            {
-                if (i > 0)
-                    sb.Append('|');
-
-                var row = data[i];
-                // An empty row still has to hold something to keep the brackets valid;
-                // zero is what the missing cells are read as anyway.
-                if (row is null || row.Length == 0)
-                    sb.Append('0');
-                else
-                    AppendCells(sb, row);
-            }
-            return sb.Append(']').ToString();
-        }
-
-        private static string Brackets(string[] values)
-        {
-            var sb = new StringBuilder("[");
-            AppendCells(sb, values);
-            return sb.Append(']').ToString();
-        }
-
-        private static void AppendCells(StringBuilder sb, string[] cells)
-        {
-            for (int j = 0, m = cells.Length; j < m; ++j)
-            {
-                if (j > 0)
-                    sb.Append("; ");
-
-                var cell = cells[j];
-                sb.Append(string.IsNullOrWhiteSpace(cell) ? "0" : cell.Trim());
-            }
-        }
-
-        /// <summary>Every cell, row by row — how a <c>type=V</c> read fills its vector.</summary>
-        private static string[] Flatten(string[][] data)
-        {
-            var cells = new List<string>();
-            foreach (var row in data)
-                if (row is not null)
-                    cells.AddRange(row);
-
-            return [.. cells];
-        }
-
-        private static string[] Axis(string[][] data)
-        {
-            if (data.Length == 1)
-                return data[0];
-
-            var values = new string[data.Length];
-            for (var i = 0; i < data.Length; ++i)
-                values[i] = data[i] is { Length: > 0 } row ? row[0] : null;
-
-            return values;
-        }
-
-        private static string[][] Skyline(string[][] data)
-        {
-            var n = data.Length;
-            var shifted = new string[n][];
-            for (var i = 0; i < n; ++i)
-            {
-                var row = data[i];
-                var m = Math.Min(row?.Length ?? 0, n - i);
-                shifted[i] = new string[i + m];
-                for (var j = 0; j < m; ++j)
-                    shifted[i][i + j] = row[j];
-            }
-            return shifted;
         }
     }
 }

--- a/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.ReadWriteOptions.cs
+++ b/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.ReadWriteOptions.cs
@@ -4,6 +4,27 @@ namespace Calcpad.Core
 {
     public partial class ExpressionParser
     {
+        /// <summary>Marks a source that carries base64 data instead of naming a file</summary>
+        internal const string DataUri = "data:";
+        /// <summary>How much of a malformed source an error quotes, so a payload is not printed whole.</summary>
+        private const int DataUriErrorLength = 32;
+        private const string CsvMime = "text/csv";
+        private const string XlsxMime = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+        private const string XlsmMime = "application/vnd.ms-excel.sheet.macroEnabled.12";
+
+        /// <summary>The extension an embedded source stands for, read from its MIME type.</summary>
+        private static ReadOnlySpan<char> MimeExtension(ReadOnlySpan<char> mime) =>
+            mime.StartsWith(CsvMime, StringComparison.OrdinalIgnoreCase) ? "csv" :
+            mime.StartsWith(XlsxMime, StringComparison.OrdinalIgnoreCase) ? "xlsx" :
+            mime.StartsWith(XlsmMime, StringComparison.OrdinalIgnoreCase) ? "xlsm" :
+            throw Exceptions.FileFormatNotSupported(mime.ToString());
+
+        /// <summary>The MIME type a file is embedded under, from its extension.</summary>
+        internal static string ExtensionMime(ReadOnlySpan<char> ext) =>
+            ext.Equals("xlsx", StringComparison.OrdinalIgnoreCase) ? XlsxMime :
+            ext.Equals("xlsm", StringComparison.OrdinalIgnoreCase) ? XlsmMime :
+            CsvMime;
+
         private readonly ref struct ReadWriteOptions
         {
             internal readonly ReadOnlySpan<char> Name;
@@ -12,6 +33,8 @@ namespace Calcpad.Core
             internal readonly ReadOnlySpan<char> Sheet;
             internal readonly ReadOnlySpan<char> Start;
             internal readonly ReadOnlySpan<char> End;
+            /// <summary>The base64 payload of a "data:" source, which is read instead of a file.</summary>
+            internal readonly ReadOnlySpan<char> Data;
             internal readonly string FullPath;
             internal readonly char Type = 'R';
             internal readonly char Separator = ',';
@@ -44,7 +67,6 @@ namespace Calcpad.Core
             {
                 if (command > 0)
                     Type = 'N';
-
                 var ts = new TextSpan(s);
                 var i0 = 0;
                 var len = s.Length;
@@ -70,11 +92,33 @@ namespace Calcpad.Core
                     throw Exceptions.MissingFileName();
 
                 ts.Reset(i0);
-                var i1 = len;
-                while (i1 >= 0) { if (s[--i1] == '.') break; }
-                ts.ExpandTo(i1);
-                Path = ts.Cut();
-                ++i1;
+                int i1;
+                ReadOnlySpan<char> dataExt = default;
+                if (s[i0..].StartsWith(DataUri, StringComparison.OrdinalIgnoreCase))
+                {
+                    // Base64 holds none of the characters that delimit what follows the source,
+                    // so a sheet and a range are written after a payload as after a file name.
+                    var end = s[i0..].IndexOfAny(' ', '@', '!');
+                    i1 = end < 0 ? len : i0 + end;
+
+                    var uri = s[i0..i1];
+                    var comma = uri.IndexOf(',');
+                    // Data is a source to read, never a target to write to.
+                    if (comma < 0 || command > 0)
+                        throw Exceptions.InvalidSyntax(uri[..Math.Min(uri.Length, DataUriErrorLength)].ToString());
+
+                    dataExt = MimeExtension(uri[DataUri.Length..comma]);
+                    Data = uri[(comma + 1)..];
+                    i0 = i1 - 1;
+                }
+                else
+                {
+                    i1 = len;
+                    while (i1 >= 0) { if (s[--i1] == '.') break; }
+                    ts.ExpandTo(i1);
+                    Path = ts.Cut();
+                    ++i1;
+                }
                 ts.Reset(i1);
                 bool HasSheet = false, hasStart = false, hasEnd = false;
                 for (int i = i1; i < len; ++i)
@@ -111,6 +155,9 @@ namespace Calcpad.Core
                     if (c == ' ')
                         break;
                 }
+                if (!Data.IsEmpty)
+                    Ext = dataExt;
+
                 IsExcel = Ext.StartsWith("xls", StringComparison.OrdinalIgnoreCase);
                 if (!IsExcel)
                     hasStart = HasSheet;
@@ -126,14 +173,17 @@ namespace Calcpad.Core
                     Ext = ts.Cut();
                     IsExcel = Ext.StartsWith("xls", StringComparison.OrdinalIgnoreCase);
                 }
-                var rawPath = $"{Path}.{Ext}";
-                if (pathRoots != null && !pathRoots.TryExpand(rawPath, out rawPath, out var tokenError))
-                    throw new MathParserException(tokenError);
+                if (Data.IsEmpty)
+                {
+                    var rawPath = $"{Path}.{Ext}";
+                    if (pathRoots != null && !pathRoots.TryExpand(rawPath, out rawPath, out var tokenError))
+                        throw new MathParserException(tokenError);
 
-                var path = Environment.ExpandEnvironmentVariables(rawPath);
-                FullPath = sourceDir != null
-                    ? System.IO.Path.GetFullPath(path, sourceDir)
-                    : System.IO.Path.GetFullPath(path);
+                    var path = Environment.ExpandEnvironmentVariables(rawPath);
+                    FullPath = sourceDir != null
+                        ? System.IO.Path.GetFullPath(path, sourceDir)
+                        : System.IO.Path.GetFullPath(path);
+                }
                 Append = command == 2;
                 ++i0;
                 for (int i = 0; i < 2; ++i)

--- a/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.cs
+++ b/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.cs
@@ -22,6 +22,7 @@ namespace Calcpad.Core
         private bool _isVisible;
         private readonly Stack<bool> _visibilityStack = new();
         private readonly Stack<int> _outputModeStack = new();
+        private readonly Stack<MathParser.VariableSubstitutionOptions> _substitutionStack = new();
         private bool _isPausedByUser;
         private int _pauseCharCount;
         private bool _isMarkdownOn;
@@ -409,13 +410,20 @@ namespace Calcpad.Core
 
                             AppendHtmlLineStart(lineType, isIndent, htmlId);
                         }
-                        if (lineType == TokenTypes.Html && !string.IsNullOrEmpty(htmlId))
-                            tokens[0] = new Token(InsertAttribute(tokens[0].Value, htmlId), TokenTypes.Html);
+                        var htmlToken = lineType == TokenTypes.Html && !string.IsNullOrEmpty(htmlId)
+                            ? tokens[0]
+                            : null;
+                        if (htmlToken is not null)
+                            tokens[0] = new Token(InsertAttribute(htmlToken.Value, htmlId), TokenTypes.Html);
 
                         if (kwdLength > 0)
                             _sb.Append(_condition.ToHtml());
 
                         ParseTokens(tokens, true, getXml);
+                        // The list is the line's cache and a loop parses it again on every
+                        // pass, so the attributes have to come back out
+                        if (htmlToken is not null)
+                            tokens[0] = htmlToken;
                         if (_isVal != 1)
                             AppendHtmlLineEnd(lineType, keyword == Keyword.If);
 
@@ -501,6 +509,7 @@ namespace Calcpad.Core
                 _loops.Clear();
                 _isVal = 0;
                 _outputModeStack.Clear();
+                _substitutionStack.Clear();
                 _parser.SetVariable("Units", new RealValue(UnitsFactor()));
                 _previousKeyword = Keyword.None;
                 _isMarkdownOn = false;

--- a/Calcpad.OpenXml/ExcelData.cs
+++ b/Calcpad.OpenXml/ExcelData.cs
@@ -106,9 +106,26 @@ namespace Calcpad.OpenXml
 
         }
 
+        public static bool IsExcelFile(string ext) =>
+            ext.Equals("xlsx", StringComparison.OrdinalIgnoreCase) ||
+            ext.Equals("xlsm", StringComparison.OrdinalIgnoreCase);
+
         public static string[][] Read(string filepath, string sheetName, string rangeStart, string rangeEnd)
         {
             using SpreadsheetDocument document = SpreadsheetDocument.Open(filepath, false); // Open in read-only mode
+            return ReadFromDocument(document, sheetName, rangeStart, rangeEnd);
+        }
+
+        /// <summary>Reads a workbook that is held in memory rather than on disk — an embedded one.</summary>
+        public static string[][] ReadFromMemory(byte[] contentBytes, string sheetName, string rangeStart, string rangeEnd)
+        {
+            using var stream = new MemoryStream(contentBytes);
+            using SpreadsheetDocument document = SpreadsheetDocument.Open(stream, false);
+            return ReadFromDocument(document, sheetName, rangeStart, rangeEnd);
+        }
+
+        private static string[][] ReadFromDocument(SpreadsheetDocument document, string sheetName, string rangeStart, string rangeEnd)
+        {
             WorkbookPart wbPart = document.WorkbookPart ??
                 throw new InvalidOperationException("The Excel workbook is missing or not initialized.");
 


### PR DESCRIPTION
- Adding end directive for nosub, varsub, and novar
- Fixing bug where data-source-line would cascade in loops
- Adding base64 data reading and reading data from memory.
- Replacing fragile matrix definitions that replaced #read for portable .cpdz exports with base64 inlining.
- Adding max base64 data size to avoid memory issues.