### PR TITLE
Updating #write/#append to allow running calculations without writing files

### DIFF
--- a/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.DataExchange.cs
+++ b/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.DataExchange.cs
@@ -184,26 +184,31 @@ namespace Calcpad.Core
                 return ExcelData.Read(options.FullPath, sheet, start, end);
             }
 
-            internal static void Write(ReadWriteOptions options, string[][] data)
+            /// <summary>
+            /// The target is checked whether or not <paramref name="allowWrite"/> lets the write run,
+            /// so a deferred one reports what a real one would refuse.
+            /// </summary>
+            internal static void Write(ReadWriteOptions options, string[][] data, bool allowWrite)
             {
-                var fileName = $"{options.Path}.{options.Ext}";
-                if (fileName == ".")
+                if ($"{options.Path}.{options.Ext}" == ".")
                     throw Exceptions.MissingFileName();
 
-                var fullPath = options.FullPath;
-                var dir = Path.GetDirectoryName(fullPath);
+                var dir = Path.GetDirectoryName(options.FullPath);
                 if (!Directory.Exists(dir))
                     throw Exceptions.PathNotFound(dir);
+
+                if (options.IsExcel &&
+                    !options.Ext.Equals("xlsx", StringComparison.OrdinalIgnoreCase) &&
+                    !options.Ext.Equals("xlsm", StringComparison.OrdinalIgnoreCase))
+                    throw Exceptions.FileFormatNotSupported(options.Ext.ToString());
+
+                if (!allowWrite)
+                    return;
 
                 try
                 {
                     if (options.IsExcel)
-                    {
-                        if (!options.Ext.Equals("xlsx", StringComparison.OrdinalIgnoreCase) && !options.Ext.Equals("xlsm", StringComparison.OrdinalIgnoreCase))
-                            throw Exceptions.FileFormatNotSupported(options.Ext.ToString());
-
                         WriteExcel(options, data);
-                    }
                     else
                         WriteCSV(options, data);
                 }

--- a/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.Keywords.cs
+++ b/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.Keywords.cs
@@ -696,8 +696,7 @@ namespace Calcpad.Core
         }
         private void ParseKeywordPathRoot(ReadOnlySpan<char> s)
         {
-            // MacroParser already declared and validated this line against the folder of the file
-            // that wrote it — which this flattened text no longer identifies — so its answer wins.
+            // MacroParser already declared and validated this line against the folder of the file that wrote it.
             if (_hasInheritedPathRoots)
                 return;
 
@@ -932,9 +931,11 @@ namespace Calcpad.Core
                         return;
 
                     var m = _parser.GetMatrix(options.Name.ToString(), options.Type);
-                    DataExchange.Write(options, m);
+                    DataExchange.Write(options, m, AllowDataWrite);
+
                     if (_isVisible)
-                        ReportDataExchageResult(options, keyword == Keyword.Write ? "written to" : "appended to");
+                        ReportDataExchageResult(options, keyword == Keyword.Write ? "written to" : "appended to",
+                            AllowDataWrite);
                 }
             }
             else if (_isVisible)
@@ -944,17 +945,21 @@ namespace Calcpad.Core
             }
         }
 
-        private void ReportDataExchageResult(ReadWriteOptions options, string command)
+        private void ReportDataExchageResult(ReadWriteOptions options, string command, bool done = true)
         {
             _sb.Append($"<p{HtmlId}>")
                .Append($"Matrix <span class=\"eq\">{new HtmlWriter(Settings.Math, false).FormatVariable(options.Name.ToString(), string.Empty, true)}</span>")
-               .Append($" was successfully {command} ");
+               .Append(done ? $" was successfully {command} " : $" will be {command} ");
 
             // Embedded data has no file to name, and no link to it that would lead anywhere.
+            // Neither does a deferred write: the file may not exist yet.
             if (options.Data.IsEmpty)
             {
-                var url = $"file:///{options.FullPath.Replace('\\', '/')}";
-                _sb.Append($"<a href=\"{url}\">{options.Path}.{options.Ext}</a>");
+                var name = $"{options.Path}.{options.Ext}";
+                if (done)
+                    _sb.Append($"<a href=\"file:///{options.FullPath.Replace('\\', '/')}\">{name}</a>");
+                else
+                    _sb.Append(name);
             }
             else
                 _sb.Append("embedded data");

--- a/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.Portable.cs
+++ b/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.Portable.cs
@@ -4,15 +4,8 @@ namespace Calcpad.Core
 {
     public partial class ExpressionParser
     {
-        /// <summary>How much data a compiled worksheet may carry, per source and in total.</summary>
         public const int MaxEmbeddedDataSize = 10 * 1024 * 1024;
 
-        /// <summary>
-        /// The same <c>#read</c>, carrying the file it names instead of pointing at it. Only the
-        /// source is rewritten, so the recipient's read takes the path the author's did. The file
-        /// is read here too, so one that cannot be read stops the compile. <paramref name="size"/>
-        /// returns the bytes embedded, for the caller to total against the same limit.
-        /// </summary>
         public static string EmbedReadDirective(ReadOnlySpan<char> line, string sourceFilePath, PathRoots pathRoots, out int size)
         {
             size = 0;
@@ -46,8 +39,6 @@ namespace Calcpad.Core
             if (connector is null)
                 return false;
 
-            // The keyword, the variable name and the connector: one space-delimited token each,
-            // consumed exactly as ReadWriteOptions consumes them.
             var len = line.Length;
             var i = 0;
             for (var token = 0; token < 3; ++token)

--- a/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.ReadWriteOptions.cs
+++ b/Calcpad.Core/Parsers/ExpressionParser/ExpressionParser.ReadWriteOptions.cs
@@ -11,6 +11,7 @@ namespace Calcpad.Core
         private const string CsvMime = "text/csv";
         private const string XlsxMime = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
         private const string XlsmMime = "application/vnd.ms-excel.sheet.macroEnabled.12";
+        public bool AllowDataWrite { get; set; } = true;
 
         /// <summary>The extension an embedded source stands for, read from its MIME type.</summary>
         private static ReadOnlySpan<char> MimeExtension(ReadOnlySpan<char> mime) =>


### PR DESCRIPTION
Updating #write/#append to allow running calculations without writing files. This is needed for input forms and previews without UI overrides (where you don't want data that is impacted by #UI fields to get overridden by default values).

Also removed/trimmed some overly verbose comments.