### PR TITLE
Server stability fixes

### DIFF
--- a/Calcpad.Web/backend/API_SCHEMA.md
+++ b/Calcpad.Web/backend/API_SCHEMA.md
@@ -30,9 +30,11 @@ Launches that do not set the variable (a `dotnet run` during development, the sa
 
 ## Table of Contents
 
+- [GET /health](#get-health)
 - [POST /convert](#post-convert)
 - [GET /sample](#get-sample)
 - [GET /debug-crash](#get-debug-crash)
+- [GET /log-level, POST /log-level](#get-log-level-post-log-level)
 - [POST /pdf](#post-pdf)
 - [GET /pdf/health](#get-pdfhealth)
 - [GET /pdf/browser](#get-pdfbrowser)
@@ -51,6 +53,24 @@ Launches that do not set the variable (a `dotnet run` during development, the sa
 - [GET /snippets](#get-snippets)
 - [Usage Notes](#usage-notes)
 - [Environment Variables](#environment-variables)
+
+---
+
+## GET /health
+
+Liveness probe. Answered from inside the MVC pipeline, so a server that is bound but wedged
+(thread-pool starvation, a deadlock) fails it.
+
+Does no work, writes no log line, and is excluded from the hang watchdog's completed-request
+accounting, so polling it costs nothing and masks nothing. Requires `X-Calcpad-Token` like every
+other `/api` route. For the Chromium readiness of PDF export see [GET /pdf/health](#get-pdfhealth).
+
+**Response:**
+```json
+{
+  "status": "ok"
+}
+```
 
 ---
 
@@ -153,6 +173,44 @@ Deliberately crashes the server, to verify which failure paths `FileLogger` actu
 | mode | `background-thread` | `throw`, `background-thread`, `unobserved-task`, `stackoverflow`, `accessviolation`, `failfast`, or `exit` |
 
 **Response:** `202 Accepted` with `{ mode, note }` for the modes that schedule a crash, `400` for an unknown mode, or no response at all for the modes that terminate the process immediately.
+
+---
+
+## GET /log-level, POST /log-level
+
+Reads and sets the server's log verbosity for the running process. Unlike `debug-crash` this is
+served in every environment — quieting a shipped server is the point — and is covered by the
+`X-Calcpad-Token` check like any other `/api` route.
+
+Levels, least to most verbose: `error`, `warning` (the default), `information`, `verbose`.
+`verbose` adds a line per request, so it is noisy during normal editing, since the editor sends
+requests continuously. Crash and hang reports are written regardless of the level.
+
+**GET response:**
+```json
+{
+  "level": "warning",
+  "available": ["error", "warning", "information", "verbose"]
+}
+```
+
+**POST request:**
+```json
+{
+  "level": "verbose"
+}
+```
+
+Common aliases are accepted (`warn`, `info`, `trace`, `debug`, `off`). `off` maps to `error`, not
+to silence.
+
+**POST response:** `200` with `{ level }`, or `400` with `{ error, message, available }` for a level
+that does not parse. The level applies immediately and is not persisted — a restart returns to
+`CALCPAD_LOG_LEVEL`, or to `warning`.
+
+> Applies to Calcpad's own logging only. ASP.NET's framework logs are filtered once at startup
+> from `CALCPAD_LOG_LEVEL`, because the framework caches its log filters per category; to see
+> framework request lines, set the variable at launch rather than calling this endpoint.
 
 ---
 
@@ -1013,7 +1071,11 @@ GET /api/calcpad/snippets?category=Functions/Trigonometric
 | `CALCPAD_ENABLE_HTTPS` | `false` | Serves `https` instead of `http`. Only applies on the `CALCPAD_PORT` path |
 | `CALCPAD_API_TOKEN` | *(unset — unauthenticated)* | Per-launch token required in `X-Calcpad-Token` |
 | `CALCPAD_DETACHED` | *(unset)* | `1` disables the stdin-EOF watchdog and the default port file, so the server outlives its parent |
-| `CALCPAD_CONTENT_CACHE_SIZE_LIMIT` | `100` | Entries kept in the resolved-content cache shared by lint/highlight/definitions |
+| `CALCPAD_LOG_LEVEL` | `warning` | Startup verbosity: `error`, `warning`, `information` or `verbose`. Also sets the floor for ASP.NET's own logs. Change Calcpad's own at runtime via [POST /log-level](#get-log-level-post-log-level) |
+| `CALCPAD_LOG_DIR` | *(executable-adjacent `logs/`)* | Where `CalcpadServer-{date}.log` is written. Hosts set this when the install directory is read-only |
+| `CALCPAD_HANG_THRESHOLD_SECONDS` | `60` | Seconds without a completed request before the hang watchdog writes a report |
+| `CALCPAD_HANG_DUMP` | *(unset)* | `1` also spawns `createdump` when a hang is detected |
+| `CALCPAD_CONTENT_CACHE_SIZE_LIMIT` | `50000` | Flattened source lines budgeted across the resolved-content cache shared by lint/highlight/definitions |
 | `BROWSER_PATH` | *(auto-detect)* | Chromium-family executable for PDF export. Also `BrowserPath` in `appsettings.json` |
 | `ALLOW_CHROMIUM_DOWNLOAD` | `false` | Lets the render path download Chromium on its own. Also `AllowChromiumDownload` in `appsettings.json` |
 

--- a/Calcpad.Web/backend/API_SCHEMA.md
+++ b/Calcpad.Web/backend/API_SCHEMA.md
@@ -61,8 +61,9 @@ Launches that do not set the variable (a `dotnet run` during development, the sa
 Liveness probe. Answered from inside the MVC pipeline, so a server that is bound but wedged
 (thread-pool starvation, a deadlock) fails it.
 
-Does no work, writes no log line, and is excluded from the hang watchdog's completed-request
-accounting, so polling it costs nothing and masks nothing. Requires `X-Calcpad-Token` like every
+Does no work, logs nothing of its own, and is excluded from the hang watchdog's completed-request
+accounting, so polling it costs nothing and masks nothing. At `verbose` the framework's own
+request logging covers it like any other route. Requires `X-Calcpad-Token` like every
 other `/api` route. For the Chromium readiness of PDF export see [GET /pdf/health](#get-pdfhealth).
 
 **Response:**
@@ -208,9 +209,13 @@ to silence.
 that does not parse. The level applies immediately and is not persisted — a restart returns to
 `CALCPAD_LOG_LEVEL`, or to `warning`.
 
-> Applies to Calcpad's own logging only. ASP.NET's framework logs are filtered once at startup
-> from `CALCPAD_LOG_LEVEL`, because the framework caches its log filters per category; to see
-> framework request lines, set the variable at launch rather than calling this endpoint.
+ASP.NET's own logging obeys this too: the framework's providers are replaced with one that writes
+through `FileLogger`, so a change here takes effect on framework entries without a restart and
+they reach `CalcpadServer-{date}.log` alongside Calcpad's own. Framework entries are far denser
+than ours at the same nominal level, so its `Information` and `Debug` are both reported at
+`verbose`, and its `Trace` is dropped. Kestrel's `Now listening on: <url>` is the one exception,
+emitted at every level because the desktop host reads the bound URL out of stdout when the port
+file is unavailable.
 
 ---
 
@@ -1071,7 +1076,7 @@ GET /api/calcpad/snippets?category=Functions/Trigonometric
 | `CALCPAD_ENABLE_HTTPS` | `false` | Serves `https` instead of `http`. Only applies on the `CALCPAD_PORT` path |
 | `CALCPAD_API_TOKEN` | *(unset — unauthenticated)* | Per-launch token required in `X-Calcpad-Token` |
 | `CALCPAD_DETACHED` | *(unset)* | `1` disables the stdin-EOF watchdog and the default port file, so the server outlives its parent |
-| `CALCPAD_LOG_LEVEL` | `warning` | Startup verbosity: `error`, `warning`, `information` or `verbose`. Also sets the floor for ASP.NET's own logs. Change Calcpad's own at runtime via [POST /log-level](#get-log-level-post-log-level) |
+| `CALCPAD_LOG_LEVEL` | `warning` | Startup verbosity: `error`, `warning`, `information` or `verbose`. Covers ASP.NET's own logs too. Change it at runtime via [POST /log-level](#get-log-level-post-log-level); both hosts pass the user's setting here so startup entries honour it as well |
 | `CALCPAD_LOG_DIR` | *(executable-adjacent `logs/`)* | Where `CalcpadServer-{date}.log` is written. Hosts set this when the install directory is read-only |
 | `CALCPAD_HANG_THRESHOLD_SECONDS` | `60` | Seconds without a completed request before the hang watchdog writes a report |
 | `CALCPAD_HANG_DUMP` | *(unset)* | `1` also spawns `createdump` when a hang is detected |

--- a/Calcpad.Web/backend/ConsoleRelay.cs
+++ b/Calcpad.Web/backend/ConsoleRelay.cs
@@ -1,14 +1,14 @@
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Text;
 
 namespace Calcpad.Server
 {
     /// <summary>
     /// Bounded, drop-on-full relay to a stream that can block forever — our stdout, which hosts
-    /// attach as a pipe. When a parent stops draining it the OS buffer fills and the next write
-    /// blocks indefinitely without throwing; since <see cref="Console.SetOut"/> wraps its writer
-    /// in <c>TextWriter.Synchronized</c>, that parked thread holds a process-wide monitor and
-    /// every other thread that logs stops behind it. One dedicated thread owns the blocking
+    /// attach as a pipe. A parent that stops draining wedges the next write, and since
+    /// <see cref="Console.SetOut"/> wraps its writer in <c>TextWriter.Synchronized</c> that
+    /// parked thread takes every other logger with it. One dedicated thread owns the blocking
     /// write so callers never can.
     /// </summary>
     internal sealed class ConsoleRelay
@@ -19,10 +19,11 @@ namespace Calcpad.Server
         private readonly Stream _target;
         private int _dropped;
         private int _droppedTotal;
+        private int _pending;
 
         /// <summary>
-        /// Lines dropped since startup. Surfaced in the log file by <see cref="FileLogger"/>,
-        /// because the in-band notice below goes to the console nobody is reading.
+        /// Writes dropped since startup. Surfaced in the log file by <see cref="FileLogger"/>,
+        /// since the in-band notice below goes to the console nobody is reading.
         /// </summary>
         internal int DroppedTotal => Volatile.Read(ref _droppedTotal);
 
@@ -40,20 +41,35 @@ namespace Calcpad.Server
         internal bool Enqueue(string text)
         {
             if (string.IsNullOrEmpty(text)) return true;
+            Interlocked.Increment(ref _pending);
             if (_queue.TryAdd(text)) return true;
+            Interlocked.Decrement(ref _pending);
             Interlocked.Increment(ref _dropped);
             Interlocked.Increment(ref _droppedTotal);
             return false;
+        }
+
+        /// <summary>
+        /// Waits up to <paramref name="timeoutMs"/> for the relay thread to catch up. The thread
+        /// is a background one, so without this the final crash lines die with the process.
+        /// </summary>
+        internal void Drain(int timeoutMs)
+        {
+            var sw = Stopwatch.StartNew();
+            while (Volatile.Read(ref _pending) > 0 && sw.ElapsedMilliseconds < timeoutMs)
+                Thread.Sleep(5);
         }
 
         private void DrainLoop()
         {
             foreach (var entry in _queue.GetConsumingEnumerable())
             {
+                // Decremented after the write, not on dequeue, so Drain covers this entry too.
                 TryWrite(entry);
+                Interlocked.Decrement(ref _pending);
                 var dropped = Interlocked.Exchange(ref _dropped, 0);
                 if (dropped > 0)
-                    TryWrite($"[calcpad] {dropped} console line(s) dropped{Environment.NewLine}");
+                    TryWrite($"[calcpad] {dropped} console write(s) dropped{Environment.NewLine}");
             }
         }
 
@@ -71,9 +87,8 @@ namespace Calcpad.Server
 
     /// <summary>
     /// <see cref="TextWriter"/> face of <see cref="ConsoleRelay"/>, installed as
-    /// <see cref="Console.Out"/> so stray <c>Console.Write</c> calls anywhere in the process are
-    /// non-blocking too. The synchronized decorator still wraps this, but its lock is now only
-    /// held across a queue insert.
+    /// <see cref="Console.Out"/> so stray <c>Console.Write</c> calls are non-blocking too. The
+    /// synchronized decorator still wraps this, but its lock now spans only a queue insert.
     /// </summary>
     internal sealed class ConsoleRelayWriter(ConsoleRelay relay) : TextWriter
     {
@@ -88,7 +103,20 @@ namespace Calcpad.Server
             if (value != null) _relay.Enqueue(value);
         }
 
+        // Required: ASP.NET's console provider writes spans, and TextWriter's base overloads
+        // fan those out to one Write(char) — one queue slot, one flushed write — per character.
+        public override void Write(char[] buffer, int index, int count) =>
+            _relay.Enqueue(new string(buffer, index, count));
+
+        public override void Write(ReadOnlySpan<char> buffer) => _relay.Enqueue(new string(buffer));
+
         public override void WriteLine(string? value) => _relay.Enqueue((value ?? string.Empty) + Environment.NewLine);
+
+        public override void WriteLine(char[] buffer, int index, int count) =>
+            _relay.Enqueue(new string(buffer, index, count) + Environment.NewLine);
+
+        public override void WriteLine(ReadOnlySpan<char> buffer) =>
+            _relay.Enqueue(string.Concat(buffer, Environment.NewLine));
 
         public override void WriteLine() => _relay.Enqueue(Environment.NewLine);
     }

--- a/Calcpad.Web/backend/ConsoleRelay.cs
+++ b/Calcpad.Web/backend/ConsoleRelay.cs
@@ -1,0 +1,95 @@
+using System.Collections.Concurrent;
+using System.Text;
+
+namespace Calcpad.Server
+{
+    /// <summary>
+    /// Bounded, drop-on-full relay to a stream that can block forever — our stdout, which hosts
+    /// attach as a pipe. When a parent stops draining it the OS buffer fills and the next write
+    /// blocks indefinitely without throwing; since <see cref="Console.SetOut"/> wraps its writer
+    /// in <c>TextWriter.Synchronized</c>, that parked thread holds a process-wide monitor and
+    /// every other thread that logs stops behind it. One dedicated thread owns the blocking
+    /// write so callers never can.
+    /// </summary>
+    internal sealed class ConsoleRelay
+    {
+        private const int Capacity = 4096;
+
+        private readonly BlockingCollection<string> _queue = new(Capacity);
+        private readonly Stream _target;
+        private int _dropped;
+        private int _droppedTotal;
+
+        /// <summary>
+        /// Lines dropped since startup. Surfaced in the log file by <see cref="FileLogger"/>,
+        /// because the in-band notice below goes to the console nobody is reading.
+        /// </summary>
+        internal int DroppedTotal => Volatile.Read(ref _droppedTotal);
+
+        internal ConsoleRelay(Stream target)
+        {
+            _target = target;
+            new Thread(DrainLoop)
+            {
+                IsBackground = true,
+                Name = "calcpad-stdout-relay",
+            }.Start();
+        }
+
+        /// <summary>Queues text for the relay thread. Never blocks; false if it was dropped.</summary>
+        internal bool Enqueue(string text)
+        {
+            if (string.IsNullOrEmpty(text)) return true;
+            if (_queue.TryAdd(text)) return true;
+            Interlocked.Increment(ref _dropped);
+            Interlocked.Increment(ref _droppedTotal);
+            return false;
+        }
+
+        private void DrainLoop()
+        {
+            foreach (var entry in _queue.GetConsumingEnumerable())
+            {
+                TryWrite(entry);
+                var dropped = Interlocked.Exchange(ref _dropped, 0);
+                if (dropped > 0)
+                    TryWrite($"[calcpad] {dropped} console line(s) dropped{Environment.NewLine}");
+            }
+        }
+
+        private void TryWrite(string text)
+        {
+            try
+            {
+                var bytes = Encoding.UTF8.GetBytes(text);
+                _target.Write(bytes, 0, bytes.Length);
+                _target.Flush();
+            }
+            catch { /* console closed or pipe broken; the log file is the source of truth */ }
+        }
+    }
+
+    /// <summary>
+    /// <see cref="TextWriter"/> face of <see cref="ConsoleRelay"/>, installed as
+    /// <see cref="Console.Out"/> so stray <c>Console.Write</c> calls anywhere in the process are
+    /// non-blocking too. The synchronized decorator still wraps this, but its lock is now only
+    /// held across a queue insert.
+    /// </summary>
+    internal sealed class ConsoleRelayWriter(ConsoleRelay relay) : TextWriter
+    {
+        private readonly ConsoleRelay _relay = relay;
+
+        public override Encoding Encoding => Encoding.UTF8;
+
+        public override void Write(char value) => _relay.Enqueue(value.ToString());
+
+        public override void Write(string? value)
+        {
+            if (value != null) _relay.Enqueue(value);
+        }
+
+        public override void WriteLine(string? value) => _relay.Enqueue((value ?? string.Empty) + Environment.NewLine);
+
+        public override void WriteLine() => _relay.Enqueue(Environment.NewLine);
+    }
+}

--- a/Calcpad.Web/backend/Controllers/CalcpadController.cs
+++ b/Calcpad.Web/backend/Controllers/CalcpadController.cs
@@ -35,6 +35,12 @@ namespace Calcpad.Server.Controllers
             _environment = environment;
         }
 
+        /// <summary>
+        /// Liveness probe. Does no work and writes no log line, since clients poll it.
+        /// </summary>
+        [HttpGet("health")]
+        public IActionResult Health() => Ok(new { status = "ok" });
+
         [HttpPost("convert")]
         public IActionResult ConvertToHtml(
             [FromBody] CalcpadRequest request, CancellationToken cancellationToken, [FromQuery] bool unwrap = false)
@@ -275,6 +281,44 @@ namespace Calcpad.Server.Controllers
         private static IActionResult Recurse(int depth) => Recurse(depth + 1);
 
         /// <summary>
+        /// The server's current log verbosity. Reveals a <c>CALCPAD_LOG_LEVEL</c> set outside
+        /// the app, and lets a client show the effective level rather than its own stored one.
+        /// </summary>
+        [HttpGet("log-level")]
+        public IActionResult GetLogLevel()
+        {
+            return Ok(new
+            {
+                level = FileLogger.MinLevel.ToString().ToLowerInvariant(),
+                available = FileLogger.LevelNames
+            });
+        }
+
+        /// <summary>
+        /// Sets log verbosity for the running process. Not gated to Development — quieting a
+        /// shipped server is the point — and the token check covers it like any /api route.
+        /// </summary>
+        [HttpPost("log-level")]
+        public IActionResult SetLogLevel([FromBody] LogLevelRequest request)
+        {
+            var parsed = FileLogger.ParseLevel(request?.Level);
+            if (parsed is null)
+            {
+                return BadRequest(new
+                {
+                    error = "Unknown log level",
+                    message = $"'{request?.Level}' is not a log level.",
+                    available = FileLogger.LevelNames
+                });
+            }
+
+            FileLogger.MinLevel = parsed.Value;
+            // After the assignment, so raising the level records itself.
+            FileLogger.LogInfo("Log level changed", parsed.Value.ToString());
+            return Ok(new { level = parsed.Value.ToString().ToLowerInvariant() });
+        }
+
+        /// <summary>
         /// Generate PDF from HTML content using Playwright and PDFsharp.
         /// </summary>
         [HttpPost("pdf")]
@@ -285,11 +329,11 @@ namespace Calcpad.Server.Controllers
                 if (string.IsNullOrWhiteSpace(request.Html))
                     return BadRequest(new { error = "HTML content is required" });
 
-                FileLogger.LogInfo("PDF generation request received", $"HTML length: {request.Html.Length}");
+                FileLogger.LogVerbose("PDF generation request received", $"HTML length: {request.Html.Length}");
 
                 var pdfBytes = await _pdfService.GeneratePdfAsync(request.Html, request.Options);
 
-                FileLogger.LogInfo("PDF generated successfully", $"Size: {pdfBytes.Length} bytes");
+                FileLogger.LogVerbose("PDF generated successfully", $"Size: {pdfBytes.Length} bytes");
 
                 return File(pdfBytes, "application/pdf", "document.pdf");
             }
@@ -384,7 +428,7 @@ namespace Calcpad.Server.Controllers
                 writer.Convert(html, ms);
                 var bytes = ms.ToArray();
 
-                FileLogger.LogInfo("DOCX generated successfully", $"Size: {bytes.Length} bytes");
+                FileLogger.LogVerbose("DOCX generated successfully", $"Size: {bytes.Length} bytes");
                 return File(
                     bytes,
                     "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
@@ -416,7 +460,7 @@ namespace Calcpad.Server.Controllers
                 // A stale request whose client already gave up shouldn't do this work at all.
                 cancellationToken.ThrowIfCancellationRequested();
 
-                FileLogger.LogInfo("Highlight request received", $"Length: {request.Content.Length}");
+                FileLogger.LogVerbose("Highlight request received", $"Length: {request.Content.Length}");
 
                 var tokenizer = new CalcpadTokenizer();
 
@@ -480,7 +524,7 @@ namespace Calcpad.Server.Controllers
 
                 cancellationToken.ThrowIfCancellationRequested();
 
-                FileLogger.LogInfo("Lint request received", "Length: " + request.Content.Length);
+                FileLogger.LogVerbose("Lint request received", "Length: " + request.Content.Length);
 
                 var linter = new CalcpadLinter();
 
@@ -535,7 +579,7 @@ namespace Calcpad.Server.Controllers
 
                 cancellationToken.ThrowIfCancellationRequested();
 
-                FileLogger.LogInfo("Definitions request received", "Length: " + request.Content.Length);
+                FileLogger.LogVerbose("Definitions request received", "Length: " + request.Content.Length);
 
                 var staged = _contentResolutionCache.GetOrResolve(request.Content, request.SourceFilePath);
 
@@ -710,7 +754,7 @@ namespace Calcpad.Server.Controllers
         {
             try
             {
-                FileLogger.LogInfo("Snippets request received", "Category: " + (category ?? "all"));
+                FileLogger.LogVerbose("Snippets request received", "Category: " + (category ?? "all"));
 
                 SnippetItem[] snippets;
                 if (string.IsNullOrWhiteSpace(category))
@@ -850,6 +894,12 @@ namespace Calcpad.Server.Controllers
     {
         /// <summary>Prettified source code</summary>
         public string Content { get; set; } = string.Empty;
+    }
+
+    public class LogLevelRequest
+    {
+        /// <summary>One of error, warning, information, verbose. Common aliases accepted.</summary>
+        public string? Level { get; set; }
     }
 
     public class CalcpadRequest

--- a/Calcpad.Web/backend/FileLogger.cs
+++ b/Calcpad.Web/backend/FileLogger.cs
@@ -6,6 +6,18 @@ using System.Text;
 namespace Calcpad.Server
 {
     /// <summary>
+    /// Verbosity of a log entry. Ordered most-severe-first so filtering is a single
+    /// <c>&gt;</c> test against <see cref="FileLogger.MinLevel"/>.
+    /// </summary>
+    public enum LogLevel
+    {
+        Error = 0,
+        Warning = 1,
+        Information = 2,
+        Verbose = 3,
+    }
+
+    /// <summary>
     /// Process-wide log sink. Every request logs before doing any work, so a stall here wedges
     /// every endpoint at once. Both outputs are therefore decoupled from the caller and from each
     /// other — stdout via <see cref="ConsoleRelay"/>, the file via a bounded queue and its own
@@ -23,6 +35,11 @@ namespace Calcpad.Server
         private static readonly ConsoleRelay _stdoutRelay = new(Console.OpenStandardOutput());
         private static readonly ConsoleRelay _stderrRelay = new(Console.OpenStandardError());
 
+        // A field initializer, not the static ctor body: this has to be set before the ctor
+        // logs its own first entry.
+        private static readonly string? _rawEnvLevel = Environment.GetEnvironmentVariable("CALCPAD_LOG_LEVEL");
+        private static volatile LogLevel _minLevel = ParseLevel(_rawEnvLevel) ?? LogLevel.Warning;
+
         private static string? _logFilePath;
         private static FileStream? _stream;
         private static bool _dirty;
@@ -30,6 +47,39 @@ namespace Calcpad.Server
         private static int _reportedConsoleDrops;
         private static long _lastConsoleDropReportTicks;
         private const int ConsoleDropReportIntervalMs = 5000;
+
+        /// <summary>
+        /// Entries more verbose than this are dropped. Set from <c>CALCPAD_LOG_LEVEL</c> at
+        /// startup and from the <c>/api/calcpad/log-level</c> endpoint at runtime.
+        /// </summary>
+        public static LogLevel MinLevel
+        {
+            get => _minLevel;
+            set => _minLevel = value;
+        }
+
+        public static readonly string[] LevelNames = ["error", "warning", "information", "verbose"];
+
+        /// <summary>
+        /// Maps a level name to a <see cref="LogLevel"/>, accepting common aliases. Null when
+        /// nothing matched, so callers choose their own default.
+        /// </summary>
+        public static LogLevel? ParseLevel(string? value) => value?.Trim().ToLowerInvariant() switch
+        {
+            "verbose" or "trace" or "debug" or "all" => LogLevel.Verbose,
+            "information" or "info" => LogLevel.Information,
+            "warning" or "warn" => LogLevel.Warning,
+            "error" or "err" or "critical" or "fatal" or "none" or "off" => LogLevel.Error,
+            _ => null,
+        };
+
+        private static string TagFor(LogLevel level) => level switch
+        {
+            LogLevel.Error => "ERROR",
+            LogLevel.Warning => "WARN",
+            LogLevel.Information => "INFO",
+            _ => "TRACE",
+        };
 
         static FileLogger()
         {
@@ -80,7 +130,12 @@ namespace Calcpad.Server
             };
             drain.Start();
 
-            WriteLog("INFO", "Logger initialized", $"Log file: {_logFilePath}");
+            // Warning, so a typo in CALCPAD_LOG_LEVEL is still visible at the default level.
+            if (!string.IsNullOrWhiteSpace(_rawEnvLevel) && ParseLevel(_rawEnvLevel) is null)
+                LogWarning($"Unrecognized CALCPAD_LOG_LEVEL '{_rawEnvLevel}' — using {_minLevel}",
+                    $"Expected one of: {string.Join(", ", LevelNames)}");
+
+            LogVerbose("Logger initialized", $"Log file: {_logFilePath}, level: {_minLevel}");
         }
 
         /// <summary>
@@ -93,14 +148,19 @@ namespace Calcpad.Server
             Console.SetError(new ConsoleRelayWriter(_stderrRelay));
         }
 
+        public static void LogVerbose(string message, string? details = null)
+        {
+            WriteLog(LogLevel.Verbose, message, details);
+        }
+
         public static void LogInfo(string message, string? details = null)
         {
-            WriteLog("INFO", message, details);
+            WriteLog(LogLevel.Information, message, details);
         }
 
         public static void LogWarning(string message, string? details = null)
         {
-            WriteLog("WARN", message, details);
+            WriteLog(LogLevel.Warning, message, details);
         }
 
         public static void LogError(string message, Exception? exception = null)
@@ -108,7 +168,7 @@ namespace Calcpad.Server
             var details = exception != null ?
                 $"Exception: {exception.GetType().Name}\nMessage: {exception.Message}\nStackTrace: {exception.StackTrace}" :
                 null;
-            WriteLog("ERROR", message, details);
+            WriteLog(LogLevel.Error, message, details);
         }
 
         public static void LogCrash(Exception exception, string context = "Application")
@@ -164,9 +224,14 @@ namespace Calcpad.Server
             catch { /* never throw from the logger */ }
         }
 
-        private static void WriteLog(string level, string message, string? details = null)
+        /// <summary>
+        /// The single funnel for level-bearing entries, and so the only place the filter lives.
+        /// <see cref="LogCrash"/> and <see cref="WriteDirect"/> bypass it deliberately.
+        /// </summary>
+        private static void WriteLog(LogLevel level, string message, string? details = null)
         {
-            var entry = Format(level, message, details);
+            if (level > _minLevel) return;
+            var entry = Format(TagFor(level), message, details);
             _stdoutRelay.Enqueue(entry);
             QueueForFile(entry);
         }

--- a/Calcpad.Web/backend/FileLogger.cs
+++ b/Calcpad.Web/backend/FileLogger.cs
@@ -157,6 +157,17 @@ namespace Calcpad.Server
             WriteLog(LogLevel.Warning, message, details);
         }
 
+        /// <summary>
+        /// Emits at Information regardless of <see cref="MinLevel"/>. Only for the bound-URL line
+        /// the hosts parse out of stdout to locate a random-port server.
+        /// </summary>
+        public static void LogAlways(string message, string? details = null)
+        {
+            var entry = Format("INFO", message, details);
+            _stdoutRelay.Enqueue(entry);
+            QueueForFile(entry);
+        }
+
         public static void LogError(string message, Exception? exception = null)
         {
             var details = exception != null ?

--- a/Calcpad.Web/backend/FileLogger.cs
+++ b/Calcpad.Web/backend/FileLogger.cs
@@ -1,13 +1,36 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Reflection;
 using System.Text;
 
 namespace Calcpad.Server
 {
+    /// <summary>
+    /// Process-wide log sink. Every request logs before doing any work, so a stall here wedges
+    /// every endpoint at once. Both outputs are therefore decoupled from the caller and from each
+    /// other — stdout via <see cref="ConsoleRelay"/>, the file via a bounded queue and its own
+    /// drain thread — so neither a stalled pipe nor a stalled disk can park a request thread, and
+    /// a stalled pipe still leaves us the log file. <see cref="LogCrash"/> is the exception: it
+    /// writes synchronously and fsyncs, to survive a kill the drain thread would not.
+    /// </summary>
     public static class FileLogger
     {
-        private static readonly object _lock = new object();
+        private const int FileQueueCapacity = 4096;
+        private const int FlushIntervalMs = 1000;
+
+        private static readonly BlockingCollection<string> _fileQueue = new(FileQueueCapacity);
+        private static readonly object _fileLock = new();
+        private static readonly ConsoleRelay _stdoutRelay = new(Console.OpenStandardOutput());
+        private static readonly ConsoleRelay _stderrRelay = new(Console.OpenStandardError());
+
         private static string? _logFilePath;
-        
+        private static FileStream? _stream;
+        private static bool _dirty;
+        private static int _fileDropped;
+        private static int _reportedConsoleDrops;
+        private static long _lastConsoleDropReportTicks;
+        private const int ConsoleDropReportIntervalMs = 5000;
+
         static FileLogger()
         {
             try
@@ -35,45 +58,59 @@ namespace Calcpad.Server
                 Directory.CreateDirectory(logsDir);
                 var timestamp = DateTime.Now.ToString("yyyyMMdd");
                 _logFilePath = Path.Combine(logsDir, $"CalcpadServer-{timestamp}.log");
-                
-                // Write initial log entry
-                WriteLog("INFO", "Logger initialized", $"Log file: {_logFilePath}");
             }
             catch (Exception ex)
             {
-                // If we can't initialize logging, try a fallback location
                 try
                 {
-                    _logFilePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Desktop), 
+                    _logFilePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Desktop),
                         $"CalcpadServer-{DateTime.Now:yyyyMMdd}.log");
-                    WriteLog("WARN", "Logger fallback location", $"Using desktop: {_logFilePath}, Error: {ex.Message}");
+                    QueueForFile(Format("WARN", "Logger fallback location", $"Error: {ex.Message}"));
                 }
                 catch
                 {
-                    // If all else fails, we'll just skip logging
                     _logFilePath = null;
                 }
             }
+
+            var drain = new Thread(FileDrainLoop)
+            {
+                IsBackground = true,
+                Name = "calcpad-log-writer",
+            };
+            drain.Start();
+
+            WriteLog("INFO", "Logger initialized", $"Log file: {_logFilePath}");
         }
-        
+
+        /// <summary>
+        /// Routes <see cref="Console"/> through the non-blocking relays. Call once at startup,
+        /// before anything else writes to the console.
+        /// </summary>
+        public static void InstallConsoleRelay()
+        {
+            Console.SetOut(new ConsoleRelayWriter(_stdoutRelay));
+            Console.SetError(new ConsoleRelayWriter(_stderrRelay));
+        }
+
         public static void LogInfo(string message, string? details = null)
         {
             WriteLog("INFO", message, details);
         }
-        
+
         public static void LogWarning(string message, string? details = null)
         {
             WriteLog("WARN", message, details);
         }
-        
+
         public static void LogError(string message, Exception? exception = null)
         {
-            var details = exception != null ? 
-                $"Exception: {exception.GetType().Name}\nMessage: {exception.Message}\nStackTrace: {exception.StackTrace}" : 
+            var details = exception != null ?
+                $"Exception: {exception.GetType().Name}\nMessage: {exception.Message}\nStackTrace: {exception.StackTrace}" :
                 null;
             WriteLog("ERROR", message, details);
         }
-        
+
         public static void LogCrash(Exception exception, string context = "Application")
         {
             var sb = new StringBuilder();
@@ -83,8 +120,7 @@ namespace Calcpad.Server
             sb.AppendLine($"Message: {exception.Message}");
             sb.AppendLine($"Stack Trace:");
             sb.AppendLine(exception.StackTrace);
-            
-            // Include inner exceptions
+
             var innerEx = exception.InnerException;
             var level = 1;
             while (innerEx != null)
@@ -97,72 +133,175 @@ namespace Calcpad.Server
                 innerEx = innerEx.InnerException;
                 level++;
             }
-            
-            sb.AppendLine($"=== END CRASH REPORT ===");
-            
-            WriteLog("CRASH", "Application crashed", sb.ToString());
 
-            // Console line is captured by the VS Code extension's stdout pipe
-            // and surfaced in the server debug channel. The full report is
-            // already in the file via WriteLog above.
+            sb.AppendLine($"=== END CRASH REPORT ===");
+
+            WriteDirect(Format("CRASH", "Application crashed", sb.ToString()));
+
             try { Console.WriteLine($"CRASH: {exception.Message} (details: {_logFilePath})"); }
             catch { /* Ignore console errors */ }
         }
 
+        /// <summary>
+        /// Writes <paramref name="body"/> straight to the log file, bypassing the queue, and
+        /// fsyncs. For diagnostics that must survive a hard kill or a wedged drain thread.
+        /// </summary>
+        public static void WriteDirect(string body)
+        {
+            if (string.IsNullOrEmpty(_logFilePath)) return;
+            try
+            {
+                lock (_fileLock)
+                {
+                    var stream = EnsureStream();
+                    if (stream == null) return;
+                    var bytes = Encoding.UTF8.GetBytes(body);
+                    stream.Write(bytes, 0, bytes.Length);
+                    stream.Flush(flushToDisk: true);
+                    _dirty = false;
+                }
+            }
+            catch { /* never throw from the logger */ }
+        }
+
         private static void WriteLog(string level, string message, string? details = null)
+        {
+            var entry = Format(level, message, details);
+            _stdoutRelay.Enqueue(entry);
+            QueueForFile(entry);
+        }
+
+        private static string Format(string level, string message, string? details)
         {
             var timestamp = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff");
             var header = $"[{timestamp}] [{level}] {message}";
-            var logEntry = string.IsNullOrEmpty(details)
+            return string.IsNullOrEmpty(details)
                 ? header + Environment.NewLine
                 : header + Environment.NewLine + details + Environment.NewLine;
+        }
 
-            // Echo to stdout so the VS Code extension's stdout pipe surfaces every log entry in
-            // the server debug channel; the console is auto-flushed (see Program.cs), so entries
-            // appear in real time. Errors here are ignored — the file write below is the source
-            // of truth.
-            try { Console.Write(logEntry); } catch { /* console may be closed */ }
+        private static void QueueForFile(string entry)
+        {
+            if (string.IsNullOrEmpty(_logFilePath)) return;
+            if (!_fileQueue.TryAdd(entry))
+                Interlocked.Increment(ref _fileDropped);
+        }
 
-            if (string.IsNullOrEmpty(_logFilePath))
-                return;
-
-            try
+        private static void FileDrainLoop()
+        {
+            while (true)
             {
-                lock (_lock)
+                try
                 {
-                    var bytes = Encoding.UTF8.GetBytes(logEntry);
+                    if (_fileQueue.TryTake(out var entry, FlushIntervalMs))
+                    {
+                        AppendToFile(entry);
 
-                    // WriteThrough bypasses the OS write cache and Flush(true) calls
-                    // FlushFileBuffers, so entries survive even a hard process kill
-                    // (StackOverflow, FailFast). Cost: ~1ms per entry.
-                    using var fs = new FileStream(
-                        _logFilePath,
-                        FileMode.Append,
-                        FileAccess.Write,
-                        FileShare.Read,
-                        bufferSize: 4096,
-                        FileOptions.WriteThrough);
-                    fs.Write(bytes, 0, bytes.Length);
-                    fs.Flush(flushToDisk: true);
+                        var dropped = Interlocked.Exchange(ref _fileDropped, 0);
+                        if (dropped > 0)
+                            AppendToFile(Format("WARN", $"{dropped} log entries dropped — writer was not keeping up", null));
+
+                        ReportConsoleDrops();
+
+                        // Flush at the end of each burst rather than only when idle, so a hard
+                        // kill loses at most the entries still queued behind this one.
+                        if (_fileQueue.Count == 0) FlushFile();
+                    }
+                    else
+                    {
+                        ReportConsoleDrops();
+                        FlushFile();
+                    }
                 }
-            }
-            catch
-            {
-                // If logging fails, we can't do much about it
-                // Don't throw exceptions from the logger
+                catch { /* a dead drain thread silently loses all logging */ }
             }
         }
 
         /// <summary>
-        /// Forces all buffered log writes to disk. Call from shutdown handlers
-        /// (ProcessExit, etc.) to ensure final entries survive process termination.
+        /// Mirrors stdout-relay drops into the log file. A stalled pipe reader is exactly when
+        /// the relay's own in-band notice cannot be seen.
+        /// </summary>
+        private static void ReportConsoleDrops()
+        {
+            var total = _stdoutRelay.DroppedTotal;
+            if (total == _reportedConsoleDrops) return;
+            // Throttled: drops arrive in floods, and one warning per drain pass would itself
+            // become the bulk of the log.
+            if (Environment.TickCount64 - _lastConsoleDropReportTicks < ConsoleDropReportIntervalMs) return;
+            _lastConsoleDropReportTicks = Environment.TickCount64;
+            _reportedConsoleDrops = total;
+            AppendToFile(Format("WARN", $"{total} console line(s) dropped since start — stdout reader is not draining", null));
+        }
+
+        private static void AppendToFile(string entry)
+        {
+            lock (_fileLock)
+            {
+                var stream = EnsureStream();
+                if (stream == null) return;
+                var bytes = Encoding.UTF8.GetBytes(entry);
+                stream.Write(bytes, 0, bytes.Length);
+                _dirty = true;
+            }
+        }
+
+        private static void FlushFile()
+        {
+            lock (_fileLock)
+            {
+                if (!_dirty || _stream == null) return;
+                try
+                {
+                    _stream.Flush();
+                    _dirty = false;
+                }
+                catch { /* retried on the next tick */ }
+            }
+        }
+
+        private static FileStream? EnsureStream()
+        {
+            if (_stream != null) return _stream;
+            if (string.IsNullOrEmpty(_logFilePath)) return null;
+            try
+            {
+                // ReadWrite share so a second instance can hold an append handle the same day,
+                // matching the interleaving the old open-per-entry write allowed.
+                _stream = new FileStream(
+                    _logFilePath,
+                    FileMode.Append,
+                    FileAccess.Write,
+                    FileShare.ReadWrite,
+                    bufferSize: 16384,
+                    FileOptions.None);
+            }
+            catch
+            {
+                _stream = null;
+            }
+            return _stream;
+        }
+
+        /// <summary>
+        /// Drains anything still queued and forces it to disk. Call from shutdown handlers
+        /// (ProcessExit, etc.) so final entries survive process termination.
         /// </summary>
         public static void Flush()
         {
-            // WriteLog already opens/writes/flushes/closes per entry, so nothing
-            // is buffered between calls. This method exists so callers don't have
-            // to know that — and so behavior stays correct if we ever switch to a
-            // long-lived stream.
+            var deadline = Stopwatch.StartNew();
+            while (_fileQueue.Count > 0 && deadline.ElapsedMilliseconds < 2000)
+                Thread.Sleep(10);
+
+            lock (_fileLock)
+            {
+                if (_stream == null) return;
+                try
+                {
+                    _stream.Flush(flushToDisk: true);
+                    _dirty = false;
+                }
+                catch { /* best-effort */ }
+            }
         }
 
         public static string? GetLogFilePath() => _logFilePath;

--- a/Calcpad.Web/backend/FileLogger.cs
+++ b/Calcpad.Web/backend/FileLogger.cs
@@ -6,8 +6,7 @@ using System.Text;
 namespace Calcpad.Server
 {
     /// <summary>
-    /// Verbosity of a log entry. Ordered most-severe-first so filtering is a single
-    /// <c>&gt;</c> test against <see cref="FileLogger.MinLevel"/>.
+    /// Verbosity of a log entry. Most-severe-first, so filtering is one <c>&gt;</c> test.
     /// </summary>
     public enum LogLevel
     {
@@ -18,12 +17,10 @@ namespace Calcpad.Server
     }
 
     /// <summary>
-    /// Process-wide log sink. Every request logs before doing any work, so a stall here wedges
-    /// every endpoint at once. Both outputs are therefore decoupled from the caller and from each
-    /// other — stdout via <see cref="ConsoleRelay"/>, the file via a bounded queue and its own
-    /// drain thread — so neither a stalled pipe nor a stalled disk can park a request thread, and
-    /// a stalled pipe still leaves us the log file. <see cref="LogCrash"/> is the exception: it
-    /// writes synchronously and fsyncs, to survive a kill the drain thread would not.
+    /// Process-wide log sink. Every request logs before doing work, so a stall here wedges every
+    /// endpoint at once; both outputs are therefore decoupled from the caller and from each other
+    /// — stdout via <see cref="ConsoleRelay"/>, the file via its own queue and drain thread.
+    /// <see cref="LogCrash"/> is the exception: synchronous and fsynced, to survive a kill.
     /// </summary>
     public static class FileLogger
     {
@@ -35,8 +32,7 @@ namespace Calcpad.Server
         private static readonly ConsoleRelay _stdoutRelay = new(Console.OpenStandardOutput());
         private static readonly ConsoleRelay _stderrRelay = new(Console.OpenStandardError());
 
-        // A field initializer, not the static ctor body: this has to be set before the ctor
-        // logs its own first entry.
+        // Field initializers, not ctor body: set before the ctor logs its own first entry.
         private static readonly string? _rawEnvLevel = Environment.GetEnvironmentVariable("CALCPAD_LOG_LEVEL");
         private static volatile LogLevel _minLevel = ParseLevel(_rawEnvLevel) ?? LogLevel.Warning;
 
@@ -44,13 +40,14 @@ namespace Calcpad.Server
         private static FileStream? _stream;
         private static bool _dirty;
         private static int _fileDropped;
+        private static int _filePending;
         private static int _reportedConsoleDrops;
         private static long _lastConsoleDropReportTicks;
         private const int ConsoleDropReportIntervalMs = 5000;
 
         /// <summary>
-        /// Entries more verbose than this are dropped. Set from <c>CALCPAD_LOG_LEVEL</c> at
-        /// startup and from the <c>/api/calcpad/log-level</c> endpoint at runtime.
+        /// Entries more verbose than this are dropped. From <c>CALCPAD_LOG_LEVEL</c> at startup,
+        /// then <c>/api/calcpad/log-level</c> at runtime.
         /// </summary>
         public static LogLevel MinLevel
         {
@@ -61,8 +58,8 @@ namespace Calcpad.Server
         public static readonly string[] LevelNames = ["error", "warning", "information", "verbose"];
 
         /// <summary>
-        /// Maps a level name to a <see cref="LogLevel"/>, accepting common aliases. Null when
-        /// nothing matched, so callers choose their own default.
+        /// Maps a level name, accepting common aliases. Null when nothing matched, so callers
+        /// choose their own default.
         /// </summary>
         public static LogLevel? ParseLevel(string? value) => value?.Trim().ToLowerInvariant() switch
         {
@@ -85,10 +82,8 @@ namespace Calcpad.Server
         {
             try
             {
-                // Host apps (Tauri AppImage, VS Code extension) set CALCPAD_LOG_DIR
-                // when the executable dir is read-only (AppImage FUSE mount, MSI
-                // Program Files, etc.). Fall back to executable-adjacent logs/ for
-                // dev runs and other embedders that don't set it.
+                // Hosts set CALCPAD_LOG_DIR when the executable dir is read-only (AppImage FUSE
+                // mount, Program Files). Executable-adjacent logs/ otherwise.
                 var overrideDir = Environment.GetEnvironmentVariable("CALCPAD_LOG_DIR");
                 string logsDir;
                 if (!string.IsNullOrEmpty(overrideDir))
@@ -139,8 +134,7 @@ namespace Calcpad.Server
         }
 
         /// <summary>
-        /// Routes <see cref="Console"/> through the non-blocking relays. Call once at startup,
-        /// before anything else writes to the console.
+        /// Routes <see cref="Console"/> through the non-blocking relays. Call once, first.
         /// </summary>
         public static void InstallConsoleRelay()
         {
@@ -198,13 +192,18 @@ namespace Calcpad.Server
 
             WriteDirect(Format("CRASH", "Application crashed", sb.ToString()));
 
-            try { Console.WriteLine($"CRASH: {exception.Message} (details: {_logFilePath})"); }
+            // Drained here, not at ProcessExit: an unhandled rethrow skips exit handlers.
+            try
+            {
+                Console.WriteLine($"CRASH: {exception.Message} (details: {_logFilePath})");
+                _stdoutRelay.Drain(1000);
+            }
             catch { /* Ignore console errors */ }
         }
 
         /// <summary>
-        /// Writes <paramref name="body"/> straight to the log file, bypassing the queue, and
-        /// fsyncs. For diagnostics that must survive a hard kill or a wedged drain thread.
+        /// Writes straight to the log file and fsyncs, bypassing the queue. For diagnostics that
+        /// must survive a hard kill or a wedged drain thread.
         /// </summary>
         public static void WriteDirect(string body)
         {
@@ -213,20 +212,24 @@ namespace Calcpad.Server
             {
                 lock (_fileLock)
                 {
-                    var stream = EnsureStream();
-                    if (stream == null) return;
-                    var bytes = Encoding.UTF8.GetBytes(body);
-                    stream.Write(bytes, 0, bytes.Length);
-                    stream.Flush(flushToDisk: true);
-                    _dirty = false;
+                    try
+                    {
+                        var stream = EnsureStream();
+                        if (stream == null) return;
+                        var bytes = Encoding.UTF8.GetBytes(body);
+                        stream.Write(bytes, 0, bytes.Length);
+                        stream.Flush(flushToDisk: true);
+                        _dirty = false;
+                    }
+                    catch { DropStream(); }
                 }
             }
             catch { /* never throw from the logger */ }
         }
 
         /// <summary>
-        /// The single funnel for level-bearing entries, and so the only place the filter lives.
-        /// <see cref="LogCrash"/> and <see cref="WriteDirect"/> bypass it deliberately.
+        /// The only place the level filter lives. <see cref="LogCrash"/> and
+        /// <see cref="WriteDirect"/> bypass it deliberately.
         /// </summary>
         private static void WriteLog(LogLevel level, string message, string? details = null)
         {
@@ -248,8 +251,10 @@ namespace Calcpad.Server
         private static void QueueForFile(string entry)
         {
             if (string.IsNullOrEmpty(_logFilePath)) return;
-            if (!_fileQueue.TryAdd(entry))
-                Interlocked.Increment(ref _fileDropped);
+            Interlocked.Increment(ref _filePending);
+            if (_fileQueue.TryAdd(entry)) return;
+            Interlocked.Decrement(ref _filePending);
+            Interlocked.Increment(ref _fileDropped);
         }
 
         private static void FileDrainLoop()
@@ -260,7 +265,9 @@ namespace Calcpad.Server
                 {
                     if (_fileQueue.TryTake(out var entry, FlushIntervalMs))
                     {
-                        AppendToFile(entry);
+                        // Decremented after the write, not on dequeue, so Flush covers this one.
+                        try { AppendToFile(entry); }
+                        finally { Interlocked.Decrement(ref _filePending); }
 
                         var dropped = Interlocked.Exchange(ref _fileDropped, 0);
                         if (dropped > 0)
@@ -268,8 +275,8 @@ namespace Calcpad.Server
 
                         ReportConsoleDrops();
 
-                        // Flush at the end of each burst rather than only when idle, so a hard
-                        // kill loses at most the entries still queued behind this one.
+                        // End of each burst, not only when idle: a kill then loses at most what
+                        // is still queued behind this entry.
                         if (_fileQueue.Count == 0) FlushFile();
                     }
                     else
@@ -283,30 +290,37 @@ namespace Calcpad.Server
         }
 
         /// <summary>
-        /// Mirrors stdout-relay drops into the log file. A stalled pipe reader is exactly when
-        /// the relay's own in-band notice cannot be seen.
+        /// Mirrors console-relay drops into the log file — a stalled reader is exactly when the
+        /// relay's own in-band notice cannot be seen.
         /// </summary>
         private static void ReportConsoleDrops()
         {
-            var total = _stdoutRelay.DroppedTotal;
+            var outDropped = _stdoutRelay.DroppedTotal;
+            var errDropped = _stderrRelay.DroppedTotal;
+            var total = outDropped + errDropped;
             if (total == _reportedConsoleDrops) return;
-            // Throttled: drops arrive in floods, and one warning per drain pass would itself
-            // become the bulk of the log.
+            // Throttled: drops flood, and one warning per pass would become the bulk of the log.
             if (Environment.TickCount64 - _lastConsoleDropReportTicks < ConsoleDropReportIntervalMs) return;
             _lastConsoleDropReportTicks = Environment.TickCount64;
             _reportedConsoleDrops = total;
-            AppendToFile(Format("WARN", $"{total} console line(s) dropped since start — stdout reader is not draining", null));
+            AppendToFile(Format("WARN",
+                $"{total} console write(s) dropped since start — a console reader is not draining",
+                $"stdout: {outDropped}, stderr: {errDropped}"));
         }
 
         private static void AppendToFile(string entry)
         {
             lock (_fileLock)
             {
-                var stream = EnsureStream();
-                if (stream == null) return;
-                var bytes = Encoding.UTF8.GetBytes(entry);
-                stream.Write(bytes, 0, bytes.Length);
-                _dirty = true;
+                try
+                {
+                    var stream = EnsureStream();
+                    if (stream == null) return;
+                    var bytes = Encoding.UTF8.GetBytes(entry);
+                    stream.Write(bytes, 0, bytes.Length);
+                    _dirty = true;
+                }
+                catch { DropStream(); }
             }
         }
 
@@ -320,8 +334,19 @@ namespace Calcpad.Server
                     _stream.Flush();
                     _dirty = false;
                 }
-                catch { /* retried on the next tick */ }
+                catch { DropStream(); }
             }
+        }
+
+        /// <summary>
+        /// Discards a stream that failed a write so the next entry reopens. Without it one
+        /// transient failure ends file logging for the life of the process.
+        /// </summary>
+        private static void DropStream()
+        {
+            try { _stream?.Dispose(); } catch { }
+            _stream = null;
+            _dirty = false;
         }
 
         private static FileStream? EnsureStream()
@@ -330,8 +355,7 @@ namespace Calcpad.Server
             if (string.IsNullOrEmpty(_logFilePath)) return null;
             try
             {
-                // ReadWrite share so a second instance can hold an append handle the same day,
-                // matching the interleaving the old open-per-entry write allowed.
+                // ReadWrite share so a second instance can append the same day.
                 _stream = new FileStream(
                     _logFilePath,
                     FileMode.Append,
@@ -348,25 +372,31 @@ namespace Calcpad.Server
         }
 
         /// <summary>
-        /// Drains anything still queued and forces it to disk. Call from shutdown handlers
-        /// (ProcessExit, etc.) so final entries survive process termination.
+        /// Drains the file queue and both console relays, then fsyncs. Call from shutdown
+        /// handlers: every drain thread here is a background one, so the tail is otherwise lost.
         /// </summary>
         public static void Flush()
         {
             var deadline = Stopwatch.StartNew();
-            while (_fileQueue.Count > 0 && deadline.ElapsedMilliseconds < 2000)
+            while (Volatile.Read(ref _filePending) > 0 && deadline.ElapsedMilliseconds < 2000)
                 Thread.Sleep(10);
 
             lock (_fileLock)
             {
-                if (_stream == null) return;
-                try
+                if (_stream != null)
                 {
-                    _stream.Flush(flushToDisk: true);
-                    _dirty = false;
+                    try
+                    {
+                        _stream.Flush(flushToDisk: true);
+                        _dirty = false;
+                    }
+                    catch { /* best-effort */ }
                 }
-                catch { /* best-effort */ }
             }
+
+            // Bounded separately: a host that stopped reading can never drain these.
+            _stdoutRelay.Drain(1000);
+            _stderrRelay.Drain(1000);
         }
 
         public static string? GetLogFilePath() => _logFilePath;

--- a/Calcpad.Web/backend/FileLoggerProvider.cs
+++ b/Calcpad.Web/backend/FileLoggerProvider.cs
@@ -1,0 +1,77 @@
+using Microsoft.Extensions.Logging;
+using MsLogLevel = Microsoft.Extensions.Logging.LogLevel;
+
+namespace Calcpad.Server
+{
+    /// <summary>
+    /// Routes Microsoft.Extensions.Logging through <see cref="FileLogger"/>, so framework entries
+    /// obey the same level as ours and reach the same file. A provider rather than a log filter
+    /// because filters are cached per (provider, category) when the host is built, which froze the
+    /// framework at whatever level startup happened to have; <see cref="FileLogger"/> re-reads its
+    /// own on every entry, so <c>/api/calcpad/log-level</c> now applies without a restart.
+    /// </summary>
+    public sealed class FileLoggerProvider : ILoggerProvider
+    {
+        public ILogger CreateLogger(string categoryName) => new CategoryLogger(categoryName);
+
+        public void Dispose() { }
+
+        private sealed class CategoryLogger(string category) : ILogger
+        {
+            // Kestrel's "Now listening on: <url>", which the Tauri host sniffs out of stdout when
+            // the port file is unreadable (extract_listening_url in src-tauri/src/lib.rs). It is
+            // one line per launch, and without it a random-port server cannot be found at all.
+            private const string LifetimeCategory = "Microsoft.Hosting.Lifetime";
+            private const int ListeningOnAddressEventId = 14;
+
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+            // The lifetime category is always enabled so the listening line below reaches Log at
+            // any level — the framework skips Log entirely when IsEnabled says no. It emits only a
+            // handful of entries per process, and Log still filters the rest of them by level.
+            public bool IsEnabled(MsLogLevel logLevel) =>
+                category == LifetimeCategory || Enabled(logLevel);
+
+            public void Log<TState>(
+                MsLogLevel logLevel,
+                EventId eventId,
+                TState state,
+                Exception? exception,
+                Func<TState, Exception?, string> formatter)
+            {
+                if (category == LifetimeCategory && eventId.Id == ListeningOnAddressEventId)
+                {
+                    FileLogger.LogAlways(formatter(state, exception));
+                    return;
+                }
+
+                if (!Enabled(logLevel)) return;
+
+                var message = $"{category}: {formatter(state, exception)}";
+                switch (LevelFor(logLevel))
+                {
+                    case LogLevel.Error: FileLogger.LogError(message, exception); break;
+                    case LogLevel.Warning: FileLogger.LogWarning(message, exception?.ToString()); break;
+                    default: FileLogger.LogVerbose(message, exception?.ToString()); break;
+                }
+            }
+
+            private static bool Enabled(MsLogLevel logLevel) =>
+                LevelFor(logLevel) is { } level && level <= FileLogger.MinLevel;
+
+            /// <summary>
+            /// The framework is far chattier than we are at the same nominal level — its
+            /// Information is several lines per request and its Trace is a hundred — so its
+            /// Information and Debug both land on Verbose, the level documented as "a line per
+            /// request". Trace is dropped outright: nothing maps to it.
+            /// </summary>
+            private static LogLevel? LevelFor(MsLogLevel level) => level switch
+            {
+                MsLogLevel.Critical or MsLogLevel.Error => LogLevel.Error,
+                MsLogLevel.Warning => LogLevel.Warning,
+                MsLogLevel.Information or MsLogLevel.Debug => LogLevel.Verbose,
+                _ => null,
+            };
+        }
+    }
+}

--- a/Calcpad.Web/backend/HangWatchdog.cs
+++ b/Calcpad.Web/backend/HangWatchdog.cs
@@ -1,0 +1,152 @@
+using System.Collections.Concurrent;
+using System.Text;
+
+namespace Calcpad.Server
+{
+    /// <summary>
+    /// Detects the process staying alive but no longer completing requests — a state that leaves
+    /// no exception, no dump and no final log entry, only a log that stops mid-sentence. Uses a
+    /// dedicated thread and <see cref="FileLogger.WriteDirect"/> because thread-pool starvation
+    /// and a stalled log queue are both things it has to be able to report on.
+    /// </summary>
+    public static class HangWatchdog
+    {
+        private static readonly ConcurrentDictionary<long, InFlight> _inFlight = new();
+        private static long _nextId;
+        private static long _lastCompletedTicks = Environment.TickCount64;
+        private static long _completedTotal;
+        private static bool _reported;
+
+        private readonly record struct InFlight(string Path, long StartTicks);
+
+        private static int ThresholdSeconds =>
+            int.TryParse(Environment.GetEnvironmentVariable("CALCPAD_HANG_THRESHOLD_SECONDS"), out var s) && s > 0
+                ? s : 60;
+
+        /// <summary>Starts the monitor thread. Safe to call once at startup.</summary>
+        public static void Start()
+        {
+            var thread = new Thread(MonitorLoop)
+            {
+                IsBackground = true,
+                Name = "calcpad-hang-watchdog",
+            };
+            thread.Start();
+        }
+
+        /// <summary>
+        /// Registers a request as in flight. Dispose the result when it finishes.
+        /// </summary>
+        public static IDisposable Track(string path)
+        {
+            var id = Interlocked.Increment(ref _nextId);
+            _inFlight[id] = new InFlight(path, Environment.TickCount64);
+            return new Registration(id);
+        }
+
+        private sealed class Registration(long id) : IDisposable
+        {
+            private readonly long _id = id;
+            private bool _disposed;
+
+            public void Dispose()
+            {
+                if (_disposed) return;
+                _disposed = true;
+                _inFlight.TryRemove(_id, out _);
+                Interlocked.Exchange(ref _lastCompletedTicks, Environment.TickCount64);
+                Interlocked.Increment(ref _completedTotal);
+                _reported = false;
+            }
+        }
+
+        private static void MonitorLoop()
+        {
+            while (true)
+            {
+                try
+                {
+                    Thread.Sleep(5000);
+
+                    var stalledFor = (Environment.TickCount64 - Interlocked.Read(ref _lastCompletedTicks)) / 1000;
+                    if (_reported || _inFlight.IsEmpty || stalledFor < ThresholdSeconds)
+                        continue;
+
+                    _reported = true;
+                    FileLogger.WriteDirect(BuildReport(stalledFor));
+                    TryCaptureDump();
+                }
+                catch { /* the watchdog must never be the thing that dies */ }
+            }
+        }
+
+        private static string BuildReport(long stalledForSeconds)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"[{DateTime.Now:yyyy-MM-dd HH:mm:ss.fff}] [HANG] Server stopped completing requests");
+            sb.AppendLine($"No request has completed in {stalledForSeconds}s; {_inFlight.Count} still in flight.");
+            sb.AppendLine($"Completed since start: {Interlocked.Read(ref _completedTotal)}");
+            sb.AppendLine();
+
+            sb.AppendLine("--- Thread pool ---");
+            ThreadPool.GetMinThreads(out var minW, out var minIo);
+            ThreadPool.GetMaxThreads(out var maxW, out var maxIo);
+            ThreadPool.GetAvailableThreads(out var availW, out var availIo);
+            sb.AppendLine($"ThreadCount={ThreadPool.ThreadCount} PendingWorkItems={ThreadPool.PendingWorkItemCount} CompletedWorkItems={ThreadPool.CompletedWorkItemCount}");
+            sb.AppendLine($"Worker min/max/available = {minW}/{maxW}/{availW}");
+            sb.AppendLine($"IO     min/max/available = {minIo}/{maxIo}/{availIo}");
+            sb.AppendLine($"Process threads: {System.Diagnostics.Process.GetCurrentProcess().Threads.Count}");
+            sb.AppendLine();
+
+            sb.AppendLine("--- Memory ---");
+            var info = GC.GetGCMemoryInfo();
+            sb.AppendLine($"HeapSize={GC.GetTotalMemory(false) / (1024 * 1024)}MB Committed={info.TotalCommittedBytes / (1024 * 1024)}MB PauseTimePct={info.PauseTimePercentage}");
+            sb.AppendLine($"Gen0={GC.CollectionCount(0)} Gen1={GC.CollectionCount(1)} Gen2={GC.CollectionCount(2)}");
+            sb.AppendLine();
+
+            sb.AppendLine("--- In-flight requests (oldest first) ---");
+            var now = Environment.TickCount64;
+            foreach (var entry in _inFlight.Values.OrderBy(v => v.StartTicks).Take(50))
+                sb.AppendLine($"{(now - entry.StartTicks) / 1000,6}s  {entry.Path}");
+
+            sb.AppendLine("=== END HANG REPORT ===");
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Spawns the runtime's <c>createdump</c> against this process — the only way to get
+        /// managed stacks for every thread, as .NET has no in-process equivalent. Off unless
+        /// CALCPAD_HANG_DUMP=1, since it suspends the process while writing.
+        /// </summary>
+        private static void TryCaptureDump()
+        {
+            if (Environment.GetEnvironmentVariable("CALCPAD_HANG_DUMP") != "1") return;
+            try
+            {
+                var exe = Path.Combine(AppContext.BaseDirectory,
+                    OperatingSystem.IsWindows() ? "createdump.exe" : "createdump");
+                if (!File.Exists(exe))
+                {
+                    FileLogger.WriteDirect($"[HANG] createdump not found at {exe}{Environment.NewLine}");
+                    return;
+                }
+
+                var dir = Path.GetDirectoryName(FileLogger.GetLogFilePath()) ?? AppContext.BaseDirectory;
+                var dumpPath = Path.Combine(dir, $"hang-{DateTime.Now:yyyyMMdd-HHmmss}.dmp");
+                using var proc = System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = exe,
+                    ArgumentList = { "-f", dumpPath, "-u", Environment.ProcessId.ToString() },
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                });
+                proc?.WaitForExit(60000);
+                FileLogger.WriteDirect($"[HANG] wrote {dumpPath}{Environment.NewLine}");
+            }
+            catch (Exception ex)
+            {
+                FileLogger.WriteDirect($"[HANG] createdump failed: {ex.Message}{Environment.NewLine}");
+            }
+        }
+    }
+}

--- a/Calcpad.Web/backend/HangWatchdog.cs
+++ b/Calcpad.Web/backend/HangWatchdog.cs
@@ -4,10 +4,9 @@ using System.Text;
 namespace Calcpad.Server
 {
     /// <summary>
-    /// Detects the process staying alive but no longer completing requests — a state that leaves
-    /// no exception, no dump and no final log entry, only a log that stops mid-sentence. Uses a
-    /// dedicated thread and <see cref="FileLogger.WriteDirect"/> because thread-pool starvation
-    /// and a stalled log queue are both things it has to be able to report on.
+    /// Detects the process staying alive but no longer completing requests. Uses a dedicated
+    /// thread and <see cref="FileLogger.WriteDirect"/> because pool starvation and a stalled
+    /// log queue are both things it must still be able to report on.
     /// </summary>
     public static class HangWatchdog
     {
@@ -15,7 +14,7 @@ namespace Calcpad.Server
         private static long _nextId;
         private static long _lastCompletedTicks = Environment.TickCount64;
         private static long _completedTotal;
-        private static bool _reported;
+        private static volatile bool _reported;
 
         private readonly record struct InFlight(string Path, long StartTicks);
 
@@ -34,9 +33,7 @@ namespace Calcpad.Server
             thread.Start();
         }
 
-        /// <summary>
-        /// Registers a request as in flight. Dispose the result when it finishes.
-        /// </summary>
+        /// <summary>Registers a request as in flight. Dispose the result when it finishes.</summary>
         public static IDisposable Track(string path)
         {
             var id = Interlocked.Increment(ref _nextId);
@@ -68,12 +65,17 @@ namespace Calcpad.Server
                 {
                     Thread.Sleep(5000);
 
-                    var stalledFor = (Environment.TickCount64 - Interlocked.Read(ref _lastCompletedTicks)) / 1000;
-                    if (_reported || _inFlight.IsEmpty || stalledFor < ThresholdSeconds)
+                    // Oldest in-flight, not last completion: an idle server never advances that.
+                    if (_reported) continue;
+                    var now = Environment.TickCount64;
+                    long oldest = 0;
+                    foreach (var entry in _inFlight.Values)
+                        oldest = Math.Max(oldest, now - entry.StartTicks);
+                    if (oldest / 1000 < ThresholdSeconds)
                         continue;
 
                     _reported = true;
-                    FileLogger.WriteDirect(BuildReport(stalledFor));
+                    FileLogger.WriteDirect(BuildReport(oldest / 1000));
                     TryCaptureDump();
                 }
                 catch { /* the watchdog must never be the thing that dies */ }
@@ -82,10 +84,11 @@ namespace Calcpad.Server
 
         private static string BuildReport(long stalledForSeconds)
         {
+            var sinceCompletion = (Environment.TickCount64 - Interlocked.Read(ref _lastCompletedTicks)) / 1000;
             var sb = new StringBuilder();
             sb.AppendLine($"[{DateTime.Now:yyyy-MM-dd HH:mm:ss.fff}] [HANG] Server stopped completing requests");
-            sb.AppendLine($"No request has completed in {stalledForSeconds}s; {_inFlight.Count} still in flight.");
-            sb.AppendLine($"Completed since start: {Interlocked.Read(ref _completedTotal)}");
+            sb.AppendLine($"Oldest of {_inFlight.Count} in-flight request(s) has been running {stalledForSeconds}s.");
+            sb.AppendLine($"Last completion was {sinceCompletion}s ago; {Interlocked.Read(ref _completedTotal)} completed since start.");
             sb.AppendLine();
 
             sb.AppendLine("--- Thread pool ---");
@@ -114,9 +117,8 @@ namespace Calcpad.Server
         }
 
         /// <summary>
-        /// Spawns the runtime's <c>createdump</c> against this process — the only way to get
-        /// managed stacks for every thread, as .NET has no in-process equivalent. Off unless
-        /// CALCPAD_HANG_DUMP=1, since it suspends the process while writing.
+        /// Spawns the runtime's <c>createdump</c> — the only way to get managed stacks for every
+        /// thread. Off unless CALCPAD_HANG_DUMP=1, since it suspends the process while writing.
         /// </summary>
         private static void TryCaptureDump()
         {

--- a/Calcpad.Web/backend/Program.cs
+++ b/Calcpad.Web/backend/Program.cs
@@ -82,7 +82,7 @@ try
 
     if (parentPid is int watchedPid)
     {
-        FileLogger.LogInfo("Parent PID watchdog enabled", watchedPid.ToString());
+        FileLogger.LogVerbose("Parent PID watchdog enabled", watchedPid.ToString());
         _ = Task.Run(async () =>
         {
             while (true)
@@ -142,7 +142,7 @@ try
             }
             catch (Exception ex)
             {
-                FileLogger.LogInfo("watchdog error", ex.Message);
+                FileLogger.LogWarning("watchdog error", ex.Message);
             }
 
             // Environment.Exit bypasses ApplicationStopping callbacks, so
@@ -169,7 +169,7 @@ try
         // Kestrel rejects "localhost:0" with "Dynamic port binding is not
         // supported when binding to localhost" — must be the loopback IP.
         forwardedArgs = forwardedArgs.Concat(new[] { "--urls", "http://127.0.0.1:0" }).ToArray();
-        FileLogger.LogInfo("No explicit URL or port set", "defaulting to http://127.0.0.1:0 (random free port)");
+        FileLogger.LogVerbose("No explicit URL or port set", "defaulting to http://127.0.0.1:0 (random free port)");
     }
     else if (!hasExplicitUrls)
     {
@@ -194,10 +194,15 @@ try
     }
 
     FileLogger.LogInfo("Starting console application", serverUrl);
-    Console.WriteLine($"Calcpad Server starting at {serverUrl}");
-    Console.WriteLine("Press Ctrl+C to stop the server.");
-    Console.WriteLine($"API Documentation: {serverUrl}/swagger");
-    Console.WriteLine($"Sample Client: Open sample-client.html in a browser");
+
+    // Only for an interactive run, where this is the only thing telling the user the URL.
+    // Under Tauri and VS Code stdout is a pipe feeding an Output panel, where it is just noise.
+    if (!Console.IsOutputRedirected)
+    {
+        Console.WriteLine($"Calcpad Server starting at {serverUrl}");
+        Console.WriteLine("Press Ctrl+C to stop the server.");
+        Console.WriteLine($"API Documentation: {serverUrl}/swagger");
+    }
 
     var cts = new CancellationTokenSource();
 
@@ -224,8 +229,8 @@ try
 
     // Log ASP.NET Core lifetime transitions so graceful-shutdown progress is visible.
     var lifetime = app.Services.GetRequiredService<IHostApplicationLifetime>();
-    lifetime.ApplicationStopping.Register(() => FileLogger.LogInfo("ApplicationStopping"));
-    lifetime.ApplicationStopped.Register(() => FileLogger.LogInfo("ApplicationStopped"));
+    lifetime.ApplicationStopping.Register(() => FileLogger.LogVerbose("ApplicationStopping"));
+    lifetime.ApplicationStopped.Register(() => FileLogger.LogVerbose("ApplicationStopped"));
 
     // The startup check above validates the URL string handed to UseUrls, which is the intent
     // rather than the outcome — a Kestrel:Endpoints section in appsettings.json overrides
@@ -305,7 +310,7 @@ try
     }
     catch (OperationCanceledException)
     {
-        Console.WriteLine("Shutting down...");
+        if (!Console.IsOutputRedirected) Console.WriteLine("Shutting down...");
         await app.StopAsync();
     }
 

--- a/Calcpad.Web/backend/Program.cs
+++ b/Calcpad.Web/backend/Program.cs
@@ -3,10 +3,14 @@ using Calcpad.Server.Services;
 using System.Net;
 using System.Runtime.InteropServices;
 
-// Auto-flush stdout so the parent process (VS Code extension) sees logs in real time
-// when stdio is piped (non-TTY), instead of waiting for buffer flush on exit.
-Console.SetOut(new StreamWriter(Console.OpenStandardOutput()) { AutoFlush = true });
-Console.SetError(new StreamWriter(Console.OpenStandardError()) { AutoFlush = true });
+// Non-blocking stdout/stderr: a host that stops draining our pipe must not be able to park the
+// threads writing to it. See ConsoleRelay for why an auto-flushing writer wedges the process.
+FileLogger.InstallConsoleRelay();
+
+// The hot endpoints are synchronous and do blocking I/O, so a burst consumes pool threads faster
+// than the default injection rate (~1-2/sec) replaces them.
+ThreadPool.GetMinThreads(out _, out var minIoThreads);
+ThreadPool.SetMinThreads(Math.Max(Environment.ProcessorCount * 4, 32), minIoThreads);
 
 // Set up global exception handling
 AppDomain.CurrentDomain.UnhandledException += (sender, e) =>
@@ -85,7 +89,8 @@ try
             {
                 try
                 {
-                    _ = System.Diagnostics.Process.GetProcessById(watchedPid);
+                    // Disposed: undisposed, this leaks a native handle every 2s to the finalizer.
+                    using var parent = System.Diagnostics.Process.GetProcessById(watchedPid);
                 }
                 catch (ArgumentException)
                 {

--- a/Calcpad.Web/backend/Program.cs
+++ b/Calcpad.Web/backend/Program.cs
@@ -3,12 +3,10 @@ using Calcpad.Server.Services;
 using System.Net;
 using System.Runtime.InteropServices;
 
-// Non-blocking stdout/stderr: a host that stops draining our pipe must not be able to park the
-// threads writing to it. See ConsoleRelay for why an auto-flushing writer wedges the process.
+// Non-blocking stdout/stderr — see ConsoleRelay for why an auto-flushing writer wedges us.
 FileLogger.InstallConsoleRelay();
 
-// The hot endpoints are synchronous and do blocking I/O, so a burst consumes pool threads faster
-// than the default injection rate (~1-2/sec) replaces them.
+// Hot endpoints are synchronous and block, so a burst outruns the ~1-2/sec injection rate.
 ThreadPool.GetMinThreads(out _, out var minIoThreads);
 ThreadPool.SetMinThreads(Math.Max(Environment.ProcessorCount * 4, 32), minIoThreads);
 
@@ -24,9 +22,7 @@ TaskScheduler.UnobservedTaskException += (sender, e) =>
     e.SetObserved();
 };
 
-// ProcessExit fires on Environment.Exit and clean Main return, but NOT on
-// FailFast or StackOverflow. Useful for catching the "graceful but unexpected"
-// exit path — and for flushing the log on normal shutdown.
+// Fires on Environment.Exit and clean Main return, but NOT on FailFast or StackOverflow.
 AppDomain.CurrentDomain.ProcessExit += (sender, e) =>
 {
     FileLogger.LogInfo("ProcessExit fired", $"ExitCode={Environment.ExitCode}");
@@ -40,16 +36,11 @@ try
     // Set default environment variables if not set
     Environment.SetEnvironmentVariable("CALCPAD_HOST", Environment.GetEnvironmentVariable("CALCPAD_HOST") ?? "127.0.0.1");
 
-    // Pull our custom CLI flags out of args before handing them to ASP.NET.
-    // --port-file <path>          Write the bound base URL here once Kestrel is listening,
-    //                             so the Tauri host can discover a random-port server.
-    // --exit-on-stdin-close       Exit when stdin reaches EOF (parent died). On by default
-    //                             whenever stdin is piped; opt out via CALCPAD_DETACHED=1,
-    //                             which VS Code sets so one server is shared across windows.
-    // --no-exit-on-stdin-close    Force-disable the watchdog. Tauri sets this because it
-    //                             uses --parent-pid for death detection instead.
-    // --parent-pid <pid>          Poll the given PID every 2s and self-exit when it
-    //                             disappears, reaping the server if Rust is SIGKILL'd.
+    // Our own CLI flags, pulled out before the rest goes to ASP.NET.
+    // --port-file <path>          Bound base URL, for hosts discovering a random-port server.
+    // --exit-on-stdin-close       Exit on stdin EOF. Default when piped; CALCPAD_DETACHED=1 opts out.
+    // --no-exit-on-stdin-close    Force off. Tauri uses --parent-pid instead.
+    // --parent-pid <pid>          Poll that PID every 2s; exit when it disappears.
     string? portFile = null;
     bool? exitOnStdinCloseExplicit = null;
     int? parentPid = null;
@@ -108,16 +99,12 @@ try
         });
     }
 
-    // Decide whether the EOF watchdog runs. Default-on when stdin is piped
-    // (we're a child of *something* that may die and orphan us), opt-out
-    // via CALCPAD_DETACHED=1 (the VS Code extension's server-manager.ts
-    // sets this because it shares one server across windows).
+    // EOF watchdog: on when stdin is piped, since that parent can die and orphan us.
+    // CALCPAD_DETACHED=1 opts out — VS Code shares one server across windows.
     bool detached = Environment.GetEnvironmentVariable("CALCPAD_DETACHED") == "1";
     bool exitOnStdinClose = exitOnStdinCloseExplicit ?? (Console.IsInputRedirected && !detached);
 
-    // Default the port file to a fixed location next to the binary when no
-    // path was given explicitly. Always wipe any stale file at startup so
-    // the frontend never reads a URL pointing at a previous (dead) server.
+    // Defaults next to the binary. Always wiped at startup, so no frontend reads a dead URL.
     if (portFile == null && !detached)
     {
         portFile = Path.Combine(AppContext.BaseDirectory, ".calcpad-server.port");
@@ -129,10 +116,8 @@ try
 
     if (exitOnStdinClose && Console.IsInputRedirected)
     {
-        // Death-detection background task: stdin stays open until the parent
-        // dies, so reading until EOF is the death signal for any parent that
-        // pipes stdio (build scripts, raw shells). Tauri opts out via
-        // --no-exit-on-stdin-close and uses --parent-pid instead.
+        // stdin stays open until the parent dies, so EOF is the death signal for any
+        // stdio-piping parent (build scripts, raw shells).
         _ = Task.Run(async () =>
         {
             try
@@ -145,9 +130,7 @@ try
                 FileLogger.LogWarning("watchdog error", ex.Message);
             }
 
-            // Environment.Exit bypasses ApplicationStopping callbacks, so
-            // clean up the port file ourselves before going down — otherwise
-            // the next launch sees a stale URL pointing at a dead server.
+            // Environment.Exit bypasses ApplicationStopping, so clear the port file here.
             if (!string.IsNullOrEmpty(portFile))
             {
                 try { if (File.Exists(portFile)) File.Delete(portFile); } catch { /* best-effort */ }
@@ -156,34 +139,28 @@ try
         });
     }
 
-    // When nothing was set explicitly (no --urls, no CALCPAD_PORT env), prefer
-    // an OS-assigned random port over the legacy hard-coded 9420 — this is
-    // what Tauri sidecar launches want, and it eliminates the "address already
-    // in use" failure mode for orphan processes. Callers that need a fixed
-    // port (`dotnet run` for dev, the VS Code extension explicitly passing
-    // --urls) keep their existing behavior.
+    // With neither --urls nor CALCPAD_PORT, take an OS-assigned port over the legacy 9420:
+    // what sidecar launches want, and it kills the "address already in use" orphan case.
+    // Callers passing either one keep their existing behavior.
     bool hasExplicitUrls = forwardedArgs.Any(a => a == "--urls");
     bool hasExplicitPort = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CALCPAD_PORT"));
     if (!hasExplicitUrls && !hasExplicitPort)
     {
-        // Kestrel rejects "localhost:0" with "Dynamic port binding is not
-        // supported when binding to localhost" — must be the loopback IP.
+        // Kestrel rejects "localhost:0" for dynamic binding — must be the loopback IP.
         forwardedArgs = forwardedArgs.Concat(new[] { "--urls", "http://127.0.0.1:0" }).ToArray();
         FileLogger.LogVerbose("No explicit URL or port set", "defaulting to http://127.0.0.1:0 (random free port)");
     }
     else if (!hasExplicitUrls)
     {
-        // CALCPAD_PORT was set explicitly — preserve the legacy 9420 default
-        // for that path through GetServerUrl.
+        // CALCPAD_PORT set — keep the legacy 9420 default through GetServerUrl.
         Environment.SetEnvironmentVariable("CALCPAD_PORT", Environment.GetEnvironmentVariable("CALCPAD_PORT") ?? "9420");
     }
 
     // Create and configure web application using shared service
     var (app, serverUrl) = CalcpadApiService.CreateConfiguredApp(forwardedArgs);
 
-    // Server mode (non-localhost binding) is in development and not yet supported:
-    // the include-resolution path that ships uploaded files from a remote browser
-    // is being reworked. Crash early if anything resolves to a non-loopback URL.
+    // Server mode (non-localhost) is unfinished — the remote-include path is being reworked.
+    // Crash early on any non-loopback URL.
     foreach (var u in serverUrl.Split(';', StringSplitOptions.RemoveEmptyEntries))
     {
         if (!Program.IsLoopbackUrl(u))
@@ -195,8 +172,7 @@ try
 
     FileLogger.LogInfo("Starting console application", serverUrl);
 
-    // Only for an interactive run, where this is the only thing telling the user the URL.
-    // Under Tauri and VS Code stdout is a pipe feeding an Output panel, where it is just noise.
+    // Interactive runs only — piped into a host's Output panel this is just noise.
     if (!Console.IsOutputRedirected)
     {
         Console.WriteLine($"Calcpad Server starting at {serverUrl}");
@@ -206,10 +182,8 @@ try
 
     var cts = new CancellationTokenSource();
 
-    // Handle SIGINT (Ctrl+C) and SIGTERM on all platforms, replacing Console.CancelKeyPress
-    // which only covers SIGINT. An exception escaping one of these runs on the runtime's
-    // signal thread and kills the process with no managed handler and no log, so nothing may
-    // propagate.
+    // SIGINT and SIGTERM on all platforms; Console.CancelKeyPress only covers SIGINT. Nothing
+    // may escape: these run on the signal thread, where an exception kills us with no log.
     void RequestShutdown(PosixSignalContext ctx, string signal)
     {
         try
@@ -232,10 +206,9 @@ try
     lifetime.ApplicationStopping.Register(() => FileLogger.LogVerbose("ApplicationStopping"));
     lifetime.ApplicationStopped.Register(() => FileLogger.LogVerbose("ApplicationStopped"));
 
-    // The startup check above validates the URL string handed to UseUrls, which is the intent
-    // rather than the outcome — a Kestrel:Endpoints section in appsettings.json overrides
-    // UseUrls entirely. app.Urls is the ground truth, so it is re-checked once Kestrel has
-    // bound, before the port-file writer so `bindingRejected` is already set when that runs.
+    // The check above validates intent (the UseUrls string); a Kestrel:Endpoints section
+    // overrides it entirely. app.Urls is ground truth, re-checked here before the port-file
+    // writer so `bindingRejected` is already set when that runs.
     var bindingRejected = false;
     lifetime.ApplicationStarted.Register(() =>
     {
@@ -252,25 +225,20 @@ try
         }
     });
 
-    // When --port-file was given, write the bound URL once Kestrel is
-    // listening. The frontend (Tauri desktop) polls this file to discover
-    // the random-port server without hard-coding 9420.
+    // The bound URL, once Kestrel is listening. Tauri polls this to find a random-port server.
     if (!string.IsNullOrEmpty(portFile))
     {
         lifetime.ApplicationStarted.Register(() =>
         {
-            // A rejected binding is being torn down; publishing its URL would point
-            // the frontend at a server that is about to stop.
+            // A rejected binding is being torn down; its URL would point at a dying server.
             if (bindingRejected) return;
             try
             {
-                // Use the first listening URL — Kestrel resolves any
-                // wildcard/random binding to a concrete one by this point.
+                // First listening URL — wildcard/random bindings are concrete by now.
                 var addresses = app.Urls.ToList();
                 var bound = addresses.FirstOrDefault() ?? serverUrl;
-                // The default port-file location on Linux is the 1777 temp dir, where
-                // any local user can read it. Tighten the mode while the file is still
-                // empty, so the URL is never briefly world-readable.
+                // Linux defaults this into the 1777 temp dir. Tighten while still empty, so
+                // the URL is never briefly world-readable.
                 using (File.Create(portFile)) { }
                 if (!OperatingSystem.IsWindows())
                     File.SetUnixFileMode(portFile, UnixFileMode.UserRead | UnixFileMode.UserWrite);
@@ -288,9 +256,8 @@ try
         });
     }
 
-    // Server is designed to be shared across multiple VS Code instances, so it
-    // intentionally outlives the spawning process. It only exits on explicit
-    // SIGINT/SIGTERM (via the `calcpad.stopServer` command) or OS shutdown.
+    // Shared across VS Code instances, so it outlives its spawner: exits only on
+    // SIGINT/SIGTERM (`calcpad.stopServer`) or OS shutdown.
 
     var runTask = Task.Run(async () =>
     {
@@ -321,19 +288,17 @@ catch (Exception ex)
     FileLogger.LogCrash(ex, "Console application");
     Console.WriteLine($"ERROR: {ex.Message}");
     Console.WriteLine($"Log file: {FileLogger.GetLogFilePath()}");
+    FileLogger.Flush();
     throw;
 }
 
-// Note: createdump (DOTNET_DbgEnableMiniDump and friends) must be set in the
-// child process's environment BEFORE the runtime starts up — setting them from
-// inside Main is too late. The VS Code extension's spawn-time env in
-// calcpad-frontend/server-manager.ts owns this configuration.
+// createdump vars (DOTNET_DbgEnableMiniDump etc.) must be in the child env before the runtime
+// starts — too late from Main. server-manager.ts owns them at spawn time.
 
 internal static partial class Program
 {
     /// <summary>
-    /// True if the URL's host resolves to a loopback address (localhost, 127.0.0.0/8, ::1).
-    /// Used to gate server-mode bindings until the remote-include path is finished.
+    /// True if the URL's host is loopback. Gates server-mode bindings for now.
     /// </summary>
     internal static bool IsLoopbackUrl(string urlString)
     {
@@ -342,8 +307,8 @@ internal static partial class Program
     }
 
     /// <summary>
-    /// True for a bare hostname that denotes this machine (localhost, 127.0.0.0/8, ::1).
-    /// Takes a hostname without scheme or port, as found in a <c>Host</c> header.
+    /// True for a bare hostname denoting this machine — no scheme or port, as in a
+    /// <c>Host</c> header.
     /// </summary>
     internal static bool IsLoopbackHost(string host)
     {

--- a/Calcpad.Web/backend/README.md
+++ b/Calcpad.Web/backend/README.md
@@ -27,13 +27,17 @@ Any attempt to bind to a non-loopback host (`0.0.0.0`, a LAN address, a domain n
 ## Health check
 
 ```
+GET  /api/calcpad/health          → { "status": "ok" }
 GET  /api/calcpad/pdf/health      → { "status": "ok", "service": "calcpad-pdf", ... }
 ```
+
+`/health` is process liveness — it does no work, writes no log line, and is safe to poll. `/pdf/health` is the Chromium readiness check for PDF export.
 
 ## Endpoints
 
 Documented in [API_SCHEMA.md](API_SCHEMA.md). Summary:
 
+- `GET  /api/calcpad/health` — liveness probe; does no work and writes no log line
 - `POST /api/calcpad/convert` — Calcpad source to HTML (`?unwrap=true` for the expanded source)
 - `POST /api/calcpad/docx`, `/pdf` — document export (`/pdf/health` for readiness, `/pdf/browser` and `/pdf/browser/install` for the Chromium dependency)
 - `GET  /api/calcpad/sample` — sample document
@@ -46,6 +50,7 @@ Documented in [API_SCHEMA.md](API_SCHEMA.md). Summary:
 - `POST /api/calcpad/cpdz/decode`, `/cpdz/encode` — compiled `.cpdz` worksheets
 - `POST /api/calcpad/portable/bundle`, `/portable/package` — self-contained worksheet and ZIP export
 - `GET  /api/calcpad/debug-crash` — deliberately crash the server (Development only)
+- `GET  /api/calcpad/log-level`, `POST /api/calcpad/log-level` — read and set log verbosity at runtime
 
 ## Configuration
 
@@ -57,7 +62,11 @@ Documented in [API_SCHEMA.md](API_SCHEMA.md). Summary:
 | `CALCPAD_HOST` | `127.0.0.1` | Host part of the bind URL |
 | `CALCPAD_API_TOKEN` | *(unset — unauthenticated)* | Required in `X-Calcpad-Token` on every `/api` request when set |
 | `CALCPAD_DETACHED` | *(unset)* | `1` disables the stdin-EOF watchdog and the default port file |
-| `CALCPAD_CONTENT_CACHE_SIZE_LIMIT` | `100` | Entries in the resolved-content cache |
+| `CALCPAD_LOG_LEVEL` | `warning` | Startup verbosity: `error`, `warning`, `information` or `verbose`. Change it at runtime via `POST /api/calcpad/log-level` |
+| `CALCPAD_LOG_DIR` | *(executable-adjacent `logs/`)* | Where `CalcpadServer-{date}.log` is written. Hosts set this when the install dir is read-only |
+| `CALCPAD_HANG_THRESHOLD_SECONDS` | `60` | How long without a completed request before the hang watchdog reports |
+| `CALCPAD_HANG_DUMP` | *(unset)* | `1` also spawns `createdump` on a detected hang |
+| `CALCPAD_CONTENT_CACHE_SIZE_LIMIT` | `50000` | Flattened source lines budgeted across the resolved-content cache |
 | `BROWSER_PATH` | *(auto-detect)* | Chromium-family executable used for PDF export |
 | `ALLOW_CHROMIUM_DOWNLOAD` | `false` | Lets the render path download Chromium on its own |
 

--- a/Calcpad.Web/backend/README.md
+++ b/Calcpad.Web/backend/README.md
@@ -54,7 +54,7 @@ Documented in [API_SCHEMA.md](API_SCHEMA.md). Summary:
 
 ## Configuration
 
-`appsettings.json` carries logging configuration and the bind URL. There are no JWT, Auth, Storage, or S3 sections on this branch.
+`appsettings.json` carries the browser settings and the bind URL. It has no `Logging` section: verbosity comes from `CALCPAD_LOG_LEVEL` and `POST /api/calcpad/log-level`, which govern the framework's logging as well as Calcpad's. There are no JWT, Auth, Storage, or S3 sections on this branch.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
@@ -62,7 +62,7 @@ Documented in [API_SCHEMA.md](API_SCHEMA.md). Summary:
 | `CALCPAD_HOST` | `127.0.0.1` | Host part of the bind URL |
 | `CALCPAD_API_TOKEN` | *(unset — unauthenticated)* | Required in `X-Calcpad-Token` on every `/api` request when set |
 | `CALCPAD_DETACHED` | *(unset)* | `1` disables the stdin-EOF watchdog and the default port file |
-| `CALCPAD_LOG_LEVEL` | `warning` | Startup verbosity: `error`, `warning`, `information` or `verbose`. Change it at runtime via `POST /api/calcpad/log-level` |
+| `CALCPAD_LOG_LEVEL` | `warning` | Startup verbosity: `error`, `warning`, `information` or `verbose`. Covers ASP.NET's own logs too. Change it at runtime via `POST /api/calcpad/log-level` |
 | `CALCPAD_LOG_DIR` | *(executable-adjacent `logs/`)* | Where `CalcpadServer-{date}.log` is written. Hosts set this when the install dir is read-only |
 | `CALCPAD_HANG_THRESHOLD_SECONDS` | `60` | How long without a completed request before the hang watchdog reports |
 | `CALCPAD_HANG_DUMP` | *(unset)* | `1` also spawns `createdump` on a detected hang |

--- a/Calcpad.Web/backend/Services/BundledFonts.cs
+++ b/Calcpad.Web/backend/Services/BundledFonts.cs
@@ -37,7 +37,7 @@ namespace Calcpad.Server.Services
                 LoadFromFilesystem(map);
                 LoadFromEmbeddedResources(map);
 
-                FileLogger.LogInfo("Bundled fonts loaded", map.Count == 0 ? "(none)" : string.Join(", ", map.Keys));
+                FileLogger.LogVerbose("Bundled fonts loaded", map.Count == 0 ? "(none)" : string.Join(", ", map.Keys));
                 _cachedDataUrls = map;
                 return _cachedDataUrls;
             }

--- a/Calcpad.Web/backend/Services/BundledUiAssets.cs
+++ b/Calcpad.Web/backend/Services/BundledUiAssets.cs
@@ -70,7 +70,7 @@ namespace Calcpad.Server.Services
                 }
                 else
                 {
-                    FileLogger.LogInfo("Bundled UI assets loaded", $"{sb.Length} chars");
+                    FileLogger.LogVerbose("Bundled UI assets loaded", $"{sb.Length} chars");
                     _cachedHeadMarkup = sb.ToString();
                 }
                 return _cachedHeadMarkup;

--- a/Calcpad.Web/backend/Services/CalcpadApiService.cs
+++ b/Calcpad.Web/backend/Services/CalcpadApiService.cs
@@ -33,11 +33,10 @@ namespace Calcpad.Server.Services
 
             // Caches ContentResolver's staged-content output across lint/highlight/definitions/
             // symbol-at-position for the same content, singleton so entries survive across requests.
+            // Budget is in flattened source lines, not entries — see ContentResolutionCache.
             builder.Services.AddMemoryCache(options =>
             {
-                options.SizeLimit = int.TryParse(
-                    Environment.GetEnvironmentVariable("CALCPAD_CONTENT_CACHE_SIZE_LIMIT"), out var limit)
-                    ? limit : 100;
+                options.SizeLimit = ContentResolutionCache.ResolveSizeLimit();
             });
             builder.Services.AddSingleton<ContentResolutionCache>();
 
@@ -154,6 +153,14 @@ namespace Calcpad.Server.Services
         /// </summary>
         public static WebApplication ConfigureApp(WebApplication app)
         {
+            // Outermost, so the in-flight set covers the whole pipeline.
+            HangWatchdog.Start();
+            app.Use(async (context, next) =>
+            {
+                using (HangWatchdog.Track($"{context.Request.Method} {context.Request.Path}"))
+                    await next();
+            });
+
             app.Use(async (context, next) =>
             {
                 try

--- a/Calcpad.Web/backend/Services/CalcpadApiService.cs
+++ b/Calcpad.Web/backend/Services/CalcpadApiService.cs
@@ -22,17 +22,15 @@ namespace Calcpad.Server.Services
                 ContentRootPath = AppContext.BaseDirectory
             });
 
-            // ASP.NET's console provider writes through Console.Out, which InstallConsoleRelay
-            // has replaced, so its output reaches the hosts' Output panels without passing
-            // FileLogger's filter — it has to track MinLevel too.
+            // One sink for framework and our own entries alike, so both obey MinLevel and both
+            // reach the log file. Everything is let through to the provider: it consults MinLevel
+            // per entry, whereas a filter here would be cached and freeze the level at startup.
             //
             // A catch-all rule, not SetMinimumLevel: that applies only when no rule matches, and
-            // appsettings.json's Logging:LogLevel:Default is such a rule, so it would always win.
-            //
-            // Microsoft.Hosting.Lifetime is pinned back for "Now listening on: <url>", which the
-            // Tauri host sniffs (extract_listening_url) when the port file is unreadable.
-            builder.Logging.AddFilter((string?)null, FrameworkLevelFor(FileLogger.MinLevel));
-            builder.Logging.AddFilter("Microsoft.Hosting.Lifetime", Microsoft.Extensions.Logging.LogLevel.Information);
+            // an appsettings Logging:LogLevel:Default is such a rule, so it would always win.
+            builder.Logging.ClearProviders();
+            builder.Logging.AddProvider(new FileLoggerProvider());
+            builder.Logging.AddFilter((string?)null, Microsoft.Extensions.Logging.LogLevel.Trace);
 
             builder.Services.AddControllers()
                 .AddApplicationPart(typeof(CalcpadApiService).Assembly);
@@ -65,18 +63,6 @@ namespace Calcpad.Server.Services
 
             return builder;
         }
-
-        /// <summary>
-        /// Our verbosity mapped onto the framework's. Startup only: the framework caches filters
-        /// per (provider, category), so a later <see cref="FileLogger.MinLevel"/> change misses.
-        /// </summary>
-        private static Microsoft.Extensions.Logging.LogLevel FrameworkLevelFor(LogLevel level) => level switch
-        {
-            LogLevel.Verbose => Microsoft.Extensions.Logging.LogLevel.Debug,
-            LogLevel.Information => Microsoft.Extensions.Logging.LogLevel.Information,
-            LogLevel.Warning => Microsoft.Extensions.Logging.LogLevel.Warning,
-            _ => Microsoft.Extensions.Logging.LogLevel.Error,
-        };
 
         internal const string CorsPolicyName = "CalcpadHosts";
 
@@ -226,7 +212,9 @@ namespace Calcpad.Server.Services
                 app.UseSwaggerUI();
             }
 
-            app.UseHttpsRedirection();
+            // No UseHttpsRedirection: Program.cs refuses any non-loopback binding and the hosts
+            // always spawn us on http, so there is never an https port to redirect to — the
+            // middleware only ever logged "Failed to determine the https port" once per launch.
             app.UseCors(CorsPolicyName);
             RequireApiToken(app);
 

--- a/Calcpad.Web/backend/Services/CalcpadApiService.cs
+++ b/Calcpad.Web/backend/Services/CalcpadApiService.cs
@@ -22,16 +22,16 @@ namespace Calcpad.Server.Services
                 ContentRootPath = AppContext.BaseDirectory
             });
 
-            // ASP.NET's own console provider writes through Console.Out, which
-            // InstallConsoleRelay has replaced — so its output reaches stdout and the hosts'
-            // Output panels without ever passing FileLogger's filter. At Information that is a
-            // "Request starting"/"Request finished" pair per request, as much noise as our own
-            // logging, so it tracks MinLevel too.
+            // ASP.NET's console provider writes through Console.Out, which InstallConsoleRelay
+            // has replaced, so its output reaches the hosts' Output panels without passing
+            // FileLogger's filter — it has to track MinLevel too.
             //
-            // Microsoft.Hosting.Lifetime is pinned back: it logs "Now listening on: <url>",
-            // which the Tauri host sniffs (extract_listening_url) as its fallback when the port
-            // file is unreadable. Raising the floor without this silently removes that path.
-            builder.Logging.SetMinimumLevel(FrameworkLevelFor(FileLogger.MinLevel));
+            // A catch-all rule, not SetMinimumLevel: that applies only when no rule matches, and
+            // appsettings.json's Logging:LogLevel:Default is such a rule, so it would always win.
+            //
+            // Microsoft.Hosting.Lifetime is pinned back for "Now listening on: <url>", which the
+            // Tauri host sniffs (extract_listening_url) when the port file is unreadable.
+            builder.Logging.AddFilter((string?)null, FrameworkLevelFor(FileLogger.MinLevel));
             builder.Logging.AddFilter("Microsoft.Hosting.Lifetime", Microsoft.Extensions.Logging.LogLevel.Information);
 
             builder.Services.AddControllers()
@@ -67,9 +67,8 @@ namespace Calcpad.Server.Services
         }
 
         /// <summary>
-        /// Our verbosity mapped onto the framework's. Only read at startup — the framework
-        /// caches filters per (provider, category), so a later <see cref="FileLogger.MinLevel"/>
-        /// change does not reach it.
+        /// Our verbosity mapped onto the framework's. Startup only: the framework caches filters
+        /// per (provider, category), so a later <see cref="FileLogger.MinLevel"/> change misses.
         /// </summary>
         private static Microsoft.Extensions.Logging.LogLevel FrameworkLevelFor(LogLevel level) => level switch
         {
@@ -92,11 +91,9 @@ namespace Calcpad.Server.Services
         /// Per-launch shared secret, handed to us by the host that spawned this process.
         /// </summary>
         /// <remarks>
-        /// Read from the environment rather than argv, which is world-readable through
-        /// <c>/proc/{pid}/cmdline</c> on Linux and WMI on Windows; the environment block is
-        /// readable only by the same user. Absent when nobody set it (<c>dotnet run</c>, the
-        /// test harness), in which case auth is off and the CORS + Host-header policy in
-        /// <see cref="IsAllowedOrigin"/> is the only control — both shipped hosts always set it.
+        /// From the environment, not argv: argv is world-readable (<c>/proc/{pid}/cmdline</c>,
+        /// WMI). Absent under <c>dotnet run</c> and tests, where auth is off and the CORS +
+        /// Host-header policy is the only control; both shipped hosts always set it.
         /// </remarks>
         private static readonly byte[]? ApiTokenBytes =
             Environment.GetEnvironmentVariable("CALCPAD_API_TOKEN") is { Length: > 0 } token
@@ -107,10 +104,9 @@ namespace Calcpad.Server.Services
         /// Rejects any <c>/api</c> request that does not present the launch token.
         /// </summary>
         /// <remarks>
-        /// Registered after <c>UseCors</c> so a browser preflight is answered by the CORS
-        /// middleware and never reaches this — the preflight itself carries no custom
-        /// headers, so checking it would fail every cross-origin request before the real
-        /// one was ever sent. <c>OPTIONS</c> is skipped for the same reason.
+        /// After <c>UseCors</c> so preflights are answered before reaching this: a preflight
+        /// carries no custom headers, so checking it would fail every cross-origin request.
+        /// <c>OPTIONS</c> is skipped for the same reason.
         /// </remarks>
         private static void RequireApiToken(WebApplication app)
         {
@@ -147,31 +143,25 @@ namespace Calcpad.Server.Services
         /// Origins permitted to call the API from a browsing context.
         /// </summary>
         /// <remarks>
-        /// Binding to loopback keeps remote machines out but not the user's own browser: a page
-        /// they visit can POST <c>#include ~/.ssh/id_rsa</c> to <c>/api/calcpad/convert</c> and
-        /// read the file back out of the rendered HTML, so the requesting origin is what stands
-        /// between that page and the file. Restricting it blocks the request rather than just
-        /// the response, since <c>[FromBody]</c> on an <c>[ApiController]</c> forces a preflight.
+        /// Loopback keeps remote machines out but not the user's own browser: a page they visit
+        /// can POST <c>#include ~/.ssh/id_rsa</c> to <c>/convert</c> and read the file back out
+        /// of the HTML. <c>[FromBody]</c> forces a preflight, so this blocks the request itself.
         /// <para>
-        /// Native callers send no Origin header and never reach this; <c>vscode-webview://</c>
-        /// is deliberately absent, and "null" — what a sandboxed opaque-origin frame sends — is
-        /// rejected. DNS rebinding is handled by the Host-header check in
-        /// <see cref="ConfigureApp"/> instead.
+        /// Native callers send no Origin and never reach this; <c>vscode-webview://</c> and
+        /// "null" (a sandboxed opaque origin) are deliberately rejected. DNS rebinding is the
+        /// Host-header check in <see cref="ConfigureApp"/> instead.
         /// </para>
         /// </remarks>
         internal static bool IsAllowedOrigin(string origin)
         {
             if (!Uri.TryCreate(origin, UriKind.Absolute, out var uri)) return false;
 
-            // Tauri serves the desktop shell from a custom scheme: tauri://localhost
-            // on Linux/macOS, http(s)://tauri.localhost on Windows (WebView2).
+            // tauri://localhost on Linux/macOS, tauri.localhost on Windows (WebView2).
             if (uri.Scheme.Equals("tauri", StringComparison.OrdinalIgnoreCase)) return true;
             if (uri.Host.Equals("tauri.localhost", StringComparison.OrdinalIgnoreCase)) return true;
 
-            // The browser build of the editor, served from loopback on any port. This
-            // also admits any other local server's pages, which is the accepted floor:
-            // anything able to serve on this machine's loopback is already past the
-            // boundary this policy defends.
+            // The browser build, on any loopback port. Admits other local servers' pages too —
+            // the accepted floor, since serving on loopback is already past this boundary.
             return Program.IsLoopbackHost(uri.Host);
         }
 
@@ -202,8 +192,7 @@ namespace Calcpad.Server.Services
                 }
                 catch (OperationCanceledException) when (context.RequestAborted.IsCancellationRequested)
                 {
-                    // The client disconnected or superseded this request — expected under
-                    // rapid tab-switching, not a server error, so it isn't logged as one.
+                    // Client disconnected or superseded the request — not a server error.
                 }
                 catch (Exception ex)
                 {
@@ -213,11 +202,9 @@ namespace Calcpad.Server.Services
                 }
             });
 
-            // DNS rebinding defense, and the reason CORS alone is not enough: an attacker who
-            // points their own hostname at 127.0.0.1 makes the request same-origin, so no CORS
-            // check runs, but the Host header still carries their name. Only loopback names are
-            // served, and a request with no Host header at all is let through as a native
-            // client, which was never the exposure here.
+            // DNS rebinding defense, and why CORS alone is not enough: a hostname pointed at
+            // 127.0.0.1 makes the request same-origin, so no CORS check runs, but the Host
+            // header still names them. No Host at all is a native client, never the exposure.
             app.Use(async (context, next) =>
             {
                 var host = context.Request.Host.Host;

--- a/Calcpad.Web/backend/Services/CalcpadApiService.cs
+++ b/Calcpad.Web/backend/Services/CalcpadApiService.cs
@@ -22,6 +22,18 @@ namespace Calcpad.Server.Services
                 ContentRootPath = AppContext.BaseDirectory
             });
 
+            // ASP.NET's own console provider writes through Console.Out, which
+            // InstallConsoleRelay has replaced — so its output reaches stdout and the hosts'
+            // Output panels without ever passing FileLogger's filter. At Information that is a
+            // "Request starting"/"Request finished" pair per request, as much noise as our own
+            // logging, so it tracks MinLevel too.
+            //
+            // Microsoft.Hosting.Lifetime is pinned back: it logs "Now listening on: <url>",
+            // which the Tauri host sniffs (extract_listening_url) as its fallback when the port
+            // file is unreadable. Raising the floor without this silently removes that path.
+            builder.Logging.SetMinimumLevel(FrameworkLevelFor(FileLogger.MinLevel));
+            builder.Logging.AddFilter("Microsoft.Hosting.Lifetime", Microsoft.Extensions.Logging.LogLevel.Information);
+
             builder.Services.AddControllers()
                 .AddApplicationPart(typeof(CalcpadApiService).Assembly);
             builder.Services.AddEndpointsApiExplorer();
@@ -54,12 +66,27 @@ namespace Calcpad.Server.Services
             return builder;
         }
 
+        /// <summary>
+        /// Our verbosity mapped onto the framework's. Only read at startup — the framework
+        /// caches filters per (provider, category), so a later <see cref="FileLogger.MinLevel"/>
+        /// change does not reach it.
+        /// </summary>
+        private static Microsoft.Extensions.Logging.LogLevel FrameworkLevelFor(LogLevel level) => level switch
+        {
+            LogLevel.Verbose => Microsoft.Extensions.Logging.LogLevel.Debug,
+            LogLevel.Information => Microsoft.Extensions.Logging.LogLevel.Information,
+            LogLevel.Warning => Microsoft.Extensions.Logging.LogLevel.Warning,
+            _ => Microsoft.Extensions.Logging.LogLevel.Error,
+        };
+
         internal const string CorsPolicyName = "CalcpadHosts";
 
         /// <summary>
         /// Header carrying the per-launch token that <see cref="RequireApiToken"/> checks.
         /// </summary>
         internal const string ApiTokenHeader = "X-Calcpad-Token";
+
+        private const string HealthPath = "/api/calcpad/health";
 
         /// <summary>
         /// Per-launch shared secret, handed to us by the host that spawned this process.
@@ -157,6 +184,12 @@ namespace Calcpad.Server.Services
             HangWatchdog.Start();
             app.Use(async (context, next) =>
             {
+                // Tracking the poll would refresh the stall clock forever and hide a real hang.
+                if (context.Request.Path.Equals(HealthPath, StringComparison.OrdinalIgnoreCase))
+                {
+                    await next();
+                    return;
+                }
                 using (HangWatchdog.Track($"{context.Request.Method} {context.Request.Path}"))
                     await next();
             });
@@ -262,10 +295,10 @@ namespace Calcpad.Server.Services
 
             var serverUrl = cliUrls ?? GetServerUrl();
 
-            FileLogger.LogInfo("Configuring server URLs", serverUrl);
+            FileLogger.LogVerbose("Configuring server URLs", serverUrl);
             builder.WebHost.UseUrls(serverUrl);
 
-            FileLogger.LogInfo("Building application");
+            FileLogger.LogVerbose("Building application");
             var app = builder.Build();
 
             ConfigureApp(app);

--- a/Calcpad.Web/backend/Services/CalcpadService.cs
+++ b/Calcpad.Web/backend/Services/CalcpadService.cs
@@ -62,9 +62,7 @@ namespace Calcpad.Server.Services
 
             try
             {
-                Console.WriteLine($"=== CALCPAD SERVICE: Starting conversion, length: {calcpadContent.Length} ===");
                 FileLogger.LogInfo("Starting conversion", $"Content length: {calcpadContent.Length}, Has settings: {settings != null}, Force unwrapped: {forceUnwrappedCode}, For print: {forPrint}");
-                FileLogger.LogInfo("Content preview:", calcpadContent.Substring(0, Math.Min(200, calcpadContent.Length)));
 
                 // 1. Use Calcpad.Core settings directly (defaults are set in constructors).
                 //    Per-file overrides now come from the #settings directive, handled in Core.

--- a/Calcpad.Web/backend/Services/CalcpadService.cs
+++ b/Calcpad.Web/backend/Services/CalcpadService.cs
@@ -54,7 +54,7 @@ namespace Calcpad.Server.Services
         {
             if (string.IsNullOrWhiteSpace(calcpadContent))
             {
-                FileLogger.LogWarning("Convert called with empty content");
+                FileLogger.LogVerbose("Convert called with empty content");
                 throw new ArgumentException("Content cannot be null or empty", nameof(calcpadContent));
             }
 
@@ -62,7 +62,7 @@ namespace Calcpad.Server.Services
 
             try
             {
-                FileLogger.LogInfo("Starting conversion", $"Content length: {calcpadContent.Length}, Has settings: {settings != null}, Force unwrapped: {forceUnwrappedCode}, For print: {forPrint}");
+                FileLogger.LogVerbose("Starting conversion", $"Content length: {calcpadContent.Length}, Has settings: {settings != null}, Force unwrapped: {forceUnwrappedCode}, For print: {forPrint}");
 
                 // 1. Use Calcpad.Core settings directly (defaults are set in constructors).
                 //    Per-file overrides now come from the #settings directive, handled in Core.
@@ -152,7 +152,7 @@ namespace Calcpad.Server.Services
 
                 // 6. Apply HTML wrapper with theme support
                 var finalHtml = WrapHtmlResult(htmlResult, theme, enableUi);
-                FileLogger.LogInfo("Conversion completed successfully", $"Output length: {finalHtml.Length}");
+                FileLogger.LogVerbose("Conversion completed successfully", $"Output length: {finalHtml.Length}");
 
                 return (finalHtml, openXmlExpressions, errors);
             }
@@ -475,7 +475,7 @@ tan_angle = tan(angle°)";
                 {
                     using var reader = new StreamReader(stream);
                     var template = reader.ReadToEnd();
-                    FileLogger.LogInfo("Loaded HTML template from embedded resource");
+                    FileLogger.LogVerbose("Loaded HTML template from embedded resource");
                     return template;
                 }
                 
@@ -484,7 +484,7 @@ tan_angle = tan(angle°)";
                 if (File.Exists(templatePath))
                 {
                     var template = File.ReadAllText(templatePath);
-                    FileLogger.LogInfo("Loaded HTML template from file system", templatePath);
+                    FileLogger.LogVerbose("Loaded HTML template from file system", templatePath);
                     return template;
                 }
                 

--- a/Calcpad.Web/backend/Services/ContentResolutionCache.cs
+++ b/Calcpad.Web/backend/Services/ContentResolutionCache.cs
@@ -15,20 +15,51 @@ namespace Calcpad.Server.Services
     /// </summary>
     public class ContentResolutionCache
     {
+        /// <summary>
+        /// How long a cached entry is trusted before its <c>#include</c>s are re-checked. One
+        /// keystroke fans out into four endpoints within a few hundred ms; re-validating on each
+        /// buys nothing.
+        /// </summary>
+        private const int RevalidateIntervalMs = 500;
+
         private readonly IMemoryCache _cache;
         private readonly ConcurrentDictionary<string, string> _activeKeyBySourceFile = new();
-        private readonly MemoryCacheEntryOptions _entryOptions;
+
+        /// <summary>
+        /// Resolutions currently running. Without this the four endpoints one keystroke triggers
+        /// all miss at once and each runs a full resolution, three of which are discarded.
+        /// </summary>
+        private readonly ConcurrentDictionary<string, Lazy<CacheEntry>> _inFlight = new();
+
+        private readonly int _sizeLimit;
+
+        /// <summary>
+        /// Cache budget in flattened source lines, not entries: an entry costs ~2-3 KB per line,
+        /// so an entry count says nothing about memory.
+        /// </summary>
+        public static int ResolveSizeLimit() =>
+            int.TryParse(Environment.GetEnvironmentVariable("CALCPAD_CONTENT_CACHE_SIZE_LIMIT"), out var limit) && limit > 0
+                ? limit : 50_000;
+
+        private sealed class CacheEntry
+        {
+            public required StagedResolvedContent Staged { get; init; }
+            public required ConcurrentDictionary<string, DateTime> IncludeWriteTimes { get; init; }
+            public long LastValidatedTicks;
+        }
+
+        private readonly MemoryCacheEntryOptions _baseOptions;
 
         public ContentResolutionCache(IMemoryCache cache)
         {
             _cache = cache;
+            _sizeLimit = ResolveSizeLimit();
             var expirationSeconds = int.TryParse(
                 Environment.GetEnvironmentVariable("CALCPAD_CONTENT_CACHE_EXPIRATION_SECONDS"), out var seconds)
                 ? seconds : 120;
-            _entryOptions = new MemoryCacheEntryOptions
+            _baseOptions = new MemoryCacheEntryOptions
             {
                 SlidingExpiration = TimeSpan.FromSeconds(expirationSeconds),
-                Size = 1
             };
         }
 
@@ -37,38 +68,100 @@ namespace Calcpad.Server.Services
             var fileKey = sourceFilePath ?? string.Empty;
             var key = $"{fileKey}|{Sha256Hex(content)}";
 
-            if (_cache.TryGetValue(key, out StagedResolvedContent? cached) && cached != null && IsIncludesFresh(cached))
-                return cached;
+            if (_cache.TryGetValue(key, out CacheEntry? cached) && cached != null && IsIncludesFresh(cached))
+                return cached.Staged;
 
+            // Concurrent callers for the same key share one resolution instead of racing.
+            var lazy = _inFlight.GetOrAdd(key, _ => new Lazy<CacheEntry>(
+                () => Resolve(content, sourceFilePath, fileKey, key),
+                LazyThreadSafetyMode.ExecutionAndPublication));
+            try
+            {
+                return lazy.Value.Staged;
+            }
+            finally
+            {
+                _inFlight.TryRemove(new KeyValuePair<string, Lazy<CacheEntry>>(key, lazy));
+            }
+        }
+
+        private CacheEntry Resolve(string content, string? sourceFilePath, string fileKey, string key)
+        {
             // New content for this file — drop its old entry now instead of waiting on the TTL.
             if (_activeKeyBySourceFile.TryGetValue(fileKey, out var oldKey) && oldKey != key)
                 _cache.Remove(oldKey);
 
             var staged = new ContentResolver().GetStagedContent(content, sourceFilePath: sourceFilePath);
-            _cache.Set(key, staged, _entryOptions);
+
+            var writeTimes = new ConcurrentDictionary<string, DateTime>();
+            foreach (var (path, _) in staged.Stage2.IncludedFileHashes)
+                writeTimes[path] = SafeWriteTime(path);
+
+            var entry = new CacheEntry
+            {
+                Staged = staged,
+                IncludeWriteTimes = writeTimes,
+                LastValidatedTicks = Environment.TickCount64,
+            };
+
+            var options = new MemoryCacheEntryOptions
+            {
+                SlidingExpiration = _baseOptions.SlidingExpiration,
+                Size = Math.Clamp(staged.Stage3.Lines?.Count ?? 1, 1, _sizeLimit),
+            };
+            _cache.Set(key, entry, options);
             _activeKeyBySourceFile[fileKey] = key;
-            return staged;
+            return entry;
         }
 
         /// <summary>
-        /// Re-hashes just the `#include`d files recorded on <paramref name="staged"/> instead of
-        /// rerunning include resolution/macro expansion, so an edit to an included file (without
-        /// touching the open document) still invalidates the cache promptly.
+        /// Confirms the <c>#include</c>d files recorded on <paramref name="entry"/> are unchanged,
+        /// so an edit to an included file (without touching the open document) still invalidates
+        /// the cache promptly.
         /// </summary>
-        private static bool IsIncludesFresh(StagedResolvedContent staged)
+        /// <remarks>
+        /// Checks last-write time before hashing. Includes commonly live in OneDrive folders,
+        /// where a read is a round trip through the cloud filter driver and can stall on the sync
+        /// engine — a timestamp query does not hydrate a placeholder, a read does.
+        /// </remarks>
+        private static bool IsIncludesFresh(CacheEntry entry)
         {
-            foreach (var (path, expectedHash) in staged.Stage2.IncludedFileHashes)
+            if (Environment.TickCount64 - Interlocked.Read(ref entry.LastValidatedTicks) < RevalidateIntervalMs)
+                return true;
+
+            foreach (var (path, expectedHash) in entry.Staged.Stage2.IncludedFileHashes)
             {
                 try
                 {
+                    var writeTime = SafeWriteTime(path);
+                    if (writeTime == default) return false; // deleted or unreadable since it was cached
+                    if (entry.IncludeWriteTimes.TryGetValue(path, out var known) && known == writeTime)
+                        continue;
+
                     if (Sha256Hex(File.ReadAllText(path)) != expectedHash) return false;
+                    entry.IncludeWriteTimes[path] = writeTime;
                 }
                 catch
                 {
-                    return false; // file deleted or unreadable since it was cached
+                    return false;
                 }
             }
+
+            Interlocked.Exchange(ref entry.LastValidatedTicks, Environment.TickCount64);
             return true;
+        }
+
+        private static DateTime SafeWriteTime(string path)
+        {
+            try
+            {
+                var info = new FileInfo(path);
+                return info.Exists ? info.LastWriteTimeUtc : default;
+            }
+            catch
+            {
+                return default;
+            }
         }
 
         private static string Sha256Hex(string text) =>

--- a/Calcpad.Web/backend/Services/ContentResolutionCache.cs
+++ b/Calcpad.Web/backend/Services/ContentResolutionCache.cs
@@ -109,6 +109,10 @@ namespace Calcpad.Server.Services
                 SlidingExpiration = _baseOptions.SlidingExpiration,
                 Size = Math.Clamp(staged.Stage3.Lines?.Count ?? 1, 1, _sizeLimit),
             };
+            // Without this the map keeps one entry per file path ever seen, outliving by far
+            // the cache entries it points at.
+            options.RegisterPostEvictionCallback((_, _, _, _) =>
+                _activeKeyBySourceFile.TryRemove(new KeyValuePair<string, string>(fileKey, key)));
             _cache.Set(key, entry, options);
             _activeKeyBySourceFile[fileKey] = key;
             return entry;

--- a/Calcpad.Web/backend/Services/PdfGeneratorService.cs
+++ b/Calcpad.Web/backend/Services/PdfGeneratorService.cs
@@ -286,7 +286,7 @@ namespace Calcpad.Server.Services
                 }
 
                 var executablePath = await ResolveBrowserPathAsync().ConfigureAwait(false);
-                FileLogger.LogInfo("Launching browser", executablePath);
+                FileLogger.LogVerbose("Launching browser", executablePath);
 
                 try
                 {
@@ -363,7 +363,7 @@ namespace Calcpad.Server.Services
             var systemBrowser = FindSystemBrowser();
             if (systemBrowser != null)
             {
-                FileLogger.LogInfo("Auto-detected system browser", systemBrowser);
+                FileLogger.LogVerbose("Auto-detected system browser", systemBrowser);
                 return systemBrowser;
             }
 
@@ -371,7 +371,7 @@ namespace Calcpad.Server.Services
             var downloaded = FindDownloadedChromium();
             if (downloaded != null)
             {
-                FileLogger.LogInfo("Using downloaded ChromeHeadlessShell", downloaded);
+                FileLogger.LogVerbose("Using downloaded ChromeHeadlessShell", downloaded);
                 return downloaded;
             }
 
@@ -379,7 +379,7 @@ namespace Calcpad.Server.Services
             if (IsDownloadAllowed())
                 return await DownloadChromiumAsync().ConfigureAwait(false);
 
-            FileLogger.LogWarning("WARNING: no Chromium-family browser found for PDF export", null);
+            FileLogger.LogWarning("No Chromium-family browser found for PDF export", null);
             throw new BrowserUnavailableException(
                 "No Chromium-family browser was found. Install Chrome, Edge or Chromium, set BrowserPath, or download the bundled Chromium.");
         }

--- a/Calcpad.Web/backend/appsettings.Development.json
+++ b/Calcpad.Web/backend/appsettings.Development.json
@@ -1,9 +1,3 @@
 {
-  "BrowserPath": "/usr/bin/chromium",
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    }
-  }
+  "BrowserPath": "/usr/bin/chromium"
 }

--- a/Calcpad.Web/backend/appsettings.json
+++ b/Calcpad.Web/backend/appsettings.json
@@ -3,7 +3,8 @@
   "AllowChromiumDownload": false,
   "Logging": {
     "LogLevel": {
-      "Default": "Information"
+      "Default": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
     }
   }
 }

--- a/Calcpad.Web/backend/appsettings.json
+++ b/Calcpad.Web/backend/appsettings.json
@@ -1,10 +1,4 @@
 {
   "BrowserPath": "",
-  "AllowChromiumDownload": false,
-  "Logging": {
-    "LogLevel": {
-      "Default": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
-    }
-  }
+  "AllowChromiumDownload": false
 }

--- a/Calcpad.Web/frontend/calcpad-desktop/src-tauri/src/lib.rs
+++ b/Calcpad.Web/frontend/calcpad-desktop/src-tauri/src/lib.rs
@@ -543,6 +543,24 @@ fn resolve_log_dir(app: &AppHandle) -> Option<PathBuf> {
     Some(dir)
 }
 
+/// The saved log level, read straight from the settings file the frontend writes.
+///
+/// The frontend re-pushes the level over `/api/calcpad/log-level` once it loads, but that is far
+/// too late for the server's own startup entries — without this, choosing Verbose still loses
+/// everything up to the first bind. Unreadable or unrecognised leaves it to the server's default.
+fn stored_log_level(app: &AppHandle) -> Option<String> {
+    let path = app
+        .path()
+        .app_data_dir()
+        .ok()?
+        .join("settings")
+        .join("active-settings.json");
+    let bytes = std::fs::read(path).ok()?;
+    let parsed: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
+    let level = parsed.get("extras")?.get("logLevel")?.as_str()?;
+    matches!(level, "error" | "warning" | "information" | "verbose").then(|| level.to_string())
+}
+
 #[tauri::command]
 fn log_dir(app: AppHandle) -> Result<String, String> {
     resolve_log_dir(&app)
@@ -612,6 +630,9 @@ async fn spawn_sidecar(app: &AppHandle) -> Result<String, String> {
         .stderr(Stdio::piped());
     if let Some(dir) = &log_dir {
         command.env("CALCPAD_LOG_DIR", dir);
+    }
+    if let Some(level) = stored_log_level(app) {
+        command.env("CALCPAD_LOG_LEVEL", level);
     }
     // Every /api route on the child requires this header value, passed via env rather than argv
     // (see api_token()). ASPNETCORE_ENVIRONMENT is pinned because the child inherits our whole

--- a/Calcpad.Web/frontend/calcpad-desktop/src-tauri/src/lib.rs
+++ b/Calcpad.Web/frontend/calcpad-desktop/src-tauri/src/lib.rs
@@ -737,6 +737,21 @@ async fn spawn_sidecar(app: &AppHandle) -> Result<String, String> {
         });
     }
 
+    // Relay task — owns every `server-log` emit so the readers below never do one. `emit`
+    // dispatches to the webview and can take arbitrarily long under load; doing it inline meant a
+    // busy UI stalled the reader, filled the child's 64KB stdout pipe, and blocked the .NET side
+    // in `Console.Write` — hanging the whole server with the app still responsive. The channel is
+    // bounded and lines are dropped rather than queued, since the tail buffer keeps them anyway.
+    let (log_tx, mut log_rx) = mpsc::channel::<ServerLogLine>(1024);
+    {
+        let app_for_log = app.clone();
+        tauri::async_runtime::spawn(async move {
+            while let Some(entry) = log_rx.recv().await {
+                let _ = app_for_log.emit("server-log", entry);
+            }
+        });
+    }
+
     // Stdout/stderr line readers — replaces the shell plugin's CommandEvent stream. Each stream
     // drains on its own task so a chatty stderr doesn't starve stdout, both feed the shared tail
     // buffer while scanning for Kestrel's "Now listening on:" marker, and both are type-erased to
@@ -750,6 +765,7 @@ async fn spawn_sidecar(app: &AppHandle) -> Result<String, String> {
         app: AppHandle,
         tail: Arc<Mutex<String>>,
         saw_first: Arc<std::sync::atomic::AtomicBool>,
+        log_tx: mpsc::Sender<ServerLogLine>,
     ) {
         tauri::async_runtime::spawn(async move {
             let mut lines = BufReader::new(stream).lines();
@@ -767,13 +783,11 @@ async fn spawn_sidecar(app: &AppHandle) -> Result<String, String> {
                             append_tail(&mut t, &line);
                             append_tail(&mut t, "\n");
                         }
-                        let _ = app.emit(
-                            "server-log",
-                            ServerLogLine {
-                                stream: label,
-                                line: line.clone(),
-                            },
-                        );
+                        // try_send, never send: blocking here is what wedges the sidecar.
+                        let _ = log_tx.try_send(ServerLogLine {
+                            stream: label,
+                            line: line.clone(),
+                        });
                         if let Some(url) = extract_listening_url(&line) {
                             let state: State<'_, ServerState> = app.state();
                             if let Ok(mut g) = state.url.lock() {
@@ -799,6 +813,7 @@ async fn spawn_sidecar(app: &AppHandle) -> Result<String, String> {
             app.clone(),
             tail.clone(),
             saw_first_output.clone(),
+            log_tx.clone(),
         );
     }
     if let Some(s) = stderr {
@@ -810,6 +825,7 @@ async fn spawn_sidecar(app: &AppHandle) -> Result<String, String> {
             app.clone(),
             tail.clone(),
             saw_first_output.clone(),
+            log_tx.clone(),
         );
     }
 

--- a/Calcpad.Web/frontend/calcpad-frontend/src/api/client.ts
+++ b/Calcpad.Web/frontend/calcpad-frontend/src/api/client.ts
@@ -244,6 +244,18 @@ export class CalcpadApiClient {
         return this.get<SnippetsResponse>('/api/calcpad/snippets', 'Snippets');
     }
 
+    /**
+     * Server-side log verbosity. Applies to the running process immediately, so it is pushed
+     * again whenever the panel mounts — the server may have restarted since it was last set.
+     */
+    public async setServerLogLevel(level: string): Promise<{ level: string } | null> {
+        return this.post<{ level: string }>('/api/calcpad/log-level', { level }, 'LogLevel');
+    }
+
+    public async getServerLogLevel(): Promise<{ level: string; available: string[] } | null> {
+        return this.get<{ level: string; available: string[] }>('/api/calcpad/log-level', 'LogLevel');
+    }
+
     public async prettify(
         content: string,
         indentUnit?: string,
@@ -386,11 +398,12 @@ export class CalcpadApiClient {
         return this.withSupersession(opts?.key, task);
     }
 
-    public async checkHealth(): Promise<boolean> {
+    /** Liveness probe. Answered from inside the pipeline, so a bound-but-wedged server fails it. */
+    public async checkHealth(timeoutMs: number = 5000): Promise<boolean> {
         try {
-            const response = await fetch(this.baseUrl + '/api/calcpad/snippets', {
+            const response = await fetch(this.baseUrl + '/api/calcpad/health', {
                 headers: this.authHeaders(),
-                signal: AbortSignal.timeout(5000),
+                signal: AbortSignal.timeout(timeoutMs),
             });
             return response.ok;
         } catch {

--- a/Calcpad.Web/frontend/calcpad-frontend/src/api/client.ts
+++ b/Calcpad.Web/frontend/calcpad-frontend/src/api/client.ts
@@ -24,6 +24,15 @@ import type { SnippetsResponse } from '../types/snippets';
 /** Request header carrying the server's per-launch token. Must match the backend's constant. */
 export const API_TOKEN_HEADER = 'X-Calcpad-Token';
 
+/**
+ * How long a request waits for a base URL before giving up. Covers a cold start: the VS Code
+ * extension has to resolve a .NET runtime, which may prompt, before the server binds a port.
+ */
+const BASE_URL_WAIT_MS = 30_000;
+
+/** What the endpoints that report to the user directly say when no server ever arrived. */
+const NO_SERVER_ERROR = 'No CalcpadCE server is available.';
+
 /** Mirrors the backend's own loopback test (`Program.IsLoopbackHost`). */
 function isLoopbackUrl(url: string): boolean {
     try {
@@ -49,13 +58,28 @@ export class CalcpadApiClient {
     private keySeq = new Map<string, number>();
     private keyAbort = new Map<string, AbortController>();
 
+    // Resolves as soon as a base URL exists. The VS Code extension builds this client during
+    // activation, well before the bundled server has bound a port, so requests can arrive while
+    // `baseUrl` is still empty.
+    private readonly baseUrlReady: Promise<void>;
+    private signalBaseUrlReady?: () => void;
+    // Set once the wait below has run out, so a host with no server at all fails the next
+    // request straight away instead of parking every keystroke's lint for the full timeout.
+    private baseUrlUnavailable = false;
+
     constructor(baseUrl: string, logger?: ILogger) {
         this.baseUrl = baseUrl;
         this.logger = logger;
+        this.baseUrlReady = new Promise<void>((resolve) => { this.signalBaseUrlReady = resolve; });
+        if (baseUrl) this.signalBaseUrlReady?.();
     }
 
     public setBaseUrl(url: string): void {
         this.baseUrl = url;
+        if (url) {
+            this.baseUrlUnavailable = false;
+            this.signalBaseUrlReady?.();
+        }
     }
 
     public getBaseUrl(): string {
@@ -84,6 +108,33 @@ export class CalcpadApiClient {
 
     private jsonHeaders(): Record<string, string> {
         return { 'Content-Type': 'application/json', ...this.authHeaders() };
+    }
+
+    /**
+     * The base URL, waiting for one to arrive if the server is still starting. Without this a
+     * request issued during activation fetches the relative `/api/calcpad/lint`, which fails with
+     * "Failed to parse URL from ..." — a confusing way to say the server is not up yet.
+     *
+     * Null means no server ever arrived, and the caller reports a failed request as usual. That
+     * verdict then sticks until a URL does arrive, so a host with no server at all does not park
+     * each keystroke's lint for the full timeout.
+     */
+    private async resolveBaseUrl(tag: string): Promise<string | null> {
+        if (this.baseUrl) return this.baseUrl;
+        if (this.baseUrlUnavailable) return null;
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        await Promise.race([
+            this.baseUrlReady,
+            new Promise<void>((resolve) => { timer = setTimeout(resolve, BASE_URL_WAIT_MS); }),
+        ]);
+        clearTimeout(timer);
+        if (this.baseUrl) return this.baseUrl;
+        // Everything waiting hits this together, so only the first one reports it.
+        if (!this.baseUrlUnavailable) {
+            this.baseUrlUnavailable = true;
+            this.logger?.appendLine(`[${tag}] No server URL — request skipped`, 'warning');
+        }
+        return null;
     }
 
     /**
@@ -175,7 +226,9 @@ export class CalcpadApiClient {
     ): Promise<PortableBundleResult> {
         return (async () => {
             try {
-                const response = await fetch(`${this.baseUrl}/api/calcpad/portable/bundle`, {
+                const base = await this.resolveBaseUrl('BundlePortable');
+                if (base === null) return { errors: [NO_SERVER_ERROR] };
+                const response = await fetch(`${base}/api/calcpad/portable/bundle`, {
                     method: 'POST',
                     headers: this.jsonHeaders(),
                     body: JSON.stringify({ content, sourceFilePath }),
@@ -184,7 +237,7 @@ export class CalcpadApiClient {
                 const body = await response.json().catch(() => null);
                 if (response.ok && typeof body?.content === 'string') return { content: body.content, errors: [] };
 
-                this.logger?.appendLine(`[BundlePortable] Server returned ${response.status}`);
+                this.logger?.appendLine(`[BundlePortable] Server returned ${response.status}`, 'warning');
                 const messages: unknown = body?.messages;
                 return {
                     errors: Array.isArray(messages) && messages.length
@@ -210,7 +263,9 @@ export class CalcpadApiClient {
     ): Promise<PortablePackageResult> {
         return (async () => {
             try {
-                const response = await fetch(`${this.baseUrl}/api/calcpad/portable/package`, {
+                const base = await this.resolveBaseUrl('PackagePortable');
+                if (base === null) return { bundled: [], errors: [NO_SERVER_ERROR] };
+                const response = await fetch(`${base}/api/calcpad/portable/package`, {
                     method: 'POST',
                     headers: this.jsonHeaders(),
                     body: JSON.stringify({ content, sourceFilePath }),
@@ -225,7 +280,7 @@ export class CalcpadApiClient {
                     errors: [],
                 };
 
-                this.logger?.appendLine(`[PackagePortable] Server returned ${response.status}`);
+                this.logger?.appendLine(`[PackagePortable] Server returned ${response.status}`, 'warning');
                 const messages: unknown = body?.messages;
                 return {
                     bundled: [],
@@ -288,7 +343,9 @@ export class CalcpadApiClient {
         opts?: { key?: string; write?: boolean },
     ): Promise<ArrayBuffer | ConvertResult | null> {
         return this.withSupersession(opts?.key, async (signal) => {
-            const url = this.baseUrl + '/api/calcpad/convert';
+            const base = await this.resolveBaseUrl('Convert');
+            if (base === null) return null;
+            const url = base + '/api/calcpad/convert';
             try {
                 const response = await fetch(url, {
                     method: 'POST',
@@ -331,7 +388,9 @@ export class CalcpadApiClient {
         opts?: { forPrint?: boolean; uiOverrides?: Record<string, string>; write?: boolean },
     ): Promise<ArrayBuffer | null> {
         return (async () => {
-            const url = this.baseUrl + '/api/calcpad/docx';
+            const base = await this.resolveBaseUrl('Docx');
+            if (base === null) return null;
+            const url = base + '/api/calcpad/docx';
             try {
                 const response = await fetch(url, {
                     method: 'POST',
@@ -367,7 +426,9 @@ export class CalcpadApiClient {
         opts?: { key?: string; write?: boolean },
     ): Promise<ConvertResult | null> {
         return this.withSupersession(opts?.key, async (signal) => {
-            const url = this.baseUrl + '/api/calcpad/convert?unwrap=true';
+            const base = await this.resolveBaseUrl('ConvertUnwrapped');
+            if (base === null) return null;
+            const url = base + '/api/calcpad/convert?unwrap=true';
             try {
                 const response = await fetch(url, {
                     method: 'POST',
@@ -400,6 +461,8 @@ export class CalcpadApiClient {
 
     /** Liveness probe. Answered from inside the pipeline, so a bound-but-wedged server fails it. */
     public async checkHealth(timeoutMs: number = 5000): Promise<boolean> {
+        // Never waits: this is the liveness probe, and no URL is already the answer.
+        if (!this.baseUrl) return false;
         try {
             const response = await fetch(this.baseUrl + '/api/calcpad/health', {
                 headers: this.authHeaders(),
@@ -413,9 +476,11 @@ export class CalcpadApiClient {
 
     private post<T>(endpoint: string, body: unknown, tag: string, key?: string): Promise<T | null> {
         return this.withSupersession(key, async (signal) => {
-            const url = this.baseUrl + endpoint;
+            const base = await this.resolveBaseUrl(tag);
+            if (base === null) return null;
+            const url = base + endpoint;
             try {
-                this.logger?.appendLine(`[${tag}] Sending request to server...`);
+                this.logger?.appendLine(`[${tag}] Sending request to server...`, 'verbose');
                 const response = await fetch(url, {
                     method: 'POST',
                     headers: this.jsonHeaders(),
@@ -423,7 +488,7 @@ export class CalcpadApiClient {
                     signal: combineSignals(AbortSignal.timeout(30000), signal),
                 });
                 if (!response.ok) {
-                    this.logger?.appendLine(`[${tag}] Server returned ${response.status}`);
+                    this.logger?.appendLine(`[${tag}] Server returned ${response.status}`, 'warning');
                     return null;
                 }
                 const data: T = await response.json();
@@ -436,15 +501,17 @@ export class CalcpadApiClient {
     }
 
     private async get<T>(endpoint: string, tag: string): Promise<T | null> {
-        const url = this.baseUrl + endpoint;
+        const base = await this.resolveBaseUrl(tag);
+        if (base === null) return null;
+        const url = base + endpoint;
         try {
-            this.logger?.appendLine(`[${tag}] Sending request to server...`);
+            this.logger?.appendLine(`[${tag}] Sending request to server...`, 'verbose');
             const response = await fetch(url, {
                 headers: this.authHeaders(),
                 signal: AbortSignal.timeout(30000),
             });
             if (!response.ok) {
-                this.logger?.appendLine(`[${tag}] Server returned ${response.status}`);
+                this.logger?.appendLine(`[${tag}] Server returned ${response.status}`, 'warning');
                 return null;
             }
             const data: T = await response.json();
@@ -457,12 +524,18 @@ export class CalcpadApiClient {
 
     private logError(tag: string, error: unknown): void {
         if (!this.logger) return;
+        // AbortError and TimeoutError are both DOMExceptions from an aborted signal, but they
+        // mean opposite things: withSupersession raises the first on every keystroke when a newer
+        // request replaces this one, while only the second is a server that never answered.
         if (error instanceof DOMException && error.name === 'AbortError') {
-            this.logger.appendLine(`[${tag}] Request timed out`);
+            this.logger.appendLine(`[${tag}] Superseded by a newer request`, 'verbose');
+        } else if (error instanceof DOMException && error.name === 'TimeoutError') {
+            this.logger.appendLine(`[${tag}] Request timed out`, 'warning');
         } else if (error instanceof TypeError && error.message.includes('fetch')) {
-            this.logger.appendLine(`[${tag}] Server connection refused`);
+            // Routine while the server is restarting; the connection monitor reports the outage.
+            this.logger.appendLine(`[${tag}] Server connection refused`, 'verbose');
         } else {
-            this.logger.appendLine(`[${tag}] Error: ${error instanceof Error ? error.message : String(error)}`);
+            this.logger.appendLine(`[${tag}] Error: ${error instanceof Error ? error.message : String(error)}`, 'warning');
         }
     }
 }

--- a/Calcpad.Web/frontend/calcpad-frontend/src/api/client.ts
+++ b/Calcpad.Web/frontend/calcpad-frontend/src/api/client.ts
@@ -111,16 +111,17 @@ export class CalcpadApiClient {
     }
 
     /**
-     * The base URL, waiting for one to arrive if the server is still starting. Without this a
-     * request issued during activation fetches the relative `/api/calcpad/lint`, which fails with
-     * "Failed to parse URL from ..." — a confusing way to say the server is not up yet.
+     * The full URL for `endpoint`, waiting for a base URL to arrive if the server is still
+     * starting. Without this a request issued during activation fetches the relative
+     * `/api/calcpad/lint`, which fails with "Failed to parse URL from ..." — a confusing way
+     * to say the server is not up yet.
      *
      * Null means no server ever arrived, and the caller reports a failed request as usual. That
      * verdict then sticks until a URL does arrive, so a host with no server at all does not park
      * each keystroke's lint for the full timeout.
      */
-    private async resolveBaseUrl(tag: string): Promise<string | null> {
-        if (this.baseUrl) return this.baseUrl;
+    private async resolveUrl(endpoint: string, tag: string): Promise<string | null> {
+        if (this.baseUrl) return this.baseUrl + endpoint;
         if (this.baseUrlUnavailable) return null;
         let timer: ReturnType<typeof setTimeout> | undefined;
         await Promise.race([
@@ -128,7 +129,7 @@ export class CalcpadApiClient {
             new Promise<void>((resolve) => { timer = setTimeout(resolve, BASE_URL_WAIT_MS); }),
         ]);
         clearTimeout(timer);
-        if (this.baseUrl) return this.baseUrl;
+        if (this.baseUrl) return this.baseUrl + endpoint;
         // Everything waiting hits this together, so only the first one reports it.
         if (!this.baseUrlUnavailable) {
             this.baseUrlUnavailable = true;
@@ -226,9 +227,9 @@ export class CalcpadApiClient {
     ): Promise<PortableBundleResult> {
         return (async () => {
             try {
-                const base = await this.resolveBaseUrl('BundlePortable');
-                if (base === null) return { errors: [NO_SERVER_ERROR] };
-                const response = await fetch(`${base}/api/calcpad/portable/bundle`, {
+                const url = await this.resolveUrl('/api/calcpad/portable/bundle', 'BundlePortable');
+                if (url === null) return { errors: [NO_SERVER_ERROR] };
+                const response = await fetch(url, {
                     method: 'POST',
                     headers: this.jsonHeaders(),
                     body: JSON.stringify({ content, sourceFilePath }),
@@ -263,9 +264,9 @@ export class CalcpadApiClient {
     ): Promise<PortablePackageResult> {
         return (async () => {
             try {
-                const base = await this.resolveBaseUrl('PackagePortable');
-                if (base === null) return { bundled: [], errors: [NO_SERVER_ERROR] };
-                const response = await fetch(`${base}/api/calcpad/portable/package`, {
+                const url = await this.resolveUrl('/api/calcpad/portable/package', 'PackagePortable');
+                if (url === null) return { bundled: [], errors: [NO_SERVER_ERROR] };
+                const response = await fetch(url, {
                     method: 'POST',
                     headers: this.jsonHeaders(),
                     body: JSON.stringify({ content, sourceFilePath }),
@@ -343,9 +344,8 @@ export class CalcpadApiClient {
         opts?: { key?: string; write?: boolean },
     ): Promise<ArrayBuffer | ConvertResult | null> {
         return this.withSupersession(opts?.key, async (signal) => {
-            const base = await this.resolveBaseUrl('Convert');
-            if (base === null) return null;
-            const url = base + '/api/calcpad/convert';
+            const url = await this.resolveUrl('/api/calcpad/convert', 'Convert');
+            if (url === null) return null;
             try {
                 const response = await fetch(url, {
                     method: 'POST',
@@ -388,9 +388,8 @@ export class CalcpadApiClient {
         opts?: { forPrint?: boolean; uiOverrides?: Record<string, string>; write?: boolean },
     ): Promise<ArrayBuffer | null> {
         return (async () => {
-            const base = await this.resolveBaseUrl('Docx');
-            if (base === null) return null;
-            const url = base + '/api/calcpad/docx';
+            const url = await this.resolveUrl('/api/calcpad/docx', 'Docx');
+            if (url === null) return null;
             try {
                 const response = await fetch(url, {
                     method: 'POST',
@@ -426,9 +425,8 @@ export class CalcpadApiClient {
         opts?: { key?: string; write?: boolean },
     ): Promise<ConvertResult | null> {
         return this.withSupersession(opts?.key, async (signal) => {
-            const base = await this.resolveBaseUrl('ConvertUnwrapped');
-            if (base === null) return null;
-            const url = base + '/api/calcpad/convert?unwrap=true';
+            const url = await this.resolveUrl('/api/calcpad/convert?unwrap=true', 'ConvertUnwrapped');
+            if (url === null) return null;
             try {
                 const response = await fetch(url, {
                     method: 'POST',
@@ -476,9 +474,8 @@ export class CalcpadApiClient {
 
     private post<T>(endpoint: string, body: unknown, tag: string, key?: string): Promise<T | null> {
         return this.withSupersession(key, async (signal) => {
-            const base = await this.resolveBaseUrl(tag);
-            if (base === null) return null;
-            const url = base + endpoint;
+            const url = await this.resolveUrl(endpoint, tag);
+            if (url === null) return null;
             try {
                 this.logger?.appendLine(`[${tag}] Sending request to server...`, 'verbose');
                 const response = await fetch(url, {
@@ -501,9 +498,8 @@ export class CalcpadApiClient {
     }
 
     private async get<T>(endpoint: string, tag: string): Promise<T | null> {
-        const base = await this.resolveBaseUrl(tag);
-        if (base === null) return null;
-        const url = base + endpoint;
+        const url = await this.resolveUrl(endpoint, tag);
+        if (url === null) return null;
         try {
             this.logger?.appendLine(`[${tag}] Sending request to server...`, 'verbose');
             const response = await fetch(url, {

--- a/Calcpad.Web/frontend/calcpad-frontend/src/defaults/settings.default.json
+++ b/Calcpad.Web/frontend/calcpad-frontend/src/defaults/settings.default.json
@@ -45,6 +45,7 @@
         "autoInputMode": true,
         "previewUiOverrides": false,
         "linterMinSeverity": "information",
+        "serverLogLevel": "warning",
         "maxOutputLines": 1000,
         "maxPreviewSizeMB": 24,
         "maxPreviewConsoleMessages": 500,

--- a/Calcpad.Web/frontend/calcpad-frontend/src/defaults/settings.default.json
+++ b/Calcpad.Web/frontend/calcpad-frontend/src/defaults/settings.default.json
@@ -45,7 +45,7 @@
         "autoInputMode": true,
         "previewUiOverrides": false,
         "linterMinSeverity": "information",
-        "serverLogLevel": "warning",
+        "logLevel": "warning",
         "maxOutputLines": 1000,
         "maxPreviewSizeMB": 24,
         "maxPreviewConsoleMessages": 500,

--- a/Calcpad.Web/frontend/calcpad-frontend/src/index.ts
+++ b/Calcpad.Web/frontend/calcpad-frontend/src/index.ts
@@ -49,10 +49,12 @@ export {
     validatePdfValue,
 } from './types/pdf-settings';
 
-export type { CalcpadSettings, CalcpadExtras, CalcpadSettingsBlob, WriteMode } from './types/settings';
+export type { CalcpadSettings, CalcpadExtras, CalcpadSettingsBlob, WriteMode, ServerLogLevel } from './types/settings';
 export {
     WRITE_MODE_OPTIONS,
     coerceWriteMode,
+    SERVER_LOG_LEVEL_OPTIONS,
+    coerceServerLogLevel,
     writesAllowed,
     getDefaultSettings,
     getDefaultExtras,

--- a/Calcpad.Web/frontend/calcpad-frontend/src/index.ts
+++ b/Calcpad.Web/frontend/calcpad-frontend/src/index.ts
@@ -100,7 +100,8 @@ export type { PdfBrowserStatus } from './api/pdf-browser';
 export { CalcpadLintService } from './services/linter';
 export { CalcpadDefinitionsService } from './services/definitions';
 export { CalcpadSnippetService } from './services/snippets';
-export { setLogLevel, getLogLevel, shouldLog } from './services/log-level';
+export { setLogLevel, getLogLevel, shouldLog, DISPLAY_LOG_LEVEL, toDisplayLogLevel } from './services/log-level';
+export type { DisplayLogLevel } from './services/log-level';
 export { ConnectionMonitor } from './services/connection-monitor';
 export type {
     ServerStatus,

--- a/Calcpad.Web/frontend/calcpad-frontend/src/index.ts
+++ b/Calcpad.Web/frontend/calcpad-frontend/src/index.ts
@@ -49,12 +49,12 @@ export {
     validatePdfValue,
 } from './types/pdf-settings';
 
-export type { CalcpadSettings, CalcpadExtras, CalcpadSettingsBlob, WriteMode, ServerLogLevel } from './types/settings';
+export type { CalcpadSettings, CalcpadExtras, CalcpadSettingsBlob, WriteMode, CalcpadLogLevel } from './types/settings';
 export {
     WRITE_MODE_OPTIONS,
     coerceWriteMode,
-    SERVER_LOG_LEVEL_OPTIONS,
-    coerceServerLogLevel,
+    LOG_LEVEL_OPTIONS,
+    coerceLogLevel,
     writesAllowed,
     getDefaultSettings,
     getDefaultExtras,
@@ -100,6 +100,13 @@ export type { PdfBrowserStatus } from './api/pdf-browser';
 export { CalcpadLintService } from './services/linter';
 export { CalcpadDefinitionsService } from './services/definitions';
 export { CalcpadSnippetService } from './services/snippets';
+export { setLogLevel, getLogLevel, shouldLog } from './services/log-level';
+export { ConnectionMonitor } from './services/connection-monitor';
+export type {
+    ServerStatus,
+    ServerLifecycleState,
+    ConnectionMonitorOptions,
+} from './services/connection-monitor';
 export {
     SEMANTIC_TOKEN_TYPES,
     TOKEN_TYPE_MAP,

--- a/Calcpad.Web/frontend/calcpad-frontend/src/services/connection-monitor.ts
+++ b/Calcpad.Web/frontend/calcpad-frontend/src/services/connection-monitor.ts
@@ -2,13 +2,19 @@
  * Tracks whether the Calcpad server is answering, and reports recoveries so the app can
  * re-render against a server that just came back.
  *
- * The host pushes lifecycle transitions in (markConnecting / markStopped / notifyMaybeUp) and an
+ * The host pushes lifecycle transitions in (applyLifecycle, or the marks it delegates to) and an
  * adaptive poll is the backstop for what the host can't see — a hang, or a process that died
- * without the Rust layer noticing. Only the probe promotes a state to `connected`: a bound port
- * proves Kestrel is listening, not that the pipeline answers.
+ * without the process supervisor noticing. Only the probe promotes a state to `connected`: a
+ * bound port proves Kestrel is listening, not that the pipeline answers.
  */
 
 export type ServerStatus = 'connected' | 'connecting' | 'disconnected';
+
+/**
+ * What the host has told us about the server process. A crash collapses into `starting` when a
+ * retry is scheduled and `stopped` when the streak is exhausted — the host owns that counter.
+ */
+export type ServerLifecycleState = 'starting' | 'running' | 'stopped';
 
 export interface ConnectionMonitorOptions {
     probe: (timeoutMs: number) => Promise<boolean>;
@@ -83,6 +89,15 @@ export class ConnectionMonitor {
         this.setStatus('disconnected', reason);
         this.suspended = true;
         this.clearTimer();
+    }
+
+    /** A host lifecycle report, mapped onto the three states. */
+    applyLifecycle(state: ServerLifecycleState, detail?: string): void {
+        switch (state) {
+            case 'starting': this.markConnecting(detail ?? 'starting'); break;
+            case 'running': this.notifyMaybeUp(); break;
+            case 'stopped': this.markStopped(detail ?? 'stopped'); break;
+        }
     }
 
     /** The host believes a port is bound. Probes to confirm before going green. */

--- a/Calcpad.Web/frontend/calcpad-frontend/src/services/log-level.ts
+++ b/Calcpad.Web/frontend/calcpad-frontend/src/services/log-level.ts
@@ -1,0 +1,30 @@
+import type { CalcpadLogLevel } from '../types/settings';
+
+/**
+ * The client-side half of the log level, mirroring FileLogger.MinLevel on the server. Module
+ * state rather than a parameter because every logger in every host consults it, and both hosts
+ * already have exactly one place where the level changes.
+ *
+ * Most-severe-first, so filtering is one `<=` test.
+ */
+const RANK: Record<CalcpadLogLevel, number> = {
+    error: 0,
+    warning: 1,
+    information: 2,
+    verbose: 3,
+};
+
+let current: CalcpadLogLevel = 'warning';
+
+export function setLogLevel(level: CalcpadLogLevel): void {
+    current = level;
+}
+
+export function getLogLevel(): CalcpadLogLevel {
+    return current;
+}
+
+/** Whether an entry at `level` should be written. Entries default to `information`. */
+export function shouldLog(level: CalcpadLogLevel = 'information'): boolean {
+    return RANK[level] <= RANK[current];
+}

--- a/Calcpad.Web/frontend/calcpad-frontend/src/services/log-level.ts
+++ b/Calcpad.Web/frontend/calcpad-frontend/src/services/log-level.ts
@@ -14,6 +14,28 @@ const RANK: Record<CalcpadLogLevel, number> = {
     verbose: 3,
 };
 
+/**
+ * How a log level is shown in an Output panel — the four labels the panels print and filter
+ * their rows by. Narrower than {@link CalcpadLogLevel}, which is what callers log at.
+ */
+export type DisplayLogLevel = 'info' | 'warn' | 'error' | 'debug';
+
+/** {@link DisplayLogLevel} onto the shared log level, which is what filtering is keyed on. */
+export const DISPLAY_LOG_LEVEL: Record<DisplayLogLevel, CalcpadLogLevel> = {
+    error: 'error',
+    warn: 'warning',
+    info: 'information',
+    debug: 'verbose',
+};
+
+/** The shared log level onto its display level. */
+export function toDisplayLogLevel(level?: CalcpadLogLevel): DisplayLogLevel {
+    return level === 'error' ? 'error'
+        : level === 'warning' ? 'warn'
+            : level === 'verbose' ? 'debug'
+                : 'info';
+}
+
 let current: CalcpadLogLevel = 'warning';
 
 export function setLogLevel(level: CalcpadLogLevel): void {

--- a/Calcpad.Web/frontend/calcpad-frontend/src/services/message-bridge/base.ts
+++ b/Calcpad.Web/frontend/calcpad-frontend/src/services/message-bridge/base.ts
@@ -7,7 +7,8 @@ import type { MetadataCommentData, MetadataCommentBlock, MetadataLayout, Definit
 import { findUiDirectiveBlock, serializeUiDirective } from '../../text/ui-directive';
 import type { UiDirectiveData } from '../../text/ui-directive';
 import type { DefinitionsResponse, ExportVariant } from '../../types/api';
-import { getDefaultSettings, buildApiSettings, coerceWriteMode, coerceServerLogLevel, writesAllowed } from '../../types/settings';
+import { getDefaultSettings, buildApiSettings, coerceWriteMode, coerceLogLevel, writesAllowed } from '../../types/settings';
+import { setLogLevel } from '../log-level';
 import type { CalcpadSettings, WriteMode } from '../../types/settings';
 import { resolveStoredPdfSettings, resolveEffectivePdfSettings } from '../../types/pdf-settings';
 import type { PdfSettings } from '../../types/pdf-settings';
@@ -313,10 +314,10 @@ export abstract class BaseMessageBridge {
                 this.setExtraSetting('linterMinSeverity', message.severity);
                 this.postToVue({ type: 'linterMinSeverityChanged', severity: message.severity });
                 break;
-            case 'updateServerLogLevel':
-                this.setExtraSetting('serverLogLevel', message.level);
-                this.postToVue({ type: 'serverLogLevelChanged', level: message.level });
-                void this.apiClient.setServerLogLevel(message.level);
+            case 'updateLogLevel':
+                this.setExtraSetting('logLevel', message.level);
+                this.postToVue({ type: 'logLevelChanged', level: message.level });
+                this.applyLogLevel(message.level);
                 break;
             case 'updateMaxOutputLines':
                 this.setExtraSetting('maxOutputLines', String(message.value));
@@ -504,11 +505,18 @@ export abstract class BaseMessageBridge {
         }
     }
 
+    /** Applies the level to this process and pushes it to the server, which holds its own copy. */
+    protected applyLogLevel(raw: string | undefined | null): void {
+        const level = coerceLogLevel(raw);
+        setLogLevel(level);
+        void this.apiClient.setServerLogLevel(level);
+    }
+
     protected async handleGetSettings(): Promise<void> {
         const extras = await this.buildSettingsResponseExtras();
         // The server may have started before us, or restarted after a crash, so it does not
         // necessarily hold the level the user chose. Re-pushing here is idempotent.
-        void this.apiClient.setServerLogLevel(coerceServerLogLevel(this.getExtraSetting('serverLogLevel')));
+        this.applyLogLevel(this.getExtraSetting('logLevel'));
         this.postToVue({
             type: 'settingsResponse',
             settings: this.settings,
@@ -522,7 +530,7 @@ export abstract class BaseMessageBridge {
             enableAutoInputMode: this.getExtraSetting('autoInputMode') !== 'false',
             enablePreviewUiOverrides: this.previewAppliesUiOverrides(),
             linterMinSeverity: this.getExtraSetting('linterMinSeverity') || 'information',
-            serverLogLevel: coerceServerLogLevel(this.getExtraSetting('serverLogLevel')),
+            logLevel: coerceLogLevel(this.getExtraSetting('logLevel')),
             maxOutputLines: Number(this.getExtraSetting('maxOutputLines')) || 1000,
             maxPreviewSizeMB: Number(this.getExtraSetting('maxPreviewSizeMB')) || DEFAULT_PREVIEW_SIZE_MB,
             maxPreviewConsoleMessages: Number(this.getExtraSetting('maxPreviewConsoleMessages'))

--- a/Calcpad.Web/frontend/calcpad-frontend/src/services/message-bridge/base.ts
+++ b/Calcpad.Web/frontend/calcpad-frontend/src/services/message-bridge/base.ts
@@ -7,7 +7,7 @@ import type { MetadataCommentData, MetadataCommentBlock, MetadataLayout, Definit
 import { findUiDirectiveBlock, serializeUiDirective } from '../../text/ui-directive';
 import type { UiDirectiveData } from '../../text/ui-directive';
 import type { DefinitionsResponse, ExportVariant } from '../../types/api';
-import { getDefaultSettings, buildApiSettings, coerceWriteMode, writesAllowed } from '../../types/settings';
+import { getDefaultSettings, buildApiSettings, coerceWriteMode, coerceServerLogLevel, writesAllowed } from '../../types/settings';
 import type { CalcpadSettings, WriteMode } from '../../types/settings';
 import { resolveStoredPdfSettings, resolveEffectivePdfSettings } from '../../types/pdf-settings';
 import type { PdfSettings } from '../../types/pdf-settings';
@@ -313,6 +313,11 @@ export abstract class BaseMessageBridge {
                 this.setExtraSetting('linterMinSeverity', message.severity);
                 this.postToVue({ type: 'linterMinSeverityChanged', severity: message.severity });
                 break;
+            case 'updateServerLogLevel':
+                this.setExtraSetting('serverLogLevel', message.level);
+                this.postToVue({ type: 'serverLogLevelChanged', level: message.level });
+                void this.apiClient.setServerLogLevel(message.level);
+                break;
             case 'updateMaxOutputLines':
                 this.setExtraSetting('maxOutputLines', String(message.value));
                 this.postToVue({ type: 'maxOutputLinesChanged', value: message.value });
@@ -501,6 +506,9 @@ export abstract class BaseMessageBridge {
 
     protected async handleGetSettings(): Promise<void> {
         const extras = await this.buildSettingsResponseExtras();
+        // The server may have started before us, or restarted after a crash, so it does not
+        // necessarily hold the level the user chose. Re-pushing here is idempotent.
+        void this.apiClient.setServerLogLevel(coerceServerLogLevel(this.getExtraSetting('serverLogLevel')));
         this.postToVue({
             type: 'settingsResponse',
             settings: this.settings,
@@ -514,6 +522,7 @@ export abstract class BaseMessageBridge {
             enableAutoInputMode: this.getExtraSetting('autoInputMode') !== 'false',
             enablePreviewUiOverrides: this.previewAppliesUiOverrides(),
             linterMinSeverity: this.getExtraSetting('linterMinSeverity') || 'information',
+            serverLogLevel: coerceServerLogLevel(this.getExtraSetting('serverLogLevel')),
             maxOutputLines: Number(this.getExtraSetting('maxOutputLines')) || 1000,
             maxPreviewSizeMB: Number(this.getExtraSetting('maxPreviewSizeMB')) || DEFAULT_PREVIEW_SIZE_MB,
             maxPreviewConsoleMessages: Number(this.getExtraSetting('maxPreviewConsoleMessages'))

--- a/Calcpad.Web/frontend/calcpad-frontend/src/types/interfaces.ts
+++ b/Calcpad.Web/frontend/calcpad-frontend/src/types/interfaces.ts
@@ -1,9 +1,12 @@
+import type { CalcpadLogLevel } from './settings';
+
 /**
- * Logging adapter interface: vscode.OutputChannel in the extension, console or a file logger
- * in the desktop app.
+ * Logging adapter interface: vscode.OutputChannel in the extension, the in-app Output panel in
+ * the desktop app. Implementations drop entries below the current level (see services/log-level),
+ * so callers may log freely at `verbose`. Omitting the level means `information`.
  */
 export interface ILogger {
-    appendLine(message: string): void;
+    appendLine(message: string, level?: CalcpadLogLevel): void;
 }
 
 /**

--- a/Calcpad.Web/frontend/calcpad-frontend/src/types/settings.ts
+++ b/Calcpad.Web/frontend/calcpad-frontend/src/types/settings.ts
@@ -82,12 +82,13 @@ export function coerceWriteMode(raw: string | undefined | null): WriteMode {
 }
 
 /**
- * Verbosity of the Calcpad server's own logging, mirroring the levels in FileLogger.cs. Pushed
- * to the server over /api/calcpad/log-level; it is a server-side setting, not a client one.
+ * Verbosity of Calcpad's logging, mirroring the levels in FileLogger.cs. It governs both sides:
+ * pushed to the server over /api/calcpad/log-level, and applied locally to what the editor writes
+ * to its own output channels.
  */
-export type ServerLogLevel = 'error' | 'warning' | 'information' | 'verbose';
+export type CalcpadLogLevel = 'error' | 'warning' | 'information' | 'verbose';
 
-export const SERVER_LOG_LEVEL_OPTIONS: { value: ServerLogLevel; label: string; detail: string }[] = [
+export const LOG_LEVEL_OPTIONS: { value: CalcpadLogLevel; label: string; detail: string }[] = [
     {
         value: 'error',
         label: 'Error',
@@ -96,22 +97,22 @@ export const SERVER_LOG_LEVEL_OPTIONS: { value: ServerLogLevel; label: string; d
     {
         value: 'warning',
         label: 'Warning',
-        detail: 'Failures plus recoverable problems, such as a missing browser for PDF export. The default, and quiet during normal editing.',
+        detail: 'Failures plus recoverable problems, such as a missing browser for PDF export. The default, and silent during normal editing.',
     },
     {
         value: 'information',
         label: 'Information',
-        detail: 'Adds one-off lifecycle events: startup, the bound URL, shutdown, and browser downloads.',
+        detail: 'Adds one-off events: startup, the bound URL, server restarts, shutdown, and browser downloads.',
     },
     {
         value: 'verbose',
         label: 'Verbose',
-        detail: 'Adds a line per request. Useful when diagnosing a specific worksheet, noisy otherwise, since editing sends requests continuously.',
+        detail: 'Adds a line per request, on both the server and the editor. Useful when diagnosing a specific worksheet, noisy otherwise, since editing sends requests continuously.',
     },
 ];
 
-export function coerceServerLogLevel(raw: string | undefined | null): ServerLogLevel {
-    return SERVER_LOG_LEVEL_OPTIONS.some(o => o.value === raw) ? raw as ServerLogLevel : 'warning';
+export function coerceLogLevel(raw: string | undefined | null): CalcpadLogLevel {
+    return LOG_LEVEL_OPTIONS.some(o => o.value === raw) ? raw as CalcpadLogLevel : 'warning';
 }
 
 /**

--- a/Calcpad.Web/frontend/calcpad-frontend/src/types/settings.ts
+++ b/Calcpad.Web/frontend/calcpad-frontend/src/types/settings.ts
@@ -82,6 +82,39 @@ export function coerceWriteMode(raw: string | undefined | null): WriteMode {
 }
 
 /**
+ * Verbosity of the Calcpad server's own logging, mirroring the levels in FileLogger.cs. Pushed
+ * to the server over /api/calcpad/log-level; it is a server-side setting, not a client one.
+ */
+export type ServerLogLevel = 'error' | 'warning' | 'information' | 'verbose';
+
+export const SERVER_LOG_LEVEL_OPTIONS: { value: ServerLogLevel; label: string; detail: string }[] = [
+    {
+        value: 'error',
+        label: 'Error',
+        detail: 'Only failures. Crash and hang reports are always written regardless of this setting.',
+    },
+    {
+        value: 'warning',
+        label: 'Warning',
+        detail: 'Failures plus recoverable problems, such as a missing browser for PDF export. The default, and quiet during normal editing.',
+    },
+    {
+        value: 'information',
+        label: 'Information',
+        detail: 'Adds one-off lifecycle events: startup, the bound URL, shutdown, and browser downloads.',
+    },
+    {
+        value: 'verbose',
+        label: 'Verbose',
+        detail: 'Adds a line per request. Useful when diagnosing a specific worksheet, noisy otherwise, since editing sends requests continuously.',
+    },
+];
+
+export function coerceServerLogLevel(raw: string | undefined | null): ServerLogLevel {
+    return SERVER_LOG_LEVEL_OPTIONS.some(o => o.value === raw) ? raw as ServerLogLevel : 'warning';
+}
+
+/**
  * Whether a render may run `#write`/`#append`, decided from the API's own two flags: `forPrint`
  * is the report layout and `enableUi` is the input form. They never both hold — the server clears
  * `enableUi` for a report — so the three cases below are exhaustive.

--- a/Calcpad.Web/frontend/calcpad-frontend/src/vue/components/CalcpadApp.vue
+++ b/Calcpad.Web/frontend/calcpad-frontend/src/vue/components/CalcpadApp.vue
@@ -85,7 +85,7 @@
         :initial-enable-preview-ui-overrides="enablePreviewUiOverrides"
         :initial-dark-background="darkBackground"
         :initial-linter-min-severity="linterMinSeverity"
-        :initial-server-log-level="serverLogLevel"
+        :initial-log-level="logLevel"
         :initial-max-output-lines="maxOutputLines"
         :initial-max-preview-size="maxPreviewSizeMB"
         :initial-max-preview-console-messages="maxPreviewConsoleMessages"
@@ -110,7 +110,7 @@
         @update-preview-ui-overrides="handleUpdatePreviewUiOverrides"
         @update-dark-background="handleUpdateDarkBackground"
         @update-linter-min-severity="handleUpdateLinterMinSeverity"
-        @update-server-log-level="handleUpdateServerLogLevel"
+        @update-log-level="handleUpdateLogLevel"
         @update-max-output-lines="handleUpdateMaxOutputLines"
         @update-max-preview-size="handleUpdateMaxPreviewSize"
         @update-max-preview-console-messages="handleUpdateMaxPreviewConsoleMessages"
@@ -256,7 +256,7 @@ const enableAutoInputMode = ref(true)
 const enablePreviewUiOverrides = ref(false)
 const darkBackground = ref('#1e1e1e')
 const linterMinSeverity = ref('information')
-const serverLogLevel = ref('warning')
+const logLevel = ref('warning')
 const maxOutputLines = ref(1000)
 const maxPreviewSizeMB = ref(DEFAULT_PREVIEW_SIZE_MB)
 const maxPreviewConsoleMessages = ref(DEFAULT_CONSOLE_MESSAGES_PER_DOCUMENT)
@@ -549,9 +549,9 @@ const handleUpdateLinterMinSeverity = (severity: string) => {
   postMessage({ type: 'updateLinterMinSeverity', severity })
 }
 
-const handleUpdateServerLogLevel = (level: string) => {
-  serverLogLevel.value = level
-  postMessage({ type: 'updateServerLogLevel', level })
+const handleUpdateLogLevel = (level: string) => {
+  logLevel.value = level
+  postMessage({ type: 'updateLogLevel', level })
 }
 
 const handleUpdateMaxOutputLines = (value: number) => {
@@ -713,7 +713,7 @@ const handleMessage = (event: MessageEvent) => {
       if (typeof message.enablePreviewUiOverrides === 'boolean') enablePreviewUiOverrides.value = message.enablePreviewUiOverrides
       darkBackground.value = message.darkBackground || '#1e1e1e'
       linterMinSeverity.value = message.linterMinSeverity || 'information'
-      serverLogLevel.value = message.serverLogLevel || 'warning'
+      logLevel.value = message.logLevel || 'warning'
       writeMode.value = coerceWriteMode(message.writeMode)
       if (typeof message.maxOutputLines === 'number' && message.maxOutputLines >= 10) {
         maxOutputLines.value = message.maxOutputLines

--- a/Calcpad.Web/frontend/calcpad-frontend/src/vue/components/CalcpadApp.vue
+++ b/Calcpad.Web/frontend/calcpad-frontend/src/vue/components/CalcpadApp.vue
@@ -85,6 +85,7 @@
         :initial-enable-preview-ui-overrides="enablePreviewUiOverrides"
         :initial-dark-background="darkBackground"
         :initial-linter-min-severity="linterMinSeverity"
+        :initial-server-log-level="serverLogLevel"
         :initial-max-output-lines="maxOutputLines"
         :initial-max-preview-size="maxPreviewSizeMB"
         :initial-max-preview-console-messages="maxPreviewConsoleMessages"
@@ -109,6 +110,7 @@
         @update-preview-ui-overrides="handleUpdatePreviewUiOverrides"
         @update-dark-background="handleUpdateDarkBackground"
         @update-linter-min-severity="handleUpdateLinterMinSeverity"
+        @update-server-log-level="handleUpdateServerLogLevel"
         @update-max-output-lines="handleUpdateMaxOutputLines"
         @update-max-preview-size="handleUpdateMaxPreviewSize"
         @update-max-preview-console-messages="handleUpdateMaxPreviewConsoleMessages"
@@ -254,6 +256,7 @@ const enableAutoInputMode = ref(true)
 const enablePreviewUiOverrides = ref(false)
 const darkBackground = ref('#1e1e1e')
 const linterMinSeverity = ref('information')
+const serverLogLevel = ref('warning')
 const maxOutputLines = ref(1000)
 const maxPreviewSizeMB = ref(DEFAULT_PREVIEW_SIZE_MB)
 const maxPreviewConsoleMessages = ref(DEFAULT_CONSOLE_MESSAGES_PER_DOCUMENT)
@@ -546,6 +549,11 @@ const handleUpdateLinterMinSeverity = (severity: string) => {
   postMessage({ type: 'updateLinterMinSeverity', severity })
 }
 
+const handleUpdateServerLogLevel = (level: string) => {
+  serverLogLevel.value = level
+  postMessage({ type: 'updateServerLogLevel', level })
+}
+
 const handleUpdateMaxOutputLines = (value: number) => {
   maxOutputLines.value = value
   postMessage({ type: 'updateMaxOutputLines', value })
@@ -705,6 +713,7 @@ const handleMessage = (event: MessageEvent) => {
       if (typeof message.enablePreviewUiOverrides === 'boolean') enablePreviewUiOverrides.value = message.enablePreviewUiOverrides
       darkBackground.value = message.darkBackground || '#1e1e1e'
       linterMinSeverity.value = message.linterMinSeverity || 'information'
+      serverLogLevel.value = message.serverLogLevel || 'warning'
       writeMode.value = coerceWriteMode(message.writeMode)
       if (typeof message.maxOutputLines === 'number' && message.maxOutputLines >= 10) {
         maxOutputLines.value = message.maxOutputLines

--- a/Calcpad.Web/frontend/calcpad-frontend/src/vue/components/CalcpadSettingsTab.vue
+++ b/Calcpad.Web/frontend/calcpad-frontend/src/vue/components/CalcpadSettingsTab.vue
@@ -514,18 +514,18 @@
             </button>
           </div>
 
-          <div v-show="rowVisible('diagnostics', 'serverLogLevel')" class="setting-group">
-            <label for="serverLogLevel">
-              Server Log Level:
-              <span class="setting-info" :title="serverLogLevelDetail">&#9432;</span>
+          <div v-show="rowVisible('diagnostics', 'logLevel')" class="setting-group">
+            <label for="logLevel">
+              Log Level:
+              <span class="setting-info" :title="logLevelDetail">&#9432;</span>
             </label>
             <select
-              id="serverLogLevel"
-              v-model="serverLogLevel"
-              @change="updateServerLogLevel"
+              id="logLevel"
+              v-model="logLevel"
+              @change="updateLogLevel"
             >
               <option
-                v-for="opt in SERVER_LOG_LEVEL_OPTIONS"
+                v-for="opt in LOG_LEVEL_OPTIONS"
                 :key="opt.value"
                 :value="opt.value"
               >{{ opt.label }}</option>
@@ -651,7 +651,7 @@ import { ref, watch, computed, reactive } from 'vue'
 import type { WritableComputedRef } from 'vue'
 import type { PdfSettings, Settings, ThemeInfo, VersionConfig } from '../types'
 import { DEFAULT_PDF_SETTINGS, DEFAULT_VERSION_CONFIG } from '../types'
-import { getDefaultSettings, METADATA_SETTINGS_KEYS, validateSettingValue, SETTINGS_PATH, SERVER_LOG_LEVEL_OPTIONS } from '../../types/settings'
+import { getDefaultSettings, METADATA_SETTINGS_KEYS, validateSettingValue, SETTINGS_PATH, LOG_LEVEL_OPTIONS } from '../../types/settings'
 import { PDF_SETTING_KEYS, validatePdfValue } from '../../types/pdf-settings'
 import { specForKey } from '../../types/catalog'
 import {
@@ -675,7 +675,7 @@ interface Props {
   initialEnablePreviewUiOverrides?: boolean
   initialDarkBackground?: string
   initialLinterMinSeverity?: string
-  initialServerLogLevel?: string
+  initialLogLevel?: string
   initialMaxOutputLines?: number
   initialMaxPreviewSize?: number
   initialMaxPreviewConsoleMessages?: number
@@ -702,7 +702,7 @@ const props = withDefaults(defineProps<Props>(), {
   initialEnablePreviewUiOverrides: false,
   initialDarkBackground: '#1a1a2e',
   initialLinterMinSeverity: 'information',
-  initialServerLogLevel: 'warning',
+  initialLogLevel: 'warning',
   initialMaxOutputLines: 1000,
   initialMaxPreviewSize: DEFAULT_PREVIEW_SIZE_MB,
   initialMaxPreviewConsoleMessages: DEFAULT_CONSOLE_MESSAGES_PER_DOCUMENT,
@@ -729,7 +729,7 @@ const emit = defineEmits<{
   updatePreviewUiOverrides: [enabled: boolean]
   updateDarkBackground: [color: string]
   updateLinterMinSeverity: [severity: string]
-  updateServerLogLevel: [level: string]
+  updateLogLevel: [level: string]
   updateMaxOutputLines: [value: number]
   updateMaxPreviewSize: [value: number]
   updateMaxPreviewConsoleMessages: [value: number]
@@ -815,9 +815,9 @@ const enableAutoInputMode = ref(props.initialEnableAutoInputMode)
 const enablePreviewUiOverrides = ref(props.initialEnablePreviewUiOverrides)
 const darkBackground = ref(props.initialDarkBackground)
 const linterMinSeverity = ref(props.initialLinterMinSeverity)
-const serverLogLevel = ref(props.initialServerLogLevel)
-const serverLogLevelDetail = computed(() =>
-  SERVER_LOG_LEVEL_OPTIONS.find(o => o.value === serverLogLevel.value)?.detail ?? ''
+const logLevel = ref(props.initialLogLevel)
+const logLevelDetail = computed(() =>
+  LOG_LEVEL_OPTIONS.find(o => o.value === logLevel.value)?.detail ?? ''
 )
 const maxOutputLines = ref(props.initialMaxOutputLines)
 const maxPreviewSizeMB = ref(props.initialMaxPreviewSize)
@@ -917,7 +917,7 @@ const SECTION_META: Record<string, { title: string; rows: Record<string, string>
     title: 'Diagnostics',
     rows: {
       logsFolder: 'open logs folder crash dump',
-      serverLogLevel: 'server log level verbosity error warning information verbose noisy quiet logging',
+      logLevel: 'log level verbosity error warning information verbose noisy quiet logging output channel',
       maxOutputLines: 'max output lines channel',
       maxPreviewSize: 'max preview size memory limit mb blocked too large',
       maxPreviewConsoleMessages: 'max preview console messages javascript js log flood suppressed'
@@ -1062,8 +1062,8 @@ const updateLinterMinSeverity = () => {
   emit('updateLinterMinSeverity', linterMinSeverity.value)
 }
 
-const updateServerLogLevel = () => {
-  emit('updateServerLogLevel', serverLogLevel.value)
+const updateLogLevel = () => {
+  emit('updateLogLevel', logLevel.value)
 }
 
 const updateMaxOutputLines = () => {
@@ -1226,9 +1226,9 @@ watch(
 )
 
 watch(
-  () => props.initialServerLogLevel,
+  () => props.initialLogLevel,
   (newValue) => {
-    serverLogLevel.value = newValue
+    logLevel.value = newValue
   }
 )
 

--- a/Calcpad.Web/frontend/calcpad-frontend/src/vue/components/CalcpadSettingsTab.vue
+++ b/Calcpad.Web/frontend/calcpad-frontend/src/vue/components/CalcpadSettingsTab.vue
@@ -514,6 +514,24 @@
             </button>
           </div>
 
+          <div v-show="rowVisible('diagnostics', 'serverLogLevel')" class="setting-group">
+            <label for="serverLogLevel">
+              Server Log Level:
+              <span class="setting-info" :title="serverLogLevelDetail">&#9432;</span>
+            </label>
+            <select
+              id="serverLogLevel"
+              v-model="serverLogLevel"
+              @change="updateServerLogLevel"
+            >
+              <option
+                v-for="opt in SERVER_LOG_LEVEL_OPTIONS"
+                :key="opt.value"
+                :value="opt.value"
+              >{{ opt.label }}</option>
+            </select>
+          </div>
+
           <div v-if="versionConfig.isWebOrDesktop" v-show="rowVisible('diagnostics', 'maxOutputLines')" class="setting-group">
             <label for="maxOutputLines">
               Max Output Lines (per channel):
@@ -633,7 +651,7 @@ import { ref, watch, computed, reactive } from 'vue'
 import type { WritableComputedRef } from 'vue'
 import type { PdfSettings, Settings, ThemeInfo, VersionConfig } from '../types'
 import { DEFAULT_PDF_SETTINGS, DEFAULT_VERSION_CONFIG } from '../types'
-import { getDefaultSettings, METADATA_SETTINGS_KEYS, validateSettingValue, SETTINGS_PATH } from '../../types/settings'
+import { getDefaultSettings, METADATA_SETTINGS_KEYS, validateSettingValue, SETTINGS_PATH, SERVER_LOG_LEVEL_OPTIONS } from '../../types/settings'
 import { PDF_SETTING_KEYS, validatePdfValue } from '../../types/pdf-settings'
 import { specForKey } from '../../types/catalog'
 import {
@@ -657,6 +675,7 @@ interface Props {
   initialEnablePreviewUiOverrides?: boolean
   initialDarkBackground?: string
   initialLinterMinSeverity?: string
+  initialServerLogLevel?: string
   initialMaxOutputLines?: number
   initialMaxPreviewSize?: number
   initialMaxPreviewConsoleMessages?: number
@@ -683,6 +702,7 @@ const props = withDefaults(defineProps<Props>(), {
   initialEnablePreviewUiOverrides: false,
   initialDarkBackground: '#1a1a2e',
   initialLinterMinSeverity: 'information',
+  initialServerLogLevel: 'warning',
   initialMaxOutputLines: 1000,
   initialMaxPreviewSize: DEFAULT_PREVIEW_SIZE_MB,
   initialMaxPreviewConsoleMessages: DEFAULT_CONSOLE_MESSAGES_PER_DOCUMENT,
@@ -709,6 +729,7 @@ const emit = defineEmits<{
   updatePreviewUiOverrides: [enabled: boolean]
   updateDarkBackground: [color: string]
   updateLinterMinSeverity: [severity: string]
+  updateServerLogLevel: [level: string]
   updateMaxOutputLines: [value: number]
   updateMaxPreviewSize: [value: number]
   updateMaxPreviewConsoleMessages: [value: number]
@@ -794,6 +815,10 @@ const enableAutoInputMode = ref(props.initialEnableAutoInputMode)
 const enablePreviewUiOverrides = ref(props.initialEnablePreviewUiOverrides)
 const darkBackground = ref(props.initialDarkBackground)
 const linterMinSeverity = ref(props.initialLinterMinSeverity)
+const serverLogLevel = ref(props.initialServerLogLevel)
+const serverLogLevelDetail = computed(() =>
+  SERVER_LOG_LEVEL_OPTIONS.find(o => o.value === serverLogLevel.value)?.detail ?? ''
+)
 const maxOutputLines = ref(props.initialMaxOutputLines)
 const maxPreviewSizeMB = ref(props.initialMaxPreviewSize)
 const maxPreviewConsoleMessages = ref(props.initialMaxPreviewConsoleMessages)
@@ -892,6 +917,7 @@ const SECTION_META: Record<string, { title: string; rows: Record<string, string>
     title: 'Diagnostics',
     rows: {
       logsFolder: 'open logs folder crash dump',
+      serverLogLevel: 'server log level verbosity error warning information verbose noisy quiet logging',
       maxOutputLines: 'max output lines channel',
       maxPreviewSize: 'max preview size memory limit mb blocked too large',
       maxPreviewConsoleMessages: 'max preview console messages javascript js log flood suppressed'
@@ -1034,6 +1060,10 @@ const resetDarkBackground = () => {
 
 const updateLinterMinSeverity = () => {
   emit('updateLinterMinSeverity', linterMinSeverity.value)
+}
+
+const updateServerLogLevel = () => {
+  emit('updateServerLogLevel', serverLogLevel.value)
 }
 
 const updateMaxOutputLines = () => {
@@ -1192,6 +1222,13 @@ watch(
   () => props.initialLinterMinSeverity,
   (newValue) => {
     linterMinSeverity.value = newValue
+  }
+)
+
+watch(
+  () => props.initialServerLogLevel,
+  (newValue) => {
+    serverLogLevel.value = newValue
   }
 )
 

--- a/Calcpad.Web/frontend/calcpad-web/src/App.vue
+++ b/Calcpad.Web/frontend/calcpad-web/src/App.vue
@@ -286,12 +286,8 @@
         </span>
         <span class="status-output" @click="openBottomTab('output')">Output</span>
         <span class="spacer"></span>
-        <span
-          class="status-server"
-          :class="{ connected: serverConnected, disconnected: !serverConnected }"
-          :title="serverConnected ? 'Server connected' : 'Server disconnected'"
-        >
-          ● {{ serverConnected ? 'Connected' : 'Disconnected' }}
+        <span class="status-server" :class="serverStatus" :title="serverStatusTitle">
+          ● {{ serverStatusLabel }}
         </span>
       </div>
     </div>
@@ -564,6 +560,7 @@ import {
   MIN_CONSOLE_MESSAGES_PER_DOCUMENT,
   type PreviewScrollState,
 } from 'calcpad-frontend'
+import type { ServerStatus } from './services/connection-monitor'
 
 export interface ProblemItem {
   severity: number
@@ -1426,7 +1423,21 @@ function gotoProblem(problem: ProblemItem): void {
   onGotoProblem.value?.(problem)
 }
 
-const serverConnected = ref(false)
+// Pushed in by main.ts's ConnectionMonitor; this component never probes the server itself.
+const serverStatus = ref<ServerStatus>('connecting')
+const serverStatusLabel = computed(() =>
+  serverStatus.value === 'connected' ? 'Connected'
+    : serverStatus.value === 'connecting' ? 'Starting…'
+      : 'Disconnected')
+const serverStatusTitle = computed(() =>
+  serverStatus.value === 'connected' ? 'Server connected'
+    : serverStatus.value === 'connecting' ? 'Server starting…'
+      : 'Server disconnected — use Server ▸ Restart Server')
+
+function setServerStatus(status: ServerStatus): void {
+  serverStatus.value = status
+}
+
 const sidebarVisible = ref(true)
 const previewVisible = ref(false)
 // Groups with an in-flight preview render; drives the "Calculating…" overlay.
@@ -2219,20 +2230,6 @@ function setProblems(groupId: string, markers: ProblemItem[]): void {
 }
 
 onMounted(async () => {
-  const checkHealth = async () => {
-    try {
-      const bridge = (window as any).calcpadBridge
-      if (bridge) {
-        serverConnected.value = await bridge.api.checkHealth()
-      }
-    } catch {
-      serverConnected.value = false
-    }
-  }
-
-  setTimeout(checkHealth, 1000)
-  setInterval(checkHealth, 30000)
-
   document.addEventListener('mousedown', onDocumentInteractionForTabMenu)
   document.addEventListener('keydown', onDocumentInteractionForTabMenu)
   window.addEventListener('message', onPreviewWindowMessage)
@@ -2350,6 +2347,7 @@ defineExpose({
   isPreviewVisible,
   setPreviewHtml,
   setPreviewLoading,
+  setServerStatus,
   setPreviewTheme,
   scrollPreviewToSourceLine,
   isPreviewFrameSource,

--- a/Calcpad.Web/frontend/calcpad-web/src/App.vue
+++ b/Calcpad.Web/frontend/calcpad-web/src/App.vue
@@ -554,6 +554,7 @@ import {
   scrollAnchorScript,
   consoleRelayGuardScript,
   shouldLog,
+  DISPLAY_LOG_LEVEL,
   truncateForOutput,
   BACK_BUFFER_CLEAR_CHARS,
   MAX_HTML_MIRROR_CHARS,
@@ -561,7 +562,7 @@ import {
   MIN_CONSOLE_MESSAGES_PER_DOCUMENT,
   type PreviewScrollState,
   type ServerStatus,
-  type CalcpadLogLevel,
+  type DisplayLogLevel,
 } from 'calcpad-frontend'
 
 export interface ProblemItem {
@@ -1524,16 +1525,8 @@ function setMaxOutputLines(n: number): void {
   for (const ch of ['app', 'preview', 'server', 'html'] as OutputChannel[]) trimChannel(ch)
 }
 
-/** Our four display levels onto the shared log level, which is what the filter is keyed on. */
-const OUTPUT_LEVEL_MAP: Record<'info' | 'warn' | 'error' | 'debug', CalcpadLogLevel> = {
-  error: 'error',
-  warn: 'warning',
-  info: 'information',
-  debug: 'verbose',
-}
-
 function appendOutput(
-  level: 'info' | 'warn' | 'error' | 'debug',
+  level: DisplayLogLevel,
   message: string,
   channel: OutputChannel = 'app',
   groupId?: string,
@@ -1541,7 +1534,7 @@ function appendOutput(
   // Only the diagnostic channels are filtered. 'preview' and 'html' carry the worksheet's own
   // output, which the user asked for by running it and which no log level should swallow.
   const diagnostic = channel === 'app' || channel === 'server'
-  if (diagnostic && !shouldLog(OUTPUT_LEVEL_MAP[level])) return
+  if (diagnostic && !shouldLog(DISPLAY_LOG_LEVEL[level])) return
   const now = new Date()
   const time = now.toLocaleTimeString('en-US', { hour12: false, hour: '2-digit', minute: '2-digit', second: '2-digit' })
   const labels: Record<string, string> = { info: 'INFO', warn: 'WARN', error: 'ERROR', debug: 'DEBUG' }

--- a/Calcpad.Web/frontend/calcpad-web/src/App.vue
+++ b/Calcpad.Web/frontend/calcpad-web/src/App.vue
@@ -553,14 +553,16 @@ import {
   previewDiagnosticsScript,
   scrollAnchorScript,
   consoleRelayGuardScript,
+  shouldLog,
   truncateForOutput,
   BACK_BUFFER_CLEAR_CHARS,
   MAX_HTML_MIRROR_CHARS,
   DEFAULT_CONSOLE_MESSAGES_PER_DOCUMENT,
   MIN_CONSOLE_MESSAGES_PER_DOCUMENT,
   type PreviewScrollState,
+  type ServerStatus,
+  type CalcpadLogLevel,
 } from 'calcpad-frontend'
-import type { ServerStatus } from './services/connection-monitor'
 
 export interface ProblemItem {
   severity: number
@@ -1522,12 +1524,24 @@ function setMaxOutputLines(n: number): void {
   for (const ch of ['app', 'preview', 'server', 'html'] as OutputChannel[]) trimChannel(ch)
 }
 
+/** Our four display levels onto the shared log level, which is what the filter is keyed on. */
+const OUTPUT_LEVEL_MAP: Record<'info' | 'warn' | 'error' | 'debug', CalcpadLogLevel> = {
+  error: 'error',
+  warn: 'warning',
+  info: 'information',
+  debug: 'verbose',
+}
+
 function appendOutput(
   level: 'info' | 'warn' | 'error' | 'debug',
   message: string,
   channel: OutputChannel = 'app',
   groupId?: string,
 ): void {
+  // Only the diagnostic channels are filtered. 'preview' and 'html' carry the worksheet's own
+  // output, which the user asked for by running it and which no log level should swallow.
+  const diagnostic = channel === 'app' || channel === 'server'
+  if (diagnostic && !shouldLog(OUTPUT_LEVEL_MAP[level])) return
   const now = new Date()
   const time = now.toLocaleTimeString('en-US', { hour12: false, hour: '2-digit', minute: '2-digit', second: '2-digit' })
   const labels: Record<string, string> = { info: 'INFO', warn: 'WARN', error: 'ERROR', debug: 'DEBUG' }

--- a/Calcpad.Web/frontend/calcpad-web/src/main.ts
+++ b/Calcpad.Web/frontend/calcpad-web/src/main.ts
@@ -5,8 +5,8 @@ import pkg from '../package.json';
 import CalcpadAppVue from 'calcpad-frontend/vue/components/CalcpadApp.vue';
 import { initMessaging } from 'calcpad-frontend/vue/services/messaging';
 import { MessageBridge } from './services/message-bridge';
-import { ConnectionMonitor } from './services/connection-monitor';
 import { buildApiSettings } from 'calcpad-frontend/types/settings';
+import { ConnectionMonitor, setLogLevel, coerceLogLevel } from 'calcpad-frontend';
 import {
     findMetadataCommentBlock,
     serializeMetadataComment,
@@ -48,7 +48,7 @@ import { registerFormatDocumentProvider } from './editor/format-document';
 import { setActiveDocumentKeyResolver, getActiveDocumentKey, type EditorBridge } from './editor/bridge';
 import { EditorGroup } from './editor/editor-group';
 import type { TabManager } from './tabs/tab-manager';
-import type { UiControl } from 'calcpad-frontend';
+import type { UiControl, CalcpadLogLevel } from 'calcpad-frontend';
 import './editor/vscode-variables.css';
 import 'calcpad-frontend/vue/styles/base.css';
 import './styles/app.css';
@@ -178,7 +178,14 @@ async function bootstrap(): Promise<void> {
     let serverManager: import('./services/server-manager').TauriServerManager | null = null;
     // Server-manager log lines that arrive before the Output panel mounts
     // get buffered here, then flushed when appInstance is ready.
-    const pendingServerLogs: string[] = [];
+    /** The shared log level onto appendOutput's four display levels. */
+    const displayLevel = (level?: CalcpadLogLevel): 'info' | 'warn' | 'error' | 'debug' =>
+        level === 'error' ? 'error'
+            : level === 'warning' ? 'warn'
+                : level === 'verbose' ? 'debug'
+                    : 'info';
+
+    const pendingServerLogs: { msg: string; level?: CalcpadLogLevel }[] = [];
     // Raw stdout/stderr lines from the Calcpad.Server sidecar (Rust's
     // `server-log` event), buffered the same way for the same reason.
     const pendingServerRawLogs: { line: string; stream: 'stdout' | 'stderr' }[] = [];
@@ -189,14 +196,14 @@ async function bootstrap(): Promise<void> {
         // its URL and surfaces crashes to the Output panel.
         const { TauriServerManager } = await import('./services/server-manager');
         serverManager = new TauriServerManager({
-            appendLine: (msg: string) => pendingServerLogs.push(msg),
+            appendLine: (msg: string, level?: CalcpadLogLevel) => pendingServerLogs.push({ msg, level }),
         });
         serverManager.onServerLog = (line: string, stream: 'stdout' | 'stderr') => {
             pendingServerRawLogs.push({ line, stream });
         };
 
         serverManager.onStartupBlocked = (details: string) => {
-            pendingServerLogs.push(`Server did not start — ${details}`);
+            pendingServerLogs.push({ msg: `Server did not start — ${details}`, level: 'error' });
             void showServerBlockedDialog(details);
         };
 
@@ -204,7 +211,7 @@ async function bootstrap(): Promise<void> {
             await serverManager.start();
         } catch (err) {
             const msg = err instanceof Error ? (err.stack ?? err.message) : String(err);
-            pendingServerLogs.push(`[bootstrap] Server failed to start: ${msg}`);
+            pendingServerLogs.push({ msg: `[bootstrap] Server failed to start: ${msg}`, level: 'error' });
             console.error('[bootstrap] Server failed to start:', err);
         }
         serverUrl = serverManager.getBaseUrl() || '';
@@ -255,6 +262,9 @@ async function bootstrap(): Promise<void> {
     // settings asynchronously, so wait for it; the web bridge is synchronous.
     if (tauriBridge) await tauriBridge.ready;
     setAppTheme(coerceAppTheme(activeBridge.getStoredColorTheme()));
+    // Before the buffered startup lines are flushed into the Output panel below, so they are
+    // filtered against the level the user actually chose rather than the default.
+    setLogLevel(coerceLogLevel((activeBridge as unknown as EditorBridge).getExtraSetting('logLevel')));
 
     const WORD_WRAP_KEY = 'calcpad.wordWrap';
     const initialWordWrap: 'on' | 'off' =
@@ -1222,12 +1232,27 @@ async function bootstrap(): Promise<void> {
     console.warn = wrap(origWarn, 'warn');
     console.error = wrap(origError, 'error');
 
+    // Monaco cancels superseded provider work — completions, semantic tokens, hovers — on
+    // essentially every keystroke, and unwinds it by rejecting with a CancellationError
+    // ("Canceled: Canceled"). That is control flow, not a failure, and Monaco exports
+    // isCancellationError for exactly this; VS Code's own error handler drops them the same way.
+    // AbortError is the fetch-side equivalent, raised by our own superseded requests.
+    const isCancellation = (reason: unknown): boolean =>
+        reason instanceof DOMException ? reason.name === 'AbortError'
+            : reason instanceof Error && reason.name === 'Canceled' && reason.message === 'Canceled';
+
+    // Stack included: without it a bare "Canceled: Canceled" gives nothing to trace it back to.
+    const describeError = (reason: unknown): string =>
+        reason instanceof Error ? (reason.stack ?? `${reason.name}: ${reason.message}`) : String(reason);
+
     // Also capture unhandled errors
     window.addEventListener('error', (e) => {
+        if (isCancellation(e.error)) return;
         appInstance.appendOutput('error', `Uncaught: ${e.message} (${e.filename}:${e.lineno})`);
     });
     window.addEventListener('unhandledrejection', (e) => {
-        appInstance.appendOutput('error', `Unhandled rejection: ${e.reason}`);
+        if (isCancellation(e.reason)) return;
+        appInstance.appendOutput('error', `Unhandled rejection: ${describeError(e.reason)}`);
     });
 
     // Messages posted from the preview iframes (App.vue:injectPreviewConsole /
@@ -1317,7 +1342,7 @@ async function bootstrap(): Promise<void> {
 
     // Flush any server-manager log lines buffered before the Output panel mounted,
     // then redirect future ones straight into the panel.
-    for (const msg of pendingServerLogs) appInstance.appendOutput('info', msg);
+    for (const { msg, level } of pendingServerLogs) appInstance.appendOutput(displayLevel(level), msg);
     pendingServerLogs.length = 0;
     for (const { line, stream } of pendingServerRawLogs) {
         appInstance.appendOutput(stream === 'stderr' ? 'error' : 'info', line, 'server');
@@ -1332,7 +1357,7 @@ async function bootstrap(): Promise<void> {
 
     if (serverManager) {
         serverManager.setLogger({
-            appendLine: (msg: string) => appInstance.appendOutput('info', msg),
+            appendLine: (msg: string, level?: CalcpadLogLevel) => appInstance.appendOutput(displayLevel(level), msg),
         });
         serverManager.onServerLog = (line: string, stream: 'stdout' | 'stderr') => {
             appInstance.appendOutput(stream === 'stderr' ? 'error' : 'info', line, 'server');
@@ -1347,14 +1372,8 @@ async function bootstrap(): Promise<void> {
                 'Use Server → Restart Server to try again.');
             if (crashOutput) appInstance.appendOutput('error', crashOutput);
         };
-        // 'running' only means Rust saw a bound port, so confirm with a probe before going green.
-        serverManager.onStatusChanged = (state, detail) => {
-            switch (state) {
-                case 'starting': connectionMonitor.markConnecting(detail ?? 'starting'); break;
-                case 'running': connectionMonitor.notifyMaybeUp(); break;
-                case 'stopped': connectionMonitor.markStopped(detail ?? 'stopped'); break;
-            }
-        };
+        // 'running' only means Rust saw a bound port, so applyLifecycle probes before going green.
+        serverManager.onStatusChanged = (state, detail) => connectionMonitor.applyLifecycle(state, detail);
     }
 
     // serverManager.start() ran before the callbacks above existed, so seed from what it knows.

--- a/Calcpad.Web/frontend/calcpad-web/src/main.ts
+++ b/Calcpad.Web/frontend/calcpad-web/src/main.ts
@@ -5,6 +5,7 @@ import pkg from '../package.json';
 import CalcpadAppVue from 'calcpad-frontend/vue/components/CalcpadApp.vue';
 import { initMessaging } from 'calcpad-frontend/vue/services/messaging';
 import { MessageBridge } from './services/message-bridge';
+import { ConnectionMonitor } from './services/connection-monitor';
 import { buildApiSettings } from 'calcpad-frontend/types/settings';
 import {
     findMetadataCommentBlock,
@@ -1322,6 +1323,13 @@ async function bootstrap(): Promise<void> {
         appInstance.appendOutput(stream === 'stderr' ? 'error' : 'info', line, 'server');
     }
     pendingServerRawLogs.length = 0;
+    const connectionMonitor = new ConnectionMonitor({
+        probe: (timeoutMs: number) => activeBridge.api.checkHealth(timeoutMs),
+        onStatusChanged: (status) => appInstance.setServerStatus(status),
+        onRecovered: () => { void runRefresh('Server reconnected — refreshing…'); },
+        log: (msg: string) => appInstance.appendOutput('info', `[Server] ${msg}`),
+    });
+
     if (serverManager) {
         serverManager.setLogger({
             appendLine: (msg: string) => appInstance.appendOutput('info', msg),
@@ -1339,7 +1347,28 @@ async function bootstrap(): Promise<void> {
                 'Use Server → Restart Server to try again.');
             if (crashOutput) appInstance.appendOutput('error', crashOutput);
         };
+        // 'running' only means Rust saw a bound port, so confirm with a probe before going green.
+        serverManager.onStatusChanged = (state, detail) => {
+            switch (state) {
+                case 'starting': connectionMonitor.markConnecting(detail ?? 'starting'); break;
+                case 'running': connectionMonitor.notifyMaybeUp(); break;
+                case 'stopped': connectionMonitor.markStopped(detail ?? 'stopped'); break;
+            }
+        };
     }
+
+    // serverManager.start() ran before the callbacks above existed, so seed from what it knows.
+    // markStopped leaves polling suspended, which is right: only a user restart can help.
+    if (serverManager && !serverManager.isRunning) {
+        connectionMonitor.markStopped('server did not start');
+    } else {
+        connectionMonitor.start();
+    }
+
+    // A hidden webview throttles timers hard, so the poll can be well stale on restore.
+    document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState === 'visible') connectionMonitor.probeSoon();
+    });
 
     // Problems panel: markers can change for any group's model (background
     // lint). Dispatch to whichever group owns the affected resource.
@@ -1431,18 +1460,25 @@ async function bootstrap(): Promise<void> {
     // Manual refresh: re-lint with current settings, refresh definitions/
     // headings, redraw previews, and re-extract Export-tab plots. Called from
     // the Server > Refresh menu item and the editor's Run action.
-    async function runRefresh(): Promise<void> {
-        appInstance.appendOutput('info', 'Refreshing…');
-        for (const g of groups.values()) {
-            await g.diagnostics?.refresh();
-            await refreshDefinitionsFor(g);
-            if (appInstance.isPreviewVisible()) await refreshPreviewFor(g);
+    let refreshInFlight = false;
+    async function runRefresh(reason: string = 'Refreshing…'): Promise<void> {
+        if (refreshInFlight) return;
+        refreshInFlight = true;
+        appInstance.appendOutput('info', reason);
+        try {
+            for (const g of groups.values()) {
+                await g.diagnostics?.refresh();
+                await refreshDefinitionsFor(g);
+                if (appInstance.isPreviewVisible()) await refreshPreviewFor(g);
+            }
+            activeBridge.refreshHeadings();
+            // Refresh the Export tab's plot list — it caches independently of the
+            // preview and would otherwise show stale plots until the user clicks
+            // "Refresh Plots" manually.
+            window.dispatchEvent(new MessageEvent('message', { data: { type: 'getPlots' } }));
+        } finally {
+            refreshInFlight = false;
         }
-        activeBridge.refreshHeadings();
-        // Refresh the Export tab's plot list — it caches independently of the
-        // preview and would otherwise show stale plots until the user clicks
-        // "Refresh Plots" manually.
-        window.dispatchEvent(new MessageEvent('message', { data: { type: 'getPlots' } }));
     }
 
     appInstance.onResultModeChanged = (mode: ResultMode) => {
@@ -2438,6 +2474,7 @@ async function bootstrap(): Promise<void> {
                 }
             } finally {
                 if (isExiting) {
+                    connectionMonitor.stop();
                     // Rust owns sidecar shutdown (kill-on-exit hook). This
                     // dispose only tears down TS event listeners.
                     if (serverManager) {

--- a/Calcpad.Web/frontend/calcpad-web/src/main.ts
+++ b/Calcpad.Web/frontend/calcpad-web/src/main.ts
@@ -1457,12 +1457,17 @@ async function bootstrap(): Promise<void> {
     // mounted, so seed it with the mode the session came up in.
     syncInputMode();
 
-    // Manual refresh: re-lint with current settings, refresh definitions/
-    // headings, redraw previews, and re-extract Export-tab plots. Called from
-    // the Server > Refresh menu item and the editor's Run action.
+    // Manual refresh: re-lint, refresh definitions/headings, redraw previews, and re-extract
+    // Export-tab plots. From the Server > Refresh menu, the Run action, and on reconnect.
     let refreshInFlight = false;
+    let refreshQueued = false;
     async function runRefresh(reason: string = 'Refreshing…'): Promise<void> {
-        if (refreshInFlight) return;
+        // Coalesced rather than dropped: the reconnect refresh has no user to retry it, and
+        // rendering against the server it just replaced is what it exists to correct.
+        if (refreshInFlight) {
+            refreshQueued = true;
+            return;
+        }
         refreshInFlight = true;
         appInstance.appendOutput('info', reason);
         try {
@@ -1472,12 +1477,14 @@ async function bootstrap(): Promise<void> {
                 if (appInstance.isPreviewVisible()) await refreshPreviewFor(g);
             }
             activeBridge.refreshHeadings();
-            // Refresh the Export tab's plot list — it caches independently of the
-            // preview and would otherwise show stale plots until the user clicks
-            // "Refresh Plots" manually.
+            // The Export tab's plot list caches independently of the preview.
             window.dispatchEvent(new MessageEvent('message', { data: { type: 'getPlots' } }));
         } finally {
             refreshInFlight = false;
+        }
+        if (refreshQueued) {
+            refreshQueued = false;
+            await runRefresh(reason);
         }
     }
 

--- a/Calcpad.Web/frontend/calcpad-web/src/main.ts
+++ b/Calcpad.Web/frontend/calcpad-web/src/main.ts
@@ -48,7 +48,8 @@ import { registerFormatDocumentProvider } from './editor/format-document';
 import { setActiveDocumentKeyResolver, getActiveDocumentKey, type EditorBridge } from './editor/bridge';
 import { EditorGroup } from './editor/editor-group';
 import type { TabManager } from './tabs/tab-manager';
-import type { UiControl, CalcpadLogLevel } from 'calcpad-frontend';
+import { toDisplayLogLevel } from 'calcpad-frontend';
+import type { UiControl, CalcpadLogLevel, DisplayLogLevel } from 'calcpad-frontend';
 import './editor/vscode-variables.css';
 import 'calcpad-frontend/vue/styles/base.css';
 import './styles/app.css';
@@ -178,13 +179,6 @@ async function bootstrap(): Promise<void> {
     let serverManager: import('./services/server-manager').TauriServerManager | null = null;
     // Server-manager log lines that arrive before the Output panel mounts
     // get buffered here, then flushed when appInstance is ready.
-    /** The shared log level onto appendOutput's four display levels. */
-    const displayLevel = (level?: CalcpadLogLevel): 'info' | 'warn' | 'error' | 'debug' =>
-        level === 'error' ? 'error'
-            : level === 'warning' ? 'warn'
-                : level === 'verbose' ? 'debug'
-                    : 'info';
-
     const pendingServerLogs: { msg: string; level?: CalcpadLogLevel }[] = [];
     // Raw stdout/stderr lines from the Calcpad.Server sidecar (Rust's
     // `server-log` event), buffered the same way for the same reason.
@@ -1217,7 +1211,7 @@ async function bootstrap(): Promise<void> {
 
     const wrap = (
         orig: (...args: any[]) => void,
-        level: 'info' | 'debug' | 'warn' | 'error',
+        level: DisplayLogLevel,
     ) => (...args: any[]) => {
         orig.apply(console, args);
         // Monaco's ConsoleLogger emits styled `%c INFO`/`%c  ERR` lines whose CSS
@@ -1276,7 +1270,7 @@ async function bootstrap(): Promise<void> {
         // tagged with the originating group.
         if (data.type === 'previewConsole') {
             if (!fromPreview) return;
-            const level: 'info' | 'warn' | 'error' | 'debug' =
+            const level: DisplayLogLevel =
                 data.level === 'warn' ? 'warn'
                 : data.level === 'error' ? 'error'
                 : data.level === 'debug' ? 'debug'
@@ -1342,7 +1336,7 @@ async function bootstrap(): Promise<void> {
 
     // Flush any server-manager log lines buffered before the Output panel mounted,
     // then redirect future ones straight into the panel.
-    for (const { msg, level } of pendingServerLogs) appInstance.appendOutput(displayLevel(level), msg);
+    for (const { msg, level } of pendingServerLogs) appInstance.appendOutput(toDisplayLogLevel(level), msg);
     pendingServerLogs.length = 0;
     for (const { line, stream } of pendingServerRawLogs) {
         appInstance.appendOutput(stream === 'stderr' ? 'error' : 'info', line, 'server');
@@ -1357,7 +1351,7 @@ async function bootstrap(): Promise<void> {
 
     if (serverManager) {
         serverManager.setLogger({
-            appendLine: (msg: string, level?: CalcpadLogLevel) => appInstance.appendOutput(displayLevel(level), msg),
+            appendLine: (msg: string, level?: CalcpadLogLevel) => appInstance.appendOutput(toDisplayLogLevel(level), msg),
         });
         serverManager.onServerLog = (line: string, stream: 'stdout' | 'stderr') => {
             appInstance.appendOutput(stream === 'stderr' ? 'error' : 'info', line, 'server');

--- a/Calcpad.Web/frontend/calcpad-web/src/services/connection-monitor.ts
+++ b/Calcpad.Web/frontend/calcpad-web/src/services/connection-monitor.ts
@@ -1,0 +1,172 @@
+/**
+ * Tracks whether the Calcpad server is answering, and reports recoveries so the app can
+ * re-render against a server that just came back.
+ *
+ * The host pushes lifecycle transitions in (markConnecting / markStopped / notifyMaybeUp) and an
+ * adaptive poll is the backstop for what the host can't see — a hang, or a process that died
+ * without the Rust layer noticing. Only the probe promotes a state to `connected`: a bound port
+ * proves Kestrel is listening, not that the pipeline answers.
+ */
+
+export type ServerStatus = 'connected' | 'connecting' | 'disconnected';
+
+export interface ConnectionMonitorOptions {
+    probe: (timeoutMs: number) => Promise<boolean>;
+    onStatusChanged: (status: ServerStatus) => void;
+    /** Fires on down -> up only, never on the session's first resolved status. */
+    onRecovered?: () => void;
+    log?: (message: string) => void;
+    connectedIntervalMs?: number;
+    disconnectedIntervalMs?: number;
+    connectingIntervalMs?: number;
+    probeTimeoutMs?: number;
+    failuresToDisconnect?: number;
+    connectingGraceMs?: number;
+}
+
+const DEFAULTS = {
+    connectedIntervalMs: 10_000,
+    disconnectedIntervalMs: 1_500,
+    connectingIntervalMs: 750,
+    probeTimeoutMs: 2_500,
+    failuresToDisconnect: 2,
+    connectingGraceMs: 20_000,
+};
+
+export class ConnectionMonitor {
+    private readonly opts: ConnectionMonitorOptions & typeof DEFAULTS;
+    private _status: ServerStatus = 'connecting';
+    private suspended = true;
+    private failures = 0;
+    private sawFirstResult = false;
+    private probeInFlight = false;
+    private generation = 0;
+    private connectingSince = Date.now();
+    private timer: ReturnType<typeof setTimeout> | null = null;
+
+    constructor(options: ConnectionMonitorOptions) {
+        this.opts = { ...DEFAULTS, ...options };
+    }
+
+    get status(): ServerStatus { return this._status; }
+
+    start(): void {
+        this.suspended = false;
+        this.schedule(0);
+    }
+
+    stop(): void {
+        this.suspended = true;
+        this.generation++;
+        this.clearTimer();
+    }
+
+    /** A start or restart is in flight: amber, fast poll. Re-arms a suspended monitor. */
+    markConnecting(reason: string): void {
+        this.generation++;
+        this.suspended = false;
+        this.failures = 0;
+        this.setStatus('connecting', reason);
+        this.schedule(300);
+    }
+
+    /**
+     * Deliberately stopped, or out of restart attempts: red, and polling suspended. Nothing but a
+     * user action can bring the server back, and that action goes through markConnecting.
+     */
+    markStopped(reason: string): void {
+        this.generation++;
+        this.failures = 0;
+        this.setStatus('disconnected', reason);
+        this.suspended = true;
+        this.clearTimer();
+    }
+
+    /** The host believes a port is bound. Probes to confirm before going green. */
+    notifyMaybeUp(): void {
+        this.suspended = false;
+        this.generation++;
+        this.schedule(0);
+    }
+
+    /** Probe now unless suspended — for a window regaining focus after timer throttling. */
+    probeSoon(): void {
+        if (this.suspended) return;
+        this.generation++;
+        this.schedule(0);
+    }
+
+    private cadence(): number {
+        if (this._status === 'connected') return this.opts.connectedIntervalMs;
+        if (this._status === 'connecting') return this.opts.connectingIntervalMs;
+        return this.opts.disconnectedIntervalMs;
+    }
+
+    private clearTimer(): void {
+        if (this.timer !== null) {
+            clearTimeout(this.timer);
+            this.timer = null;
+        }
+    }
+
+    // Chained timeout rather than an interval, so a slow probe can never stack up behind itself.
+    private schedule(delayMs: number): void {
+        this.clearTimer();
+        if (this.suspended) return;
+        this.timer = setTimeout(() => { void this.runProbe(); }, delayMs);
+    }
+
+    private async runProbe(): Promise<void> {
+        if (this.suspended || this.probeInFlight) return;
+        this.probeInFlight = true;
+        const generation = this.generation;
+        let ok = false;
+        try {
+            ok = await this.opts.probe(this.opts.probeTimeoutMs);
+        } catch {
+            ok = false;
+        } finally {
+            this.probeInFlight = false;
+        }
+
+        // A bumped generation means the base URL or lifecycle changed mid-flight, so this
+        // answer is about a server we no longer care about.
+        if (generation !== this.generation) {
+            this.schedule(0);
+            return;
+        }
+        if (this.suspended) return;
+
+        if (ok) {
+            this.setStatus('connected');
+        } else {
+            this.failures++;
+            const inGrace = this._status === 'connecting'
+                && Date.now() - this.connectingSince < this.opts.connectingGraceMs;
+            if (!inGrace && this.failures >= this.opts.failuresToDisconnect) {
+                this.setStatus('disconnected');
+            }
+        }
+        this.schedule(this.cadence());
+    }
+
+    private setStatus(next: ServerStatus, reason?: string): void {
+        if (next === 'connected') this.failures = 0;
+        if (next === this._status) {
+            if (next !== 'connecting') this.sawFirstResult = true;
+            return;
+        }
+
+        const previous = this._status;
+        this._status = next;
+        if (next === 'connecting') this.connectingSince = Date.now();
+        this.opts.log?.(reason ? `${previous} -> ${next} (${reason})` : `${previous} -> ${next}`);
+        this.opts.onStatusChanged(next);
+
+        // Every observer of a recovery funnels through here, so a single transition fires
+        // onRecovered once however many of them noticed it.
+        const isFirstResult = !this.sawFirstResult;
+        if (next !== 'connecting') this.sawFirstResult = true;
+        if (next === 'connected' && !isFirstResult) this.opts.onRecovered?.();
+    }
+}

--- a/Calcpad.Web/frontend/calcpad-web/src/services/connection-monitor.ts
+++ b/Calcpad.Web/frontend/calcpad-web/src/services/connection-monitor.ts
@@ -66,6 +66,9 @@ export class ConnectionMonitor {
         this.generation++;
         this.suspended = false;
         this.failures = 0;
+        // Reset here, not only on transition: a retry re-enters an already-'connecting' state,
+        // and setStatus early-returns, so the grace would still be timing the first attempt.
+        this.connectingSince = Date.now();
         this.setStatus('connecting', reason);
         this.schedule(300);
     }

--- a/Calcpad.Web/frontend/calcpad-web/src/services/server-manager.ts
+++ b/Calcpad.Web/frontend/calcpad-web/src/services/server-manager.ts
@@ -38,6 +38,13 @@ interface ServerLogPayload {
     line: string;
 }
 
+/**
+ * What Rust has told us about the sidecar process. A crash collapses into `starting` when a retry
+ * is scheduled and `stopped` when the streak is exhausted — that distinction lives here because
+ * this class owns the crash counter.
+ */
+export type ServerLifecycleState = 'starting' | 'running' | 'stopped';
+
 export class TauriServerManager {
     private url = '';
     private token: string | null = null;
@@ -52,6 +59,8 @@ export class TauriServerManager {
 
     public onCrashExhausted?: (crashOutput: string) => void;
     public onUrlChanged?: (newUrl: string) => void;
+    /** Always raised after onUrlChanged, so a listener may assume the new URL is already applied. */
+    public onStatusChanged?: (state: ServerLifecycleState, detail?: string) => void;
     public onStartupBlocked?: (details: string) => void;
     public onServerLog?: (line: string, stream: 'stdout' | 'stderr') => void;
 
@@ -81,6 +90,7 @@ export class TauriServerManager {
         const startedAt = performance.now();
         const t = () => Math.round(performance.now() - startedAt);
         this.log(`[timing] start() called`);
+        this.onStatusChanged?.('starting', 'boot');
         let resolveReady: ((url: string) => void) | null = null;
         let rejectReady: ((err: Error) => void) | null = null;
         const ready = new Promise<string>((resolve, reject) => {
@@ -102,6 +112,7 @@ export class TauriServerManager {
                 this.log(`[timing] server-url event received ${t()}ms after start()`);
                 this.log(`Server ready at ${this.url}`);
                 this.onUrlChanged?.(this.url);
+                this.onStatusChanged?.('running', this.url);
                 resolveReady?.(this.url);
                 resolveReady = null;
             });
@@ -120,8 +131,10 @@ export class TauriServerManager {
             this.log(`Server crashed (code=${evt.payload.code ?? 'unknown'}) — attempt ${this._crashCount}/${MAX_AUTO_RESTARTS}`);
             void this.writeCrashRecord(evt.payload);
             if (this._crashCount < MAX_AUTO_RESTARTS) {
+                this.onStatusChanged?.('starting', `crashed, retry ${this._crashCount}/${MAX_AUTO_RESTARTS}`);
                 setTimeout(() => { void this.autoRestart(); }, AUTO_RESTART_DELAY_MS);
             } else {
+                this.onStatusChanged?.('stopped', 'auto-restart exhausted');
                 this.onCrashExhausted?.(evt.payload.tail || '');
             }
         });
@@ -132,6 +145,7 @@ export class TauriServerManager {
 
         this.unlistenStartupError = await listen<string>('server-startup-error', (evt) => {
             this.log(`Server failed to start: ${evt.payload}`);
+            this.onStatusChanged?.('stopped', evt.payload);
             this.onStartupBlocked?.(evt.payload);
             rejectReady?.(new Error(evt.payload));
             rejectReady = null;
@@ -151,6 +165,7 @@ export class TauriServerManager {
                 this._isRunning = true;
                 this.log(`Server already running at ${current}`);
                 this.onUrlChanged?.(this.url);
+                this.onStatusChanged?.('running', this.url);
                 return;
             }
         } catch (err) {
@@ -179,23 +194,28 @@ export class TauriServerManager {
         }
         this._isRunning = false;
         this.url = '';
+        this.onStatusChanged?.('stopped', 'stopped by user');
     }
 
     /** Manual force-stop then respawn via Rust (menu / refresh). Resets the crash streak. */
     async restart(): Promise<void> {
         this.clearStabilityReset();
         this._crashCount = 0;
+        this.onStatusChanged?.('starting', 'restart');
         try {
             const newUrl = await invoke<string>('restart_server');
             this.url = newUrl;
             this._isRunning = true;
             this.onUrlChanged?.(this.url);
+            // The `server-url` event may not have reached JS yet, and a duplicate is a no-op.
+            this.onStatusChanged?.('running', this.url);
             this.log(`Server restarted at ${newUrl}`);
         } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
             this.log(`restart_server invoke failed: ${msg}`);
             this._isRunning = false;
             this.url = '';
+            this.onStatusChanged?.('stopped', msg);
             throw err;
         }
     }
@@ -211,6 +231,7 @@ export class TauriServerManager {
             this.url = newUrl;
             this._isRunning = true;
             this.onUrlChanged?.(this.url);
+            this.onStatusChanged?.('running', this.url);
             this.log(`Server auto-restarted at ${newUrl} (attempt ${this._crashCount}/${MAX_AUTO_RESTARTS})`);
         } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
@@ -219,8 +240,10 @@ export class TauriServerManager {
             this._crashCount++;
             this.log(`Auto-restart failed: ${msg} — attempt ${this._crashCount}/${MAX_AUTO_RESTARTS}`);
             if (this._crashCount < MAX_AUTO_RESTARTS) {
+                this.onStatusChanged?.('starting', `retry ${this._crashCount}/${MAX_AUTO_RESTARTS}`);
                 setTimeout(() => { void this.autoRestart(); }, AUTO_RESTART_DELAY_MS);
             } else {
+                this.onStatusChanged?.('stopped', 'auto-restart exhausted');
                 this.onCrashExhausted?.(msg);
             }
         }

--- a/Calcpad.Web/frontend/calcpad-web/src/services/server-manager.ts
+++ b/Calcpad.Web/frontend/calcpad-web/src/services/server-manager.ts
@@ -2,7 +2,7 @@ import { invoke } from '@tauri-apps/api/core';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import { join } from '@tauri-apps/api/path';
 import { readTextFile, writeTextFile, exists } from '@tauri-apps/plugin-fs';
-import { buildCrashRecord } from 'calcpad-frontend';
+import { buildCrashRecord, type ILogger, type CalcpadLogLevel, type ServerLifecycleState } from 'calcpad-frontend';
 
 /**
  * Manages the client-side view of the Calcpad.Server lifecycle. The actual
@@ -24,9 +24,7 @@ const START_TIMEOUT_MS = 30_000;
 // never hit the give-up threshold.
 const STABLE_RESET_MS = 30_000;
 
-export interface ServerManagerLogger {
-    appendLine(message: string): void;
-}
+export type ServerManagerLogger = ILogger;
 
 interface ServerCrashPayload {
     code: number | null;
@@ -37,13 +35,6 @@ interface ServerLogPayload {
     stream: 'stdout' | 'stderr';
     line: string;
 }
-
-/**
- * What Rust has told us about the sidecar process. A crash collapses into `starting` when a retry
- * is scheduled and `stopped` when the streak is exhausted — that distinction lives here because
- * this class owns the crash counter.
- */
-export type ServerLifecycleState = 'starting' | 'running' | 'stopped';
 
 export class TauriServerManager {
     private url = '';
@@ -89,7 +80,7 @@ export class TauriServerManager {
         // channel; time out after START_TIMEOUT_MS to avoid a wedged boot.
         const startedAt = performance.now();
         const t = () => Math.round(performance.now() - startedAt);
-        this.log(`[timing] start() called`);
+        this.log(`[timing] start() called`, 'verbose');
         this.onStatusChanged?.('starting', 'boot');
         let resolveReady: ((url: string) => void) | null = null;
         let rejectReady: ((err: Error) => void) | null = null;
@@ -101,7 +92,7 @@ export class TauriServerManager {
         try {
             this.token = await invoke<string>('server_token');
         } catch (err) {
-            this.log(`server_token invoke failed — API calls will be rejected: ${err instanceof Error ? err.message : String(err)}`);
+            this.log(`server_token invoke failed — API calls will be rejected: ${err instanceof Error ? err.message : String(err)}`, 'error');
         }
 
         try {
@@ -109,16 +100,16 @@ export class TauriServerManager {
                 this.url = evt.payload;
                 this._isRunning = true;
                 this.scheduleStabilityReset();
-                this.log(`[timing] server-url event received ${t()}ms after start()`);
+                this.log(`[timing] server-url event received ${t()}ms after start()`, 'verbose');
                 this.log(`Server ready at ${this.url}`);
                 this.onUrlChanged?.(this.url);
                 this.onStatusChanged?.('running', this.url);
                 resolveReady?.(this.url);
                 resolveReady = null;
             });
-            this.log(`[timing] server-url listener ready at ${t()}ms`);
+            this.log(`[timing] server-url listener ready at ${t()}ms`, 'verbose');
         } catch (err) {
-            this.log(`[timing] server-url listener FAILED at ${t()}ms: ${err instanceof Error ? err.message : String(err)}`);
+            this.log(`[timing] server-url listener FAILED at ${t()}ms: ${err instanceof Error ? err.message : String(err)}`, 'verbose');
             throw err;
         }
 
@@ -128,7 +119,7 @@ export class TauriServerManager {
             // Crash before the stability window elapsed — the streak stands.
             this.clearStabilityReset();
             this._crashCount++;
-            this.log(`Server crashed (code=${evt.payload.code ?? 'unknown'}) — attempt ${this._crashCount}/${MAX_AUTO_RESTARTS}`);
+            this.log(`Server crashed (code=${evt.payload.code ?? 'unknown'}) — attempt ${this._crashCount}/${MAX_AUTO_RESTARTS}`, 'error');
             void this.writeCrashRecord(evt.payload);
             if (this._crashCount < MAX_AUTO_RESTARTS) {
                 this.onStatusChanged?.('starting', `crashed, retry ${this._crashCount}/${MAX_AUTO_RESTARTS}`);
@@ -144,7 +135,7 @@ export class TauriServerManager {
         });
 
         this.unlistenStartupError = await listen<string>('server-startup-error', (evt) => {
-            this.log(`Server failed to start: ${evt.payload}`);
+            this.log(`Server failed to start: ${evt.payload}`, 'error');
             this.onStatusChanged?.('stopped', evt.payload);
             this.onStartupBlocked?.(evt.payload);
             rejectReady?.(new Error(evt.payload));
@@ -152,14 +143,14 @@ export class TauriServerManager {
             resolveReady = null;
         });
 
-        this.log(`[timing] all listeners ready at ${t()}ms`);
+        this.log(`[timing] all listeners ready at ${t()}ms`, 'verbose');
 
         // Rust starts spawning the sidecar in setup() before our listeners
         // registered, so first check if the URL is already known — otherwise
         // wait for the server-url event to fire.
         try {
             const current = await invoke<string | null>('server_url');
-            this.log(`[timing] server_url invoke returned "${current ?? 'null'}" at ${t()}ms`);
+            this.log(`[timing] server_url invoke returned "${current ?? 'null'}" at ${t()}ms`, 'verbose');
             if (current) {
                 this.url = current;
                 this._isRunning = true;
@@ -169,18 +160,18 @@ export class TauriServerManager {
                 return;
             }
         } catch (err) {
-            this.log(`[timing] server_url invoke failed at ${t()}ms: ${err instanceof Error ? err.message : String(err)}`);
+            this.log(`[timing] server_url invoke failed at ${t()}ms: ${err instanceof Error ? err.message : String(err)}`, 'verbose');
         }
 
-        this.log(`[timing] awaiting server-url event race at ${t()}ms`);
+        this.log(`[timing] awaiting server-url event race at ${t()}ms`, 'verbose');
         const timeout = new Promise<never>((_, reject) =>
             setTimeout(() => reject(new Error(`server did not report a URL within ${START_TIMEOUT_MS}ms`)), START_TIMEOUT_MS),
         );
         try {
             await Promise.race([ready, timeout]);
-            this.log(`[timing] race resolved at ${t()}ms`);
+            this.log(`[timing] race resolved at ${t()}ms`, 'verbose');
         } catch (err) {
-            this.log(`[timing] race REJECTED at ${t()}ms: ${err instanceof Error ? err.message : String(err)}`);
+            this.log(`[timing] race REJECTED at ${t()}ms: ${err instanceof Error ? err.message : String(err)}`, 'verbose');
             throw err;
         }
     }
@@ -190,7 +181,7 @@ export class TauriServerManager {
         try {
             await invoke('stop_server');
         } catch (err) {
-            this.log(`stop_server invoke failed: ${err instanceof Error ? err.message : String(err)}`);
+            this.log(`stop_server invoke failed: ${err instanceof Error ? err.message : String(err)}`, 'error');
         }
         this._isRunning = false;
         this.url = '';
@@ -212,7 +203,7 @@ export class TauriServerManager {
             this.log(`Server restarted at ${newUrl}`);
         } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
-            this.log(`restart_server invoke failed: ${msg}`);
+            this.log(`restart_server invoke failed: ${msg}`, 'error');
             this._isRunning = false;
             this.url = '';
             this.onStatusChanged?.('stopped', msg);
@@ -238,7 +229,7 @@ export class TauriServerManager {
             this._isRunning = false;
             this.url = '';
             this._crashCount++;
-            this.log(`Auto-restart failed: ${msg} — attempt ${this._crashCount}/${MAX_AUTO_RESTARTS}`);
+            this.log(`Auto-restart failed: ${msg} — attempt ${this._crashCount}/${MAX_AUTO_RESTARTS}`, 'error');
             if (this._crashCount < MAX_AUTO_RESTARTS) {
                 this.onStatusChanged?.('starting', `retry ${this._crashCount}/${MAX_AUTO_RESTARTS}`);
                 setTimeout(() => { void this.autoRestart(); }, AUTO_RESTART_DELAY_MS);
@@ -255,7 +246,7 @@ export class TauriServerManager {
         this._stableTimer = setTimeout(() => {
             this._stableTimer = null;
             if (this._crashCount > 0) {
-                this.log(`Server stable for ${STABLE_RESET_MS / 1000}s — resetting crash streak`);
+                this.log(`Server stable for ${STABLE_RESET_MS / 1000}s — resetting crash streak`, 'verbose');
                 this._crashCount = 0;
             }
         }, STABLE_RESET_MS);
@@ -297,9 +288,9 @@ export class TauriServerManager {
                 reportJson,
             });
             await writeTextFile(await join(dir, 'last-crash.txt'), record);
-            this.log(`Crash record written to ${dir}/last-crash.txt`);
+            this.log(`Crash record written to ${dir}/last-crash.txt`, 'verbose');
         } catch (err) {
-            this.log(`Could not write crash record: ${err instanceof Error ? err.message : String(err)}`);
+            this.log(`Could not write crash record: ${err instanceof Error ? err.message : String(err)}`, 'warning');
         }
     }
 
@@ -321,7 +312,7 @@ export class TauriServerManager {
         this.unlistenLog = null;
     }
 
-    private log(message: string): void {
-        this.logger.appendLine(`[ServerManager] ${message}`);
+    private log(message: string, level: CalcpadLogLevel = 'information'): void {
+        this.logger.appendLine(`[ServerManager] ${message}`, level);
     }
 }

--- a/Calcpad.Web/frontend/calcpad-web/src/styles/app.css
+++ b/Calcpad.Web/frontend/calcpad-web/src/styles/app.css
@@ -114,11 +114,16 @@ select option {
     font-size: 12px;
     background: rgba(0, 0, 0, 0.35);
     border-radius: 2px;
+    -webkit-user-select: none;
     user-select: none;
 }
 
 .status-bar .status-server.connected {
     color: #6bd66b;
+}
+
+.status-bar .status-server.connecting {
+    color: #ffcc66;
 }
 
 .status-bar .status-server.disconnected {
@@ -273,6 +278,7 @@ select option {
     overflow-y: hidden;
     flex-shrink: 0;
     height: 30px;
+    -webkit-user-select: none;
     user-select: none;
 }
 
@@ -454,6 +460,7 @@ select option {
     align-items: center;
     justify-content: center;
     cursor: pointer;
+    -webkit-user-select: none;
     user-select: none;
     border-right: 1px solid var(--vscode-widget-border, #1e1e1e);
     transition: background 0.15s;
@@ -925,6 +932,7 @@ select option {
     color: var(--vscode-statusBar-foreground, #fff);
     font-size: 12px;
     cursor: pointer;
+    -webkit-user-select: none;
     user-select: none;
 }
 

--- a/Calcpad.Web/frontend/vscode-calcpad/media/restart-connected-dark.svg
+++ b/Calcpad.Web/frontend/vscode-calcpad/media/restart-connected-dark.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path d="M8.21 2.18 A 4.7 4.7 0 1 1 3.58 3.00"
+        fill="none" stroke="#C5C5C5" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M5.42 1.46 L 4.67 4.30 L 2.49 1.70 Z" fill="#C5C5C5"/>
+  <circle cx="12.4" cy="12.4" r="4.1" fill="#1F1F1F"/>
+  <circle cx="12.4" cy="12.4" r="3.0" fill="#3fb950"/>
+</svg>

--- a/Calcpad.Web/frontend/vscode-calcpad/media/restart-connected-light.svg
+++ b/Calcpad.Web/frontend/vscode-calcpad/media/restart-connected-light.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path d="M8.21 2.18 A 4.7 4.7 0 1 1 3.58 3.00"
+        fill="none" stroke="#424242" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M5.42 1.46 L 4.67 4.30 L 2.49 1.70 Z" fill="#424242"/>
+  <circle cx="12.4" cy="12.4" r="4.1" fill="#FFFFFF"/>
+  <circle cx="12.4" cy="12.4" r="3.0" fill="#3fb950"/>
+</svg>

--- a/Calcpad.Web/frontend/vscode-calcpad/media/restart-connecting-dark.svg
+++ b/Calcpad.Web/frontend/vscode-calcpad/media/restart-connecting-dark.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path d="M8.21 2.18 A 4.7 4.7 0 1 1 3.58 3.00"
+        fill="none" stroke="#C5C5C5" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M5.42 1.46 L 4.67 4.30 L 2.49 1.70 Z" fill="#C5C5C5"/>
+  <circle cx="12.4" cy="12.4" r="4.1" fill="#1F1F1F"/>
+  <circle cx="12.4" cy="12.4" r="3.0" fill="#d29922"/>
+</svg>

--- a/Calcpad.Web/frontend/vscode-calcpad/media/restart-connecting-light.svg
+++ b/Calcpad.Web/frontend/vscode-calcpad/media/restart-connecting-light.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path d="M8.21 2.18 A 4.7 4.7 0 1 1 3.58 3.00"
+        fill="none" stroke="#424242" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M5.42 1.46 L 4.67 4.30 L 2.49 1.70 Z" fill="#424242"/>
+  <circle cx="12.4" cy="12.4" r="4.1" fill="#FFFFFF"/>
+  <circle cx="12.4" cy="12.4" r="3.0" fill="#d29922"/>
+</svg>

--- a/Calcpad.Web/frontend/vscode-calcpad/media/restart-disconnected-dark.svg
+++ b/Calcpad.Web/frontend/vscode-calcpad/media/restart-disconnected-dark.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path d="M8.21 2.18 A 4.7 4.7 0 1 1 3.58 3.00"
+        fill="none" stroke="#C5C5C5" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M5.42 1.46 L 4.67 4.30 L 2.49 1.70 Z" fill="#C5C5C5"/>
+  <circle cx="12.4" cy="12.4" r="4.1" fill="#1F1F1F"/>
+  <circle cx="12.4" cy="12.4" r="3.0" fill="#f85149"/>
+</svg>

--- a/Calcpad.Web/frontend/vscode-calcpad/media/restart-disconnected-light.svg
+++ b/Calcpad.Web/frontend/vscode-calcpad/media/restart-disconnected-light.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path d="M8.21 2.18 A 4.7 4.7 0 1 1 3.58 3.00"
+        fill="none" stroke="#424242" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M5.42 1.46 L 4.67 4.30 L 2.49 1.70 Z" fill="#424242"/>
+  <circle cx="12.4" cy="12.4" r="4.1" fill="#FFFFFF"/>
+  <circle cx="12.4" cy="12.4" r="3.0" fill="#f85149"/>
+</svg>

--- a/Calcpad.Web/frontend/vscode-calcpad/package.json
+++ b/Calcpad.Web/frontend/vscode-calcpad/package.json
@@ -411,6 +411,30 @@
         "icon": "$(refresh)"
       },
       {
+        "command": "calcpad.refreshDocumentConnected",
+        "title": "CalcpadCE: Restart Server (server connected)",
+        "icon": {
+          "light": "media/restart-connected-light.svg",
+          "dark": "media/restart-connected-dark.svg"
+        }
+      },
+      {
+        "command": "calcpad.refreshDocumentConnecting",
+        "title": "CalcpadCE: Restart Server (server starting\u2026)",
+        "icon": {
+          "light": "media/restart-connecting-light.svg",
+          "dark": "media/restart-connecting-dark.svg"
+        }
+      },
+      {
+        "command": "calcpad.refreshDocumentDisconnected",
+        "title": "CalcpadCE: Restart Server (server disconnected)",
+        "icon": {
+          "light": "media/restart-disconnected-light.svg",
+          "dark": "media/restart-disconnected-dark.svg"
+        }
+      },
+      {
         "command": "calcpad.stopServer",
         "title": "Stop CalcpadCE Server",
         "icon": "$(debug-stop)"
@@ -492,14 +516,38 @@
           "group": "navigation@1"
         },
         {
-          "command": "calcpad.refreshDocument",
-          "when": "view == calcpadVueUI",
+          "command": "calcpad.refreshDocumentConnected",
+          "when": "view == calcpadVueUI && calcpad.serverStatus == 'connected'",
+          "group": "navigation@2"
+        },
+        {
+          "command": "calcpad.refreshDocumentConnecting",
+          "when": "view == calcpadVueUI && calcpad.serverStatus == 'connecting'",
+          "group": "navigation@2"
+        },
+        {
+          "command": "calcpad.refreshDocumentDisconnected",
+          "when": "view == calcpadVueUI && calcpad.serverStatus == 'disconnected'",
           "group": "navigation@2"
         },
         {
           "command": "calcpad.stopServer",
           "when": "view == calcpadVueUI",
           "group": "navigation@3"
+        }
+      ],
+      "commandPalette": [
+        {
+          "command": "calcpad.refreshDocumentConnected",
+          "when": "false"
+        },
+        {
+          "command": "calcpad.refreshDocumentConnecting",
+          "when": "false"
+        },
+        {
+          "command": "calcpad.refreshDocumentDisconnected",
+          "when": "false"
         }
       ],
       "editor/context": [

--- a/Calcpad.Web/frontend/vscode-calcpad/src/adapters.ts
+++ b/Calcpad.Web/frontend/vscode-calcpad/src/adapters.ts
@@ -1,11 +1,21 @@
 import * as vscode from 'vscode';
-import type { ILogger, IFileSystem } from 'calcpad-frontend';
+import type { ILogger, IFileSystem, CalcpadLogLevel } from 'calcpad-frontend';
+import { shouldLog } from 'calcpad-frontend';
 
+/**
+ * An output channel behind the shared level filter. Entries below the current level are dropped
+ * rather than written, so the channel stays readable during normal editing; `show`/`clear`/
+ * `dispose` are forwarded so this can stand in for the channel itself.
+ */
 export class VSCodeLogger implements ILogger {
     constructor(private channel: vscode.OutputChannel) {}
-    appendLine(msg: string): void {
+    appendLine(msg: string, level?: CalcpadLogLevel): void {
+        if (!shouldLog(level)) return;
         this.channel.appendLine(msg);
     }
+    show(preserveFocus?: boolean): void { this.channel.show(preserveFocus); }
+    clear(): void { this.channel.clear(); }
+    dispose(): void { this.channel.dispose(); }
 }
 
 export class VSCodeFileSystem implements IFileSystem {

--- a/Calcpad.Web/frontend/vscode-calcpad/src/autoIndenter.ts
+++ b/Calcpad.Web/frontend/vscode-calcpad/src/autoIndenter.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import type { ILogger } from 'calcpad-frontend';
 import {
     shouldIncreaseIndent,
     shouldDecreaseIndent,
@@ -12,9 +13,9 @@ import {
  * Logic is provided by calcpad-frontend; this class handles VS Code event wiring.
  */
 export class AutoIndenter {
-    private outputChannel: vscode.OutputChannel;
+    private outputChannel: ILogger;
 
-    constructor(outputChannel: vscode.OutputChannel) {
+    constructor(outputChannel: ILogger) {
         this.outputChannel = outputChannel;
     }
 

--- a/Calcpad.Web/frontend/vscode-calcpad/src/baseServerManager.ts
+++ b/Calcpad.Web/frontend/vscode-calcpad/src/baseServerManager.ts
@@ -3,8 +3,8 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as crypto from 'crypto';
 import { spawn, execSync, ChildProcess } from 'child_process';
-import type { ILogger } from 'calcpad-frontend';
-import { decodeExitCode, buildCrashRecord, API_TOKEN_HEADER } from 'calcpad-frontend';
+import type { ILogger, ServerLifecycleState, CalcpadLogLevel } from 'calcpad-frontend';
+import { decodeExitCode, buildCrashRecord, API_TOKEN_HEADER, getLogLevel } from 'calcpad-frontend';
 
 interface LockFileContents {
     pid: number;
@@ -12,6 +12,8 @@ interface LockFileContents {
     startedAt: number;
     /** Per-launch token the server requires on `/api` routes. Absent in a pre-token lock. */
     token?: string;
+    /** Set only on the pre-spawn placeholder, whose `pid` is an extension host, not a server. */
+    starting?: true;
 }
 
 /** Lock files carry the API token, so nobody but this user may read one. */
@@ -65,6 +67,16 @@ export class BaseServerManager {
     public onCrashExhausted?: (crashOutput: string) => void;
 
     /**
+     * The server we are now talking to, whether we spawned it, adopted a peer's, or came back
+     * from an auto-restart. Every start picks a fresh port, so a listener that skips this ends
+     * up addressing a dead one.
+     */
+    public onUrlChanged?: (newUrl: string) => void;
+
+    /** Always raised after onUrlChanged, so a listener may assume the new URL is already applied. */
+    public onStatusChanged?: (state: ServerLifecycleState, detail?: string) => void;
+
+    /**
      * @param logger    Server debug channel — receives stdout (verbose server output).
      * @param mainLogger Main extension log — receives stderr only. Falls back to `logger` if omitted.
      */
@@ -75,6 +87,12 @@ export class BaseServerManager {
         this.dotnetPath = dotnetPath;
         this.lockFilePath = path.join(basePath, 'bin', '.calcpad-server.lock');
         this.startCrashWatcher();
+    }
+
+    /** Announces a server this window can now talk to. URL first, so a status listener may use it. */
+    private announceRunning(): void {
+        this.onUrlChanged?.(this.getBaseUrl());
+        this.onStatusChanged?.('running', this.getBaseUrl());
     }
 
     /**
@@ -110,8 +128,12 @@ export class BaseServerManager {
     /**
      * Read the lock file and verify the recorded server is alive and healthy.
      * Returns the lock contents if reusable, or null if the lock is missing/stale.
+     *
+     * @param replaceUnhealthy Kill an alive-but-unhealthy server and drop its lock. Only safe
+     * from `start()`: while waiting on a peer, the server the lock names is one that is still
+     * booting and legitimately not answering yet.
      */
-    private async tryReuseExistingServer(): Promise<LockFileContents | null> {
+    private async tryReuseExistingServer(replaceUnhealthy: boolean = false): Promise<LockFileContents | null> {
         const lock = this.readLockFile();
         if (!lock) {
             if (fs.existsSync(this.lockFilePath)) this.removeLockFile();
@@ -121,26 +143,51 @@ export class BaseServerManager {
         try {
             process.kill(lock.pid, 0);
         } catch {
-            this.log(`Lock file references dead PID ${lock.pid} — ignoring`);
+            this.log(`Lock file references dead PID ${lock.pid} — ignoring`, 'verbose');
             this.removeLockFile();
             return null;
         }
 
-        try {
-            const response = await fetch(`http://localhost:${lock.port}/api/calcpad/snippets`, {
-                headers: lock.token ? { [API_TOKEN_HEADER]: lock.token } : {},
-                signal: AbortSignal.timeout(2000)
-            });
-            if (!response.ok) {
-                this.log(`Existing server at port ${lock.port} unhealthy (HTTP ${response.status}) — ignoring`);
-                return null;
+        const why = await this.probeLockedServer(lock);
+        if (why) {
+            // Alive but not answering: wedged, or an orphan too old to know /health. It is no
+            // use to any window, so replace it rather than leaving peers to time out on it —
+            // but confirm first, since one missed probe can just be a server under load.
+            if (replaceUnhealthy && !lock.starting
+                && await this.probeLockedServer(lock) && this.stillNamesSameServer(lock)) {
+                this.log(`Existing server at port ${lock.port} failed two health checks (${why}) — replacing it`, 'warning');
+                this.killByPid(lock.pid);
+                this.removeLockFile();
+            } else {
+                this.log(`Existing server at port ${lock.port} failed its health check (${why}) — ignoring`, 'verbose');
             }
-        } catch (err) {
-            this.log(`Existing server at port ${lock.port} unreachable: ${err instanceof Error ? err.message : String(err)}`);
             return null;
         }
 
         return lock;
+    }
+
+    /**
+     * True when the lock on disk still names the server we just probed. Re-read because the
+     * probes take seconds, and a peer that finishes spawning meanwhile replaces its placeholder —
+     * whose `pid` is that window's extension host, not something to kill.
+     */
+    private stillNamesSameServer(lock: LockFileContents): boolean {
+        const current = this.readLockFile();
+        return !!current && !current.starting && current.pid === lock.pid && current.port === lock.port;
+    }
+
+    /** Null when the locked server answers its health probe, otherwise why it did not. */
+    private async probeLockedServer(lock: LockFileContents): Promise<string | null> {
+        try {
+            const response = await fetch(`http://localhost:${lock.port}/api/calcpad/health`, {
+                headers: lock.token ? { [API_TOKEN_HEADER]: lock.token } : {},
+                signal: AbortSignal.timeout(2000)
+            });
+            return response.ok ? null : `HTTP ${response.status}`;
+        } catch (err) {
+            return err instanceof Error ? err.message : String(err);
+        }
     }
 
     /**
@@ -152,15 +199,17 @@ export class BaseServerManager {
             this.log('Server is already running');
             return;
         }
+        this.onStatusChanged?.('starting', 'start');
 
         // Reuse an existing server from another VS Code window if one is alive.
-        const existing = await this.tryReuseExistingServer();
+        const existing = await this.tryReuseExistingServer(true);
         if (existing) {
             this.port = existing.port;
             this.authToken = existing.token ?? null;
             this._owned = false;
             this._isRunning = true;
             this.log(`Reusing existing server (PID ${existing.pid}) at port ${existing.port}`);
+            this.announceRunning();
             return;
         }
 
@@ -183,10 +232,11 @@ export class BaseServerManager {
         const placeholderLock: LockFileContents = {
             pid: process.pid,  // extension host PID — used by peers to detect if spawner died
             port: candidatePort,
-            startedAt: Date.now()
+            startedAt: Date.now(),
+            starting: true
         };
         if (!this.tryClaimLockExclusive(placeholderLock)) {
-            this.log('Another window is spawning the server — waiting to adopt it...');
+            this.log('Another window is spawning the server — waiting to adopt it...', 'verbose');
             const adopted = await this.waitForPeerServer(20000);
             if (adopted) {
                 this.port = adopted.port;
@@ -194,9 +244,10 @@ export class BaseServerManager {
                 this._owned = false;
                 this._isRunning = true;
                 this.log(`Adopted peer-spawned server (PID ${adopted.pid}) at port ${adopted.port}`);
+                this.announceRunning();
                 return;
             }
-            this.log('Timed out waiting for peer server — reclaiming lock and spawning our own');
+            this.log('Timed out waiting for peer server — reclaiming lock and spawning our own', 'warning');
             this.removeLockFile();
             this.tryClaimLockExclusive(placeholderLock);
         }
@@ -221,7 +272,7 @@ export class BaseServerManager {
             try {
                 fs.chmodSync(exePath, 0o755);
             } catch (err) {
-                this.log(`Warning: could not chmod ${exeName}: ${err instanceof Error ? err.message : String(err)}`);
+                this.log(`Warning: could not chmod ${exeName}: ${err instanceof Error ? err.message : String(err)}`, 'warning');
             }
             // createdump is invoked by the .NET runtime on crash; without +x
             // the runtime aborts startup on some distros.
@@ -264,6 +315,9 @@ export class BaseServerManager {
             // ASPNETCORE_ENVIRONMENT=Development exported would otherwise get
             // Swagger and the debug-crash endpoint on a shipped extension.
             ASPNETCORE_ENVIRONMENT: 'Production',
+            // The client re-pushes this over /api/calcpad/log-level once it connects, which is
+            // far too late for the server's own startup entries.
+            CALCPAD_LOG_LEVEL: getLogLevel(),
         };
 
         // The apphost probes the standard install locations and PATH, so it cannot find a
@@ -295,7 +349,7 @@ export class BaseServerManager {
         this._spawnFailed = false;
         this._spawnFailedCode = null;
         this._processClosed = false;
-        this.log(`Spawned via ${useAppHost ? 'apphost' : 'dotnet'} (PID ${this.serverProcess.pid}, detached)`);
+        this.log(`Spawned via ${useAppHost ? 'apphost' : 'dotnet'} (PID ${this.serverProcess.pid}, detached)`, 'verbose');
 
         // Rewrite the lock with the actual child PID (replacing our host-PID placeholder).
         if (this.serverProcess.pid) {
@@ -308,16 +362,18 @@ export class BaseServerManager {
         }
 
         // stdout → server debug channel only. Not buffered, not surfaced in crash messages.
+        // Passed through at 'error' rather than filtered again: the server has already applied
+        // the same level at the source, and re-filtering here would drop the crash tail.
         this.serverProcess.stdout?.on('data', (data: Buffer) => {
             const text = data.toString().trim();
-            this.logger.appendLine(`[ServerManager] [stdout] ${text}`);
+            this.logger.appendLine(`[ServerManager] [stdout] ${text}`, 'error');
         });
 
         // stderr → main extension log + crash buffer. These are the lines we actually
         // want visible to the user and included in crash reports.
         this.serverProcess.stderr?.on('data', (data: Buffer) => {
             const text = data.toString().trim();
-            this.mainLogger.appendLine(`[ServerManager] [stderr] ${text}`);
+            this.mainLogger.appendLine(`[ServerManager] [stderr] ${text}`, 'error');
             this._lastCrashOutput.push(text);
             if (this._lastCrashOutput.length > 20) {
                 this._lastCrashOutput.shift();
@@ -336,7 +392,7 @@ export class BaseServerManager {
         // user has to unblock the file in Explorer and click Refresh.
         this.serverProcess.on('error', (err: NodeJS.ErrnoException) => {
             const code = err.code ?? '';
-            this.log(`[error] Failed to start server: ${err.message}${code ? ` (${code})` : ''}`);
+            this.log(`[error] Failed to start server: ${err.message}${code ? ` (${code})` : ''}`, 'error');
             this._spawnFailed = true;
             this._spawnFailedCode = code;
             this._isRunning = false;
@@ -377,16 +433,18 @@ export class BaseServerManager {
                 this._restartCount++;
                 if (this._restartCount < BaseServerManager.MAX_RESTARTS) {
                     this.log(`Unexpected exit — attempting restart ${this._restartCount}/${BaseServerManager.MAX_RESTARTS} in 2 seconds...`);
+                    this.onStatusChanged?.('starting', `crashed, retry ${this._restartCount}/${BaseServerManager.MAX_RESTARTS}`);
                     setTimeout(() => {
                         if (!this._disposed) {
                             this.start().catch(err => {
-                                this.log(`Restart failed: ${err instanceof Error ? err.message : String(err)}`);
+                                this.log(`Restart failed: ${err instanceof Error ? err.message : String(err)}`, 'error');
                             });
                         }
                     }, 2000);
                 } else {
                     const crashOutput = this._lastCrashOutput.join('\n');
-                    this.log(`Server crashed ${this._restartCount} times — auto-restart disabled. Use refresh to restart manually.`);
+                    this.log(`Server crashed ${this._restartCount} times — auto-restart disabled. Use refresh to restart manually.`, 'error');
+                    this.onStatusChanged?.('stopped', 'auto-restart exhausted');
                     this.onCrashExhausted?.(crashOutput);
                 }
             }
@@ -398,6 +456,7 @@ export class BaseServerManager {
             this._isRunning = true;
             this._lastCrashOutput = [];
             this.log(`Server is ready at ${serverUrl}`);
+            this.announceRunning();
         } catch (err) {
             // If the spawn failed (Windows blocked the .exe, dotnet missing, etc.) the
             // child PID is unknown and the placeholder lock still holds the extension
@@ -406,6 +465,9 @@ export class BaseServerManager {
             if (this._spawnFailed) {
                 this.removeLockFile();
             }
+            // Nothing retries from here: the exit handler stands down while _startingUp,
+            // and the auto-restart path's own start() lands here too.
+            this.onStatusChanged?.('stopped', err instanceof Error ? err.message : String(err));
             throw err;
         } finally {
             this._startingUp = false;
@@ -434,7 +496,7 @@ export class BaseServerManager {
             const lock = this.readLockFile();
             if (lock) {
                 if (lock.pid === process.pid) {
-                    this.log(`Discarding stale placeholder lock (our own PID ${lock.pid}, no child to kill)`);
+                    this.log(`Discarding stale placeholder lock (our own PID ${lock.pid}, no child to kill)`, 'verbose');
                 } else {
                     this.log(`Stopping shared server (PID ${lock.pid})`);
                     this.killByPid(lock.pid);
@@ -443,10 +505,11 @@ export class BaseServerManager {
             } else if (fs.existsSync(this.lockFilePath)) {
                 // Present but unreadable or out of range — nothing safe to kill,
                 // and leaving it would make every peer wait on a phantom server.
-                this.log('Discarding unusable lock file');
+                this.log('Discarding unusable lock file', 'verbose');
                 this.removeLockFile();
             }
             this._isRunning = false;
+            this.onStatusChanged?.('stopped', 'stopped by user');
             return;
         }
 
@@ -480,6 +543,7 @@ export class BaseServerManager {
 
         this.removeLockFile();
         this.log('Server stopped');
+        this.onStatusChanged?.('stopped', 'stopped by user');
     }
 
     /**
@@ -577,7 +641,7 @@ export class BaseServerManager {
         try {
             fs.writeFileSync(this.lockFilePath, JSON.stringify(lock), { encoding: 'utf-8', mode: LOCK_FILE_MODE });
         } catch (err) {
-            this.log(`Warning: Could not write lock file: ${err instanceof Error ? err.message : String(err)}`);
+            this.log(`Warning: Could not write lock file: ${err instanceof Error ? err.message : String(err)}`, 'warning');
         }
     }
 
@@ -593,7 +657,7 @@ export class BaseServerManager {
             if (err && typeof err === 'object' && 'code' in err && (err as { code: string }).code === 'EEXIST') {
                 return false;
             }
-            this.log(`Warning: Could not claim lock file: ${err instanceof Error ? err.message : String(err)}`);
+            this.log(`Warning: Could not claim lock file: ${err instanceof Error ? err.message : String(err)}`, 'warning');
             return false;
         }
     }
@@ -665,7 +729,7 @@ export class BaseServerManager {
     }
 
     private async waitForReady(serverUrl: string, maxAttempts: number = 60, intervalMs: number = 500): Promise<void> {
-        const healthUrl = `${serverUrl}/api/calcpad/snippets`;
+        const healthUrl = `${serverUrl}/api/calcpad/health`;
 
         for (let i = 0; i < maxAttempts; i++) {
             // Fail fast if the server process has fully closed (stdio drained).
@@ -730,8 +794,8 @@ export class BaseServerManager {
         }
     }
 
-    private log(message: string): void {
-        this.logger.appendLine(`[ServerManager] ${message}`);
+    private log(message: string, level: CalcpadLogLevel = 'information'): void {
+        this.logger.appendLine(`[ServerManager] ${message}`, level);
     }
 
     /**
@@ -773,7 +837,7 @@ export class BaseServerManager {
             fs.writeFileSync(file, record, 'utf-8');
             this.mainLogger.appendLine(`[ServerManager] Crash record written: ${file}`);
         } catch (err) {
-            this.log(`Warning: could not write crash record: ${err instanceof Error ? err.message : String(err)}`);
+            this.log(`Warning: could not write crash record: ${err instanceof Error ? err.message : String(err)}`, 'warning');
         }
     }
 

--- a/Calcpad.Web/frontend/vscode-calcpad/src/calcpadCompiledEditorProvider.ts
+++ b/Calcpad.Web/frontend/vscode-calcpad/src/calcpadCompiledEditorProvider.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import type { ILogger } from 'calcpad-frontend';
 import * as path from 'path';
 import { writeUiOverrides } from 'calcpad-frontend';
 import type { CalcpadApiClient, UiOverrideStore } from 'calcpad-frontend';
@@ -59,14 +60,14 @@ export class CalcpadCompiledEditorProvider
         private readonly _apiClient: CalcpadApiClient,
         private readonly _uiOverrides: UiOverrideStore,
         private readonly _renderPanel: RenderPanel,
-        private readonly _log: vscode.OutputChannel,
+        private readonly _log: ILogger,
     ) {}
 
     public static register(
         apiClient: CalcpadApiClient,
         uiOverrides: UiOverrideStore,
         renderPanel: RenderPanel,
-        log: vscode.OutputChannel,
+        log: ILogger,
     ): CalcpadCompiledEditorProvider {
         const provider = new CalcpadCompiledEditorProvider(apiClient, uiOverrides, renderPanel, log);
         provider._registration = vscode.window.registerCustomEditorProvider(

--- a/Calcpad.Web/frontend/vscode-calcpad/src/calcpadCompletionProvider.ts
+++ b/Calcpad.Web/frontend/vscode-calcpad/src/calcpadCompletionProvider.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import type { ILogger } from 'calcpad-frontend';
 import {
     buildInsertSnippet,
     hasSnippetPlaceholders,
@@ -52,9 +53,9 @@ function toVscodeCompletion(data: CompletionData): vscode.CompletionItem {
 export class CalcpadCompletionProvider implements vscode.CompletionItemProvider {
     private insertManager: CalcpadInsertManager;
     private definitionsService: CalcpadDefinitionsService;
-    private outputChannel: vscode.OutputChannel;
+    private outputChannel: ILogger;
 
-    constructor(definitionsService: CalcpadDefinitionsService, insertManager: CalcpadInsertManager, outputChannel: vscode.OutputChannel) {
+    constructor(definitionsService: CalcpadDefinitionsService, insertManager: CalcpadInsertManager, outputChannel: ILogger) {
         this.insertManager = insertManager;
         this.definitionsService = definitionsService;
         this.outputChannel = outputChannel;
@@ -85,14 +86,14 @@ export class CalcpadCompletionProvider implements vscode.CompletionItemProvider 
         const wordRange = document.getWordRangeAtPosition(position);
         const word = wordRange ? document.getText(wordRange) : '';
 
-        this.outputChannel.appendLine('[COMPLETION] Word: "' + word + '" at position ' + position.line + ':' + position.character);
+        this.outputChannel.appendLine('[COMPLETION] Word: "' + word + '" at position ' + position.line + ':' + position.character, 'verbose');
 
         // Ensure snippets are loaded
         if (!this.insertManager.isLoaded()) {
             try {
                 await this.insertManager.loadSnippets();
             } catch (error) {
-                this.outputChannel.appendLine('[COMPLETION] Failed to load snippets: ' + error);
+                this.outputChannel.appendLine('[COMPLETION] Failed to load snippets: ' + error, 'verbose');
             }
         }
 
@@ -121,7 +122,7 @@ export class CalcpadCompletionProvider implements vscode.CompletionItemProvider 
             }
 
         } catch (error) {
-            this.outputChannel.appendLine('[COMPLETION ERROR] ' + error);
+            this.outputChannel.appendLine('[COMPLETION ERROR] ' + error, 'verbose');
         }
 
         // Add built-in content from insert manager — only snippets that define a keyword
@@ -140,7 +141,7 @@ export class CalcpadCompletionProvider implements vscode.CompletionItemProvider 
             }
         }
 
-        this.outputChannel.appendLine(`[COMPLETION] Returning ${completionItems.length} items`);
+        this.outputChannel.appendLine(`[COMPLETION] Returning ${completionItems.length} items`, 'verbose');
         return completionItems;
     }
 
@@ -467,7 +468,7 @@ export class CalcpadCompletionProvider implements vscode.CompletionItemProvider 
     /**
      * Register the completion provider
      */
-    public static register(definitionsService: CalcpadDefinitionsService, insertManager: CalcpadInsertManager, outputChannel: vscode.OutputChannel): vscode.Disposable {
+    public static register(definitionsService: CalcpadDefinitionsService, insertManager: CalcpadInsertManager, outputChannel: ILogger): vscode.Disposable {
         const provider = new CalcpadCompletionProvider(definitionsService, insertManager, outputChannel);
         return vscode.languages.registerCompletionItemProvider(
             ['calcpad', 'plaintext'], // Language selector

--- a/Calcpad.Web/frontend/vscode-calcpad/src/calcpadDefinitionProvider.ts
+++ b/Calcpad.Web/frontend/vscode-calcpad/src/calcpadDefinitionProvider.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
+import type { ILogger } from 'calcpad-frontend';
 import { CalcpadApiClient, SymbolAtPositionResponse, parseDirectiveLine } from 'calcpad-frontend';
-import { VSCodeLogger, VSCodeFileSystem } from './adapters';
+import { VSCodeFileSystem } from './adapters';
 import { resolveSymbolLocation, resolveIncludeDirectiveLocation, resolveDocumentPathRoots } from './calcpadLocationResolver';
 import type { CalcpadDefinitionsService } from './calcpadDefinitionsService';
 
@@ -12,15 +13,15 @@ import type { CalcpadDefinitionsService } from './calcpadDefinitionsService';
 export class CalcpadDefinitionProvider implements vscode.DefinitionProvider {
     private apiClient: CalcpadApiClient;
     private definitionsService: CalcpadDefinitionsService;
-    private outputChannel: vscode.OutputChannel;
-    private logger: VSCodeLogger;
+    private outputChannel: ILogger;
+    private logger: ILogger;
     private fileSystem: VSCodeFileSystem;
 
-    constructor(apiClient: CalcpadApiClient, definitionsService: CalcpadDefinitionsService, outputChannel: vscode.OutputChannel) {
+    constructor(apiClient: CalcpadApiClient, definitionsService: CalcpadDefinitionsService, outputChannel: ILogger) {
         this.apiClient = apiClient;
         this.definitionsService = definitionsService;
         this.outputChannel = outputChannel;
-        this.logger = new VSCodeLogger(outputChannel);
+        this.logger = outputChannel;
         this.fileSystem = new VSCodeFileSystem();
     }
 
@@ -40,22 +41,22 @@ export class CalcpadDefinitionProvider implements vscode.DefinitionProvider {
 
         const sym = await this.fetchSymbol(document, position);
         if (!sym) {
-            this.outputChannel.appendLine('[Definition] No symbol at cursor position');
+            this.outputChannel.appendLine('[Definition] No symbol at cursor position', 'verbose');
             return null;
         }
 
-        this.outputChannel.appendLine('[Definition] Looking for definition of: ' + sym.symbolName);
+        this.outputChannel.appendLine('[Definition] Looking for definition of: ' + sym.symbolName, 'verbose');
 
         const definition = sym.locations.find(loc => loc.isAssignment);
         if (!definition) {
-            this.outputChannel.appendLine('[Definition] No definition (assignment) found for: ' + sym.symbolName);
+            this.outputChannel.appendLine('[Definition] No definition (assignment) found for: ' + sym.symbolName, 'verbose');
             return null;
         }
 
         this.outputChannel.appendLine(
             `[Definition] Found definition at line ${definition.line}, col ${definition.column}` +
             (definition.sourceFile ? ` in ${definition.sourceFile}` : '')
-        );
+        , 'verbose');
 
         return resolveSymbolLocation(document, definition, this.fileSystem, this.outputChannel, '[Definition]');
     }
@@ -84,7 +85,7 @@ export class CalcpadDefinitionProvider implements vscode.DefinitionProvider {
         } catch (error) {
             this.outputChannel.appendLine(
                 '[Definition] Error resolving symbol: ' + (error instanceof Error ? error.message : 'Unknown error')
-            );
+            , 'verbose');
             return null;
         }
     }
@@ -92,7 +93,7 @@ export class CalcpadDefinitionProvider implements vscode.DefinitionProvider {
     static register(
         apiClient: CalcpadApiClient,
         definitionsService: CalcpadDefinitionsService,
-        outputChannel: vscode.OutputChannel
+        outputChannel: ILogger
     ): vscode.Disposable {
         const provider = new CalcpadDefinitionProvider(apiClient, definitionsService, outputChannel);
         return vscode.languages.registerDefinitionProvider(

--- a/Calcpad.Web/frontend/vscode-calcpad/src/calcpadDefinitionsService.ts
+++ b/Calcpad.Web/frontend/vscode-calcpad/src/calcpadDefinitionsService.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import type { ILogger } from 'calcpad-frontend';
 import * as path from 'path';
 import {
     CalcpadDefinitionsService as FrontendDefinitionsService,
@@ -6,20 +7,20 @@ import {
     DefinitionsResponse,
     ResolvedPathRoots,
 } from 'calcpad-frontend';
-import { VSCodeLogger, VSCodeFileSystem } from './adapters';
+import { VSCodeFileSystem } from './adapters';
 
 /**
  * VS Code wrapper around CalcpadDefinitionsService from calcpad-frontend.
  * Adapts the platform-agnostic definitions service for use with
- * vscode.TextDocument and vscode.OutputChannel.
+ * vscode.TextDocument and ILogger.
  */
 export class CalcpadDefinitionsService {
     private definitionsService: FrontendDefinitionsService;
-    private logger: VSCodeLogger;
+    private logger: ILogger;
     private fileSystem: VSCodeFileSystem;
 
-    constructor(apiClient: CalcpadApiClient, debugChannel: vscode.OutputChannel) {
-        this.logger = new VSCodeLogger(debugChannel);
+    constructor(apiClient: CalcpadApiClient, debugChannel: ILogger) {
+        this.logger = debugChannel;
         this.fileSystem = new VSCodeFileSystem();
         this.definitionsService = new FrontendDefinitionsService(apiClient, this.logger);
     }
@@ -37,7 +38,7 @@ export class CalcpadDefinitionsService {
 
         try {
             return await this.definitionsService.refreshDefinitions(
-                content, document.uri.toString(), document.uri.fsPath
+                content, document.uri.toString(), document.uri.fsPath, `defs:${document.uri.toString()}`
             );
         } catch (error) {
             this.logger.appendLine(

--- a/Calcpad.Web/frontend/vscode-calcpad/src/calcpadHoverProvider.ts
+++ b/Calcpad.Web/frontend/vscode-calcpad/src/calcpadHoverProvider.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import type { ILogger } from 'calcpad-frontend';
 import { CalcpadDefinitionsService } from './calcpadDefinitionsService';
 import { CalcpadInsertManager } from './calcpadInsertManager';
 import { buildBuiltinDocMarkdown, extractFunctionName } from './calcpadBuiltinDocs';
@@ -17,12 +18,12 @@ import type {
 export class CalcpadHoverProvider implements vscode.HoverProvider {
     private definitionsService: CalcpadDefinitionsService;
     private insertManager: CalcpadInsertManager;
-    private outputChannel: vscode.OutputChannel;
+    private outputChannel: ILogger;
 
     constructor(
         definitionsService: CalcpadDefinitionsService,
         insertManager: CalcpadInsertManager,
-        outputChannel: vscode.OutputChannel
+        outputChannel: ILogger
     ) {
         this.definitionsService = definitionsService;
         this.insertManager = insertManager;
@@ -51,25 +52,25 @@ export class CalcpadHoverProvider implements vscode.HoverProvider {
         if (definitions) {
             const macro = definitions.macros.find(m => m.name === word);
             if (macro) {
-                this.outputChannel.appendLine('[Hover] Macro: ' + word);
+                this.outputChannel.appendLine('[Hover] Macro: ' + word, 'verbose');
                 return new vscode.Hover(this.buildMacroHover(macro), wordRange);
             }
 
             const func = definitions.functions.find(f => f.name === word);
             if (func) {
-                this.outputChannel.appendLine('[Hover] Function: ' + word);
+                this.outputChannel.appendLine('[Hover] Function: ' + word, 'verbose');
                 return new vscode.Hover(this.buildFunctionHover(func), wordRange);
             }
 
             const variable = definitions.variables.find(v => v.name === word);
             if (variable) {
-                this.outputChannel.appendLine('[Hover] Variable: ' + word);
+                this.outputChannel.appendLine('[Hover] Variable: ' + word, 'verbose');
                 return new vscode.Hover(this.buildVariableHover(variable), wordRange);
             }
 
             const unit = definitions.customUnits.find(u => u.name === word);
             if (unit) {
-                this.outputChannel.appendLine('[Hover] Custom unit: ' + word);
+                this.outputChannel.appendLine('[Hover] Custom unit: ' + word, 'verbose');
                 return new vscode.Hover(this.buildCustomUnitHover(unit), wordRange);
             }
         }
@@ -81,7 +82,7 @@ export class CalcpadHoverProvider implements vscode.HoverProvider {
                 return extractFunctionName(item.tag) === word;
             });
             if (builtin) {
-                this.outputChannel.appendLine('[Hover] Built-in function: ' + word);
+                this.outputChannel.appendLine('[Hover] Built-in function: ' + word, 'verbose');
                 return new vscode.Hover(buildBuiltinDocMarkdown(builtin), wordRange);
             }
         }
@@ -217,7 +218,7 @@ export class CalcpadHoverProvider implements vscode.HoverProvider {
     static register(
         definitionsService: CalcpadDefinitionsService,
         insertManager: CalcpadInsertManager,
-        outputChannel: vscode.OutputChannel
+        outputChannel: ILogger
     ): vscode.Disposable {
         const provider = new CalcpadHoverProvider(definitionsService, insertManager, outputChannel);
         return vscode.languages.registerHoverProvider(

--- a/Calcpad.Web/frontend/vscode-calcpad/src/calcpadIncludeCompletionProvider.ts
+++ b/Calcpad.Web/frontend/vscode-calcpad/src/calcpadIncludeCompletionProvider.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import type { ILogger } from 'calcpad-frontend';
 import * as path from 'path';
 import * as os from 'os';
 import {
@@ -18,10 +19,10 @@ import { expandEnvVars } from './calcpadLocationResolver';
 import type { CalcpadDefinitionsService } from './calcpadDefinitionsService';
 
 export class CalcpadIncludeCompletionProvider implements vscode.CompletionItemProvider {
-    private outputChannel: vscode.OutputChannel;
+    private outputChannel: ILogger;
     private definitionsService: CalcpadDefinitionsService;
 
-    constructor(definitionsService: CalcpadDefinitionsService, outputChannel: vscode.OutputChannel) {
+    constructor(definitionsService: CalcpadDefinitionsService, outputChannel: ILogger) {
         this.definitionsService = definitionsService;
         this.outputChannel = outputChannel;
     }
@@ -41,7 +42,7 @@ export class CalcpadIncludeCompletionProvider implements vscode.CompletionItemPr
 
         const { directive, pathStartCol } = parsed;
 
-        this.outputChannel.appendLine(`[INCLUDE COMPLETION] Triggered on line: "${lineText}" (directive: #${directive})`);
+        this.outputChannel.appendLine(`[INCLUDE COMPLETION] Triggered on line: "${lineText}" (directive: #${directive})`, 'verbose');
 
         // Strip any trailing options (@sheet, type=, sep=) from the partial path for completion
         let partialPath = parsed.partialPath;
@@ -50,7 +51,7 @@ export class CalcpadIncludeCompletionProvider implements vscode.CompletionItemPr
             partialPath = partialPath.substring(0, atIndex);
         }
 
-        this.outputChannel.appendLine(`[INCLUDE COMPLETION] Partial path: "${partialPath}"`);
+        this.outputChannel.appendLine(`[INCLUDE COMPLETION] Partial path: "${partialPath}"`, 'verbose');
 
         const documentDir = path.dirname(document.uri.fsPath);
         const homeDir = os.homedir();
@@ -84,7 +85,7 @@ export class CalcpadIncludeCompletionProvider implements vscode.CompletionItemPr
         });
         this.outputChannel.appendLine(
             `[INCLUDE COMPLETION] Resolved roots: project="${resolvedRoots.project || '(none)'}" library="${resolvedRoots.library || '(none)'}"`
-        );
+        , 'verbose');
 
         try {
             const tokenKind = getPathRootTokenKind(partialPath);
@@ -95,7 +96,7 @@ export class CalcpadIncludeCompletionProvider implements vscode.CompletionItemPr
                 const tokenText = partialPath.slice(0, USER_TOKEN.length);
                 let rest = partialPath.slice(tokenText.length);
                 if (rest.startsWith('/') || rest.startsWith('\\')) rest = rest.slice(1);
-                this.outputChannel.appendLine(`[INCLUDE COMPLETION] Inside {user} root, relative path: "${rest}"`);
+                this.outputChannel.appendLine(`[INCLUDE COMPLETION] Inside {user} root, relative path: "${rest}"`, 'verbose');
                 await this.addEntriesFromDirectory(
                     homeDir, rest, extensions, replaceRange,
                     document.uri.fsPath, completionItems, addedEntries, token,
@@ -109,7 +110,7 @@ export class CalcpadIncludeCompletionProvider implements vscode.CompletionItemPr
                     const tokenText = partialPath.slice(0, PATH_ROOT_TOKEN[tokenKind].length);
                     let rest = partialPath.slice(tokenText.length);
                     if (rest.startsWith('/') || rest.startsWith('\\')) rest = rest.slice(1);
-                    this.outputChannel.appendLine(`[INCLUDE COMPLETION] Inside ${tokenKind} root, relative path: "${rest}"`);
+                    this.outputChannel.appendLine(`[INCLUDE COMPLETION] Inside ${tokenKind} root, relative path: "${rest}"`, 'verbose');
                     await this.addEntriesFromDirectory(
                         root, rest, extensions, replaceRange,
                         document.uri.fsPath, completionItems, addedEntries, token,
@@ -118,7 +119,7 @@ export class CalcpadIncludeCompletionProvider implements vscode.CompletionItemPr
                 }
             } else if (partialPath.includes('/') || partialPath.includes('\\')) {
                 // User is navigating local subdirectories (path has separators but isn't a token)
-                this.outputChannel.appendLine(`[INCLUDE COMPLETION] Navigating local subdirectory`);
+                this.outputChannel.appendLine(`[INCLUDE COMPLETION] Navigating local subdirectory`, 'verbose');
 
                 await this.addEntriesFromDirectory(
                     documentDir, partialPath, extensions, replaceRange,
@@ -127,7 +128,7 @@ export class CalcpadIncludeCompletionProvider implements vscode.CompletionItemPr
                 );
             } else {
                 // Root level - show local files/folders + declared roots + workspace folders
-                this.outputChannel.appendLine(`[INCLUDE COMPLETION] Root level - searching local + declared roots + workspace`);
+                this.outputChannel.appendLine(`[INCLUDE COMPLETION] Root level - searching local + declared roots + workspace`, 'verbose');
 
                 await this.addEntriesFromDirectory(
                     documentDir, partialPath, extensions, replaceRange,
@@ -168,7 +169,7 @@ export class CalcpadIncludeCompletionProvider implements vscode.CompletionItemPr
                     if (folderNorm === docDirNorm || rootNorms.includes(folderNorm)) {
                         continue;
                     }
-                    this.outputChannel.appendLine(`[INCLUDE COMPLETION] Also searching workspace folder: ${folderPath}`);
+                    this.outputChannel.appendLine(`[INCLUDE COMPLETION] Also searching workspace folder: ${folderPath}`, 'verbose');
                     await this.addEntriesFromDirectory(
                         folderPath, '', extensions, replaceRange,
                         document.uri.fsPath, completionItems, addedEntries, token,
@@ -177,9 +178,9 @@ export class CalcpadIncludeCompletionProvider implements vscode.CompletionItemPr
                 }
             }
 
-            this.outputChannel.appendLine(`[INCLUDE COMPLETION] Returning ${completionItems.length} items (isIncomplete=true)`);
+            this.outputChannel.appendLine(`[INCLUDE COMPLETION] Returning ${completionItems.length} items (isIncomplete=true)`, 'verbose');
         } catch (error) {
-            this.outputChannel.appendLine(`[INCLUDE COMPLETION ERROR] ${error}`);
+            this.outputChannel.appendLine(`[INCLUDE COMPLETION ERROR] ${error}`, 'verbose');
         }
 
         // Return as incomplete so VS Code re-invokes the provider on each keystroke
@@ -212,13 +213,13 @@ export class CalcpadIncludeCompletionProvider implements vscode.CompletionItemPr
             searchDir = baseDir;
         }
 
-        this.outputChannel.appendLine(`[INCLUDE COMPLETION]   Reading directory: ${searchDir} (pathPrefix="${pathPrefix}", libraryPrefix="${libraryPrefix}")`);
+        this.outputChannel.appendLine(`[INCLUDE COMPLETION]   Reading directory: ${searchDir} (pathPrefix="${pathPrefix}", libraryPrefix="${libraryPrefix}")`, 'verbose');
 
         let entries: [string, vscode.FileType][];
         try {
             entries = await vscode.workspace.fs.readDirectory(vscode.Uri.file(searchDir));
         } catch (err) {
-            this.outputChannel.appendLine(`[INCLUDE COMPLETION]   Could not read directory: ${searchDir} (${err})`);
+            this.outputChannel.appendLine(`[INCLUDE COMPLETION]   Could not read directory: ${searchDir} (${err})`, 'verbose');
             return;
         }
 
@@ -226,7 +227,7 @@ export class CalcpadIncludeCompletionProvider implements vscode.CompletionItemPr
             return;
         }
 
-        this.outputChannel.appendLine(`[INCLUDE COMPLETION]   Found ${entries.length} entries in ${searchDir}`);
+        this.outputChannel.appendLine(`[INCLUDE COMPLETION]   Found ${entries.length} entries in ${searchDir}`, 'verbose');
 
         // Insert workspace-folder entries with absolute paths so #include
         // resolves regardless of the current file's location.
@@ -309,7 +310,7 @@ export class CalcpadIncludeCompletionProvider implements vscode.CompletionItemPr
         }
     }
 
-    public static register(definitionsService: CalcpadDefinitionsService, outputChannel: vscode.OutputChannel): vscode.Disposable {
+    public static register(definitionsService: CalcpadDefinitionsService, outputChannel: ILogger): vscode.Disposable {
         const provider = new CalcpadIncludeCompletionProvider(definitionsService, outputChannel);
         return vscode.languages.registerCompletionItemProvider(
             ['calcpad', 'plaintext'],

--- a/Calcpad.Web/frontend/vscode-calcpad/src/calcpadIncludeLinkProvider.ts
+++ b/Calcpad.Web/frontend/vscode-calcpad/src/calcpadIncludeLinkProvider.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import type { ILogger } from 'calcpad-frontend';
 import { parseDirectiveLine } from 'calcpad-frontend';
 import { VSCodeFileSystem } from './adapters';
 import { resolveIncludeDirectiveLocation, resolveDocumentPathRoots } from './calcpadLocationResolver';
@@ -14,7 +15,7 @@ export class CalcpadIncludeLinkProvider implements vscode.DocumentLinkProvider {
 
     constructor(
         private definitionsService: CalcpadDefinitionsService,
-        private outputChannel: vscode.OutputChannel,
+        private outputChannel: ILogger,
     ) {
         this.fileSystem = new VSCodeFileSystem();
     }
@@ -44,7 +45,7 @@ export class CalcpadIncludeLinkProvider implements vscode.DocumentLinkProvider {
         return links;
     }
 
-    static register(definitionsService: CalcpadDefinitionsService, outputChannel: vscode.OutputChannel): vscode.Disposable {
+    static register(definitionsService: CalcpadDefinitionsService, outputChannel: ILogger): vscode.Disposable {
         return vscode.languages.registerDocumentLinkProvider(
             { language: 'calcpad' },
             new CalcpadIncludeLinkProvider(definitionsService, outputChannel),

--- a/Calcpad.Web/frontend/vscode-calcpad/src/calcpadInsertManager.ts
+++ b/Calcpad.Web/frontend/vscode-calcpad/src/calcpadInsertManager.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import type { ILogger } from 'calcpad-frontend';
 import {
     CalcpadSnippetService,
     CalcpadApiClient,
@@ -6,7 +7,6 @@ import {
     InsertDataTree,
     SnippetsLoadedCallback,
 } from 'calcpad-frontend';
-import { VSCodeLogger } from './adapters';
 
 export type { InsertItem, InsertDataTree, SnippetsLoadedCallback };
 
@@ -17,8 +17,8 @@ export type { InsertItem, InsertDataTree, SnippetsLoadedCallback };
 export class CalcpadInsertManager {
     private snippetService: CalcpadSnippetService;
 
-    constructor(apiClient: CalcpadApiClient, outputChannel: vscode.OutputChannel) {
-        const logger = new VSCodeLogger(outputChannel);
+    constructor(apiClient: CalcpadApiClient, outputChannel: ILogger) {
+        const logger = outputChannel;
         this.snippetService = new CalcpadSnippetService(apiClient, logger);
     }
 

--- a/Calcpad.Web/frontend/vscode-calcpad/src/calcpadLocationResolver.ts
+++ b/Calcpad.Web/frontend/vscode-calcpad/src/calcpadLocationResolver.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import type { ILogger } from 'calcpad-frontend';
 import * as path from 'path';
 import * as os from 'os';
 import type { SymbolLocation } from 'calcpad-frontend';
@@ -42,13 +43,13 @@ export async function resolveIncludeDirectiveLocation(
     document: vscode.TextDocument,
     rawPath: string,
     fileSystem: VSCodeFileSystem,
-    outputChannel: vscode.OutputChannel,
+    outputChannel: ILogger,
     logPrefix: string,
     roots: ResolvedPathRoots = resolveDocumentPathRoots(document),
 ): Promise<vscode.Location | null> {
     const { expanded: tokenExpanded, ok } = expandPathRootToken(rawPath.trim(), roots, os.homedir());
     if (!ok) {
-        outputChannel.appendLine(`${logPrefix} Include target's path root is not declared: ${rawPath}`);
+        outputChannel.appendLine(`${logPrefix} Include target's path root is not declared: ${rawPath}`, 'verbose');
         return null;
     }
     const expanded = expandEnvVars(tokenExpanded);
@@ -58,23 +59,23 @@ export async function resolveIncludeDirectiveLocation(
     const documentDir = path.dirname(document.uri.fsPath);
     const relativeResolved = path.resolve(documentDir, expanded);
     if (await fileSystem.exists(relativeResolved)) {
-        outputChannel.appendLine(`${logPrefix} Resolved include via document dir: ${relativeResolved}`);
+        outputChannel.appendLine(`${logPrefix} Resolved include via document dir: ${relativeResolved}`, 'verbose');
         return new vscode.Location(vscode.Uri.file(relativeResolved), start);
     }
 
     if (path.isAbsolute(expanded) && await fileSystem.exists(expanded)) {
-        outputChannel.appendLine(`${logPrefix} Resolved include via absolute path: ${expanded}`);
+        outputChannel.appendLine(`${logPrefix} Resolved include via absolute path: ${expanded}`, 'verbose');
         return new vscode.Location(vscode.Uri.file(expanded), start);
     }
 
     const pattern = '**/' + expanded.replace(/\\/g, '/');
     const foundFiles = await vscode.workspace.findFiles(pattern, '**/node_modules/**', 1);
     if (foundFiles.length > 0) {
-        outputChannel.appendLine(`${logPrefix} Resolved include via workspace search: ${foundFiles[0].fsPath}`);
+        outputChannel.appendLine(`${logPrefix} Resolved include via workspace search: ${foundFiles[0].fsPath}`, 'verbose');
         return new vscode.Location(foundFiles[0], start);
     }
 
-    outputChannel.appendLine(`${logPrefix} Include target not found: ${rawPath} (tried ${relativeResolved} and workspace search)`);
+    outputChannel.appendLine(`${logPrefix} Include target not found: ${rawPath} (tried ${relativeResolved} and workspace search)`, 'verbose');
     return null;
 }
 
@@ -89,7 +90,7 @@ export async function resolveSymbolLocation(
     document: vscode.TextDocument,
     loc: SymbolLocation,
     fileSystem: VSCodeFileSystem,
-    outputChannel: vscode.OutputChannel,
+    outputChannel: ILogger,
     logPrefix: string,
 ): Promise<vscode.Location | null> {
     const line = Math.max(0, loc.line);
@@ -105,17 +106,17 @@ export async function resolveSymbolLocation(
     const documentDir = path.dirname(document.uri.fsPath);
     const relativeResolved = path.resolve(documentDir, loc.sourceFile);
     if (await fileSystem.exists(relativeResolved)) {
-        outputChannel.appendLine(`${logPrefix} Resolved include via document dir: ${relativeResolved}`);
+        outputChannel.appendLine(`${logPrefix} Resolved include via document dir: ${relativeResolved}`, 'verbose');
         return new vscode.Location(vscode.Uri.file(relativeResolved), range);
     }
 
     const pattern = '**/' + loc.sourceFile;
     const foundFiles = await vscode.workspace.findFiles(pattern, '**/node_modules/**', 1);
     if (foundFiles.length > 0) {
-        outputChannel.appendLine(`${logPrefix} Resolved include via workspace search: ${foundFiles[0].fsPath}`);
+        outputChannel.appendLine(`${logPrefix} Resolved include via workspace search: ${foundFiles[0].fsPath}`, 'verbose');
         return new vscode.Location(foundFiles[0], range);
     }
 
-    outputChannel.appendLine(`${logPrefix} Source file not found: ${loc.sourceFile} (tried ${relativeResolved} and workspace search)`);
+    outputChannel.appendLine(`${logPrefix} Source file not found: ${loc.sourceFile} (tried ${relativeResolved} and workspace search)`, 'verbose');
     return null;
 }

--- a/Calcpad.Web/frontend/vscode-calcpad/src/calcpadReferenceProvider.ts
+++ b/Calcpad.Web/frontend/vscode-calcpad/src/calcpadReferenceProvider.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
+import type { ILogger } from 'calcpad-frontend';
 import { CalcpadApiClient, SymbolAtPositionResponse } from 'calcpad-frontend';
-import { VSCodeLogger, VSCodeFileSystem } from './adapters';
+import { VSCodeFileSystem } from './adapters';
 import { resolveSymbolLocation } from './calcpadLocationResolver';
 
 /**
@@ -10,14 +11,14 @@ import { resolveSymbolLocation } from './calcpadLocationResolver';
  */
 export class CalcpadReferenceProvider implements vscode.ReferenceProvider {
     private apiClient: CalcpadApiClient;
-    private outputChannel: vscode.OutputChannel;
-    private logger: VSCodeLogger;
+    private outputChannel: ILogger;
+    private logger: ILogger;
     private fileSystem: VSCodeFileSystem;
 
-    constructor(apiClient: CalcpadApiClient, outputChannel: vscode.OutputChannel) {
+    constructor(apiClient: CalcpadApiClient, outputChannel: ILogger) {
         this.apiClient = apiClient;
         this.outputChannel = outputChannel;
-        this.logger = new VSCodeLogger(outputChannel);
+        this.logger = outputChannel;
         this.fileSystem = new VSCodeFileSystem();
     }
 
@@ -29,17 +30,17 @@ export class CalcpadReferenceProvider implements vscode.ReferenceProvider {
     ): Promise<vscode.Location[] | null> {
         const sym = await this.fetchSymbol(document, position);
         if (!sym) {
-            this.outputChannel.appendLine('[References] No symbol at cursor position');
+            this.outputChannel.appendLine('[References] No symbol at cursor position', 'verbose');
             return null;
         }
 
-        this.outputChannel.appendLine('[References] Finding references for: ' + sym.symbolName);
+        this.outputChannel.appendLine('[References] Finding references for: ' + sym.symbolName, 'verbose');
 
         const filtered = context.includeDeclaration
             ? sym.locations
             : sym.locations.filter(loc => !loc.isAssignment);
 
-        this.outputChannel.appendLine(`[References] Found ${filtered.length} reference(s) (${sym.locations.length} total)`);
+        this.outputChannel.appendLine(`[References] Found ${filtered.length} reference(s) (${sym.locations.length} total)`, 'verbose');
 
         const results: vscode.Location[] = [];
         for (const loc of filtered) {
@@ -61,14 +62,14 @@ export class CalcpadReferenceProvider implements vscode.ReferenceProvider {
         } catch (error) {
             this.outputChannel.appendLine(
                 '[References] Error resolving symbol: ' + (error instanceof Error ? error.message : 'Unknown error')
-            );
+            , 'verbose');
             return null;
         }
     }
 
     static register(
         apiClient: CalcpadApiClient,
-        outputChannel: vscode.OutputChannel
+        outputChannel: ILogger
     ): vscode.Disposable {
         const provider = new CalcpadReferenceProvider(apiClient, outputChannel);
         return vscode.languages.registerReferenceProvider(

--- a/Calcpad.Web/frontend/vscode-calcpad/src/calcpadRenameProvider.ts
+++ b/Calcpad.Web/frontend/vscode-calcpad/src/calcpadRenameProvider.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
+import type { ILogger } from 'calcpad-frontend';
 import { CalcpadApiClient, SymbolAtPositionResponse } from 'calcpad-frontend';
-import { VSCodeLogger, VSCodeFileSystem } from './adapters';
+import { VSCodeFileSystem } from './adapters';
 
 /**
  * Provides "Rename Symbol" (F2) for CalcPad variables, functions, and macros by asking the
@@ -9,14 +10,14 @@ import { VSCodeLogger, VSCodeFileSystem } from './adapters';
  */
 export class CalcpadRenameProvider implements vscode.RenameProvider {
     private apiClient: CalcpadApiClient;
-    private outputChannel: vscode.OutputChannel;
-    private logger: VSCodeLogger;
+    private outputChannel: ILogger;
+    private logger: ILogger;
     private fileSystem: VSCodeFileSystem;
 
-    constructor(apiClient: CalcpadApiClient, outputChannel: vscode.OutputChannel) {
+    constructor(apiClient: CalcpadApiClient, outputChannel: ILogger) {
         this.apiClient = apiClient;
         this.outputChannel = outputChannel;
-        this.logger = new VSCodeLogger(outputChannel);
+        this.logger = outputChannel;
         this.fileSystem = new VSCodeFileSystem();
     }
 
@@ -50,15 +51,15 @@ export class CalcpadRenameProvider implements vscode.RenameProvider {
     ): Promise<vscode.WorkspaceEdit | null> {
         const sym = await this.fetchSymbol(document, position);
         if (!sym) {
-            this.outputChannel.appendLine('[Rename] No symbol at cursor position');
+            this.outputChannel.appendLine('[Rename] No symbol at cursor position', 'verbose');
             return null;
         }
         if (sym.symbolName === newName) return null;
 
-        this.outputChannel.appendLine(`[Rename] Renaming '${sym.symbolName}' to '${newName}'`);
+        this.outputChannel.appendLine(`[Rename] Renaming '${sym.symbolName}' to '${newName}'`, 'verbose');
 
         const localLocations = sym.locations.filter(loc => loc.source === 'local');
-        this.outputChannel.appendLine(`[Rename] Found ${localLocations.length} local occurrence(s) (${sym.locations.length} total)`);
+        this.outputChannel.appendLine(`[Rename] Found ${localLocations.length} local occurrence(s) (${sym.locations.length} total)`, 'verbose');
 
         const edit = new vscode.WorkspaceEdit();
         for (const loc of localLocations) {
@@ -94,14 +95,14 @@ export class CalcpadRenameProvider implements vscode.RenameProvider {
         } catch (error) {
             this.outputChannel.appendLine(
                 '[Rename] Error resolving symbol: ' + (error instanceof Error ? error.message : 'Unknown error')
-            );
+            , 'verbose');
             return null;
         }
     }
 
     static register(
         apiClient: CalcpadApiClient,
-        outputChannel: vscode.OutputChannel
+        outputChannel: ILogger
     ): vscode.Disposable {
         const provider = new CalcpadRenameProvider(apiClient, outputChannel);
         return vscode.languages.registerRenameProvider(

--- a/Calcpad.Web/frontend/vscode-calcpad/src/calcpadSemanticTokensProvider.ts
+++ b/Calcpad.Web/frontend/vscode-calcpad/src/calcpadSemanticTokensProvider.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import type { ILogger } from 'calcpad-frontend';
 import * as path from 'path';
 import {
     CalcpadApiClient,
@@ -21,20 +22,20 @@ export const semanticTokensLegend = new vscode.SemanticTokensLegend(
  * via CalcpadApiClient from calcpad-frontend.
  */
 export class CalcpadSemanticTokensProvider implements vscode.DocumentSemanticTokensProvider {
-    private debugChannel: vscode.OutputChannel;
+    private debugChannel: ILogger;
     private apiClient: CalcpadApiClient;
     private fileSystem = new VSCodeFileSystem();
     private requestId = 0;
     private _onDidChangeSemanticTokens = new vscode.EventEmitter<void>();
     public readonly onDidChangeSemanticTokens = this._onDidChangeSemanticTokens.event;
 
-    constructor(apiClient: CalcpadApiClient, debugChannel: vscode.OutputChannel) {
+    constructor(apiClient: CalcpadApiClient, debugChannel: ILogger) {
         this.apiClient = apiClient;
         this.debugChannel = debugChannel;
     }
 
     public refresh(): void {
-        this.debugChannel.appendLine('[Highlight] Manual refresh triggered');
+        this.debugChannel.appendLine('[Highlight] Manual refresh triggered', 'verbose');
         this._onDidChangeSemanticTokens.fire();
     }
 
@@ -46,10 +47,10 @@ export class CalcpadSemanticTokensProvider implements vscode.DocumentSemanticTok
         const reqId = ++this.requestId;
         const startTime = Date.now();
 
-        this.debugChannel.appendLine('[Highlight #' + reqId + '] Request started for ' + document.fileName + ' (' + content.length + ' chars)');
+        this.debugChannel.appendLine('[Highlight #' + reqId + '] Request started for ' + document.fileName + ' (' + content.length + ' chars)', 'verbose');
 
         if (!content.trim()) {
-            this.debugChannel.appendLine('[Highlight #' + reqId + '] Skipped - empty document');
+            this.debugChannel.appendLine('[Highlight #' + reqId + '] Skipped - empty document', 'verbose');
             return null;
         }
 
@@ -61,16 +62,16 @@ export class CalcpadSemanticTokensProvider implements vscode.DocumentSemanticTok
             });
 
             if (cancellationToken.isCancellationRequested) {
-                this.debugChannel.appendLine('[Highlight #' + reqId + '] Cancelled after ' + (Date.now() - startTime) + 'ms');
+                this.debugChannel.appendLine('[Highlight #' + reqId + '] Cancelled after ' + (Date.now() - startTime) + 'ms', 'verbose');
                 return null;
             }
 
             if (!tokens) {
-                this.debugChannel.appendLine('[Highlight #' + reqId + '] No tokens returned after ' + (Date.now() - startTime) + 'ms');
+                this.debugChannel.appendLine('[Highlight #' + reqId + '] No tokens returned after ' + (Date.now() - startTime) + 'ms', 'verbose');
                 return null;
             }
 
-            this.debugChannel.appendLine('[Highlight #' + reqId + '] Received ' + tokens.length + ' tokens in ' + (Date.now() - startTime) + 'ms');
+            this.debugChannel.appendLine('[Highlight #' + reqId + '] Received ' + tokens.length + ' tokens in ' + (Date.now() - startTime) + 'ms', 'verbose');
 
             const builder = new vscode.SemanticTokensBuilder(semanticTokensLegend);
 
@@ -93,10 +94,10 @@ export class CalcpadSemanticTokensProvider implements vscode.DocumentSemanticTok
                 }
             }
 
-            this.debugChannel.appendLine('[Highlight #' + reqId + '] Built ' + validCount + ' semantic tokens, total time: ' + (Date.now() - startTime) + 'ms');
+            this.debugChannel.appendLine('[Highlight #' + reqId + '] Built ' + validCount + ' semantic tokens, total time: ' + (Date.now() - startTime) + 'ms', 'verbose');
             return builder.build();
         } catch (error) {
-            this.debugChannel.appendLine('[Highlight #' + reqId + '] Error after ' + (Date.now() - startTime) + 'ms: ' + (error instanceof Error ? error.message : 'Unknown error'));
+            this.debugChannel.appendLine('[Highlight #' + reqId + '] Error after ' + (Date.now() - startTime) + 'ms: ' + (error instanceof Error ? error.message : 'Unknown error'), 'verbose');
             return null;
         }
     }

--- a/Calcpad.Web/frontend/vscode-calcpad/src/calcpadServerLinter.ts
+++ b/Calcpad.Web/frontend/vscode-calcpad/src/calcpadServerLinter.ts
@@ -1,11 +1,11 @@
 import * as vscode from 'vscode';
+import type { ILogger } from 'calcpad-frontend';
 import * as path from 'path';
 import {
     CalcpadLintService,
     CalcpadApiClient,
     LintDiagnostic,
 } from 'calcpad-frontend';
-import { VSCodeLogger } from './adapters';
 import { CalcpadSettingsManager } from './calcpadSettings';
 
 /**
@@ -16,11 +16,11 @@ import { CalcpadSettingsManager } from './calcpadSettings';
 export class CalcpadServerLinter {
     private diagnosticCollection: vscode.DiagnosticCollection;
     private lintService: CalcpadLintService;
-    private logger: VSCodeLogger;
+    private logger: ILogger;
 
-    constructor(apiClient: CalcpadApiClient, debugChannel: vscode.OutputChannel) {
+    constructor(apiClient: CalcpadApiClient, debugChannel: ILogger) {
         this.diagnosticCollection = vscode.languages.createDiagnosticCollection('calcpad');
-        this.logger = new VSCodeLogger(debugChannel);
+        this.logger = debugChannel;
         this.lintService = new CalcpadLintService(apiClient, this.logger);
     }
 
@@ -34,7 +34,7 @@ export class CalcpadServerLinter {
 
         try {
             const sourceFilePath = document.uri.fsPath;
-            const lintResponse = await this.lintService.lintContent(content, sourceFilePath, document.uri.toString());
+            const lintResponse = await this.lintService.lintContent(content, sourceFilePath, `lint:${document.uri.toString()}`);
 
             if (lintResponse) {
                 const diagnostics = this.convertToDiagnostics(lintResponse.diagnostics);

--- a/Calcpad.Web/frontend/vscode-calcpad/src/calcpadServerManager.ts
+++ b/Calcpad.Web/frontend/vscode-calcpad/src/calcpadServerManager.ts
@@ -1,8 +1,8 @@
 import * as vscode from 'vscode';
+import type { ILogger } from 'calcpad-frontend';
 import * as path from 'path';
 import * as fs from 'fs';
 import { BaseServerManager } from './baseServerManager';
-import { VSCodeLogger } from './adapters';
 import {
     NUGET_HOSTS,
     assertAllowedUrl,
@@ -130,7 +130,7 @@ function getPlatformNativeInfo(): PlatformNativeInfo | null {
  */
 export class CalcpadServerManager extends BaseServerManager implements vscode.Disposable {
     private extensionPath: string;
-    private outputChannel: vscode.OutputChannel;
+    private outputChannel: ILogger;
 
     /**
      * @param outputChannel Server debug channel — receives stdout (verbose server output).
@@ -138,15 +138,15 @@ export class CalcpadServerManager extends BaseServerManager implements vscode.Di
      */
     constructor(
         extensionPath: string,
-        outputChannel: vscode.OutputChannel,
+        outputChannel: ILogger,
         dotnetPath: string = 'dotnet',
-        mainOutputChannel?: vscode.OutputChannel
+        mainOutputChannel?: ILogger
     ) {
         super(
             extensionPath,
-            new VSCodeLogger(outputChannel),
+            outputChannel,
             dotnetPath,
-            mainOutputChannel ? new VSCodeLogger(mainOutputChannel) : undefined
+            mainOutputChannel
         );
         this.extensionPath = extensionPath;
         this.outputChannel = outputChannel;

--- a/Calcpad.Web/frontend/vscode-calcpad/src/calcpadSettings.ts
+++ b/Calcpad.Web/frontend/vscode-calcpad/src/calcpadSettings.ts
@@ -18,6 +18,7 @@ import {
     writesAllowed,
 } from 'calcpad-frontend';
 import type { WriteMode } from 'calcpad-frontend';
+import { VSCodeLogger } from './adapters';
 
 export type { CalcpadSettings, CalcpadExtras };
 
@@ -34,11 +35,11 @@ const ACTIVE_PRESET_KEY = 'calcpad-active-preset';
 const HOTKEYS_WORKSPACE_KEY = 'enableFormattingHotkeys';
 const HOTKEYS_EXTRA_KEY = 'formattingHotkeys';
 
-let _outputChannel: vscode.OutputChannel | undefined;
+let _outputChannel: VSCodeLogger | undefined;
 
-function getOutputChannel(): vscode.OutputChannel {
+function getOutputChannel(): VSCodeLogger {
     if (!_outputChannel) {
-        _outputChannel = vscode.window.createOutputChannel('CalcpadCE Settings');
+        _outputChannel = new VSCodeLogger(vscode.window.createOutputChannel('CalcpadCE Settings'));
     }
     return _outputChannel;
 }
@@ -178,10 +179,10 @@ export class CalcpadSettingsManager {
         const apiSettings = buildApiSettings(this._settings);
 
         const outputChannel = getOutputChannel();
-        outputChannel.appendLine('API settings being sent:');
-        outputChannel.appendLine(`  Local Server URL: ${this._localServerUrl ?? '(none)'}`);
-        outputChannel.appendLine(`  Remote Server URL: ${this._settings.server.url}`);
-        outputChannel.appendLine(`  Effective Server URL: ${this.getServerUrl()}`);
+        outputChannel.appendLine('API settings being sent:', 'verbose');
+        outputChannel.appendLine(`  Local Server URL: ${this._localServerUrl ?? '(none)'}`, 'verbose');
+        outputChannel.appendLine(`  Remote Server URL: ${this._settings.server.url}`, 'verbose');
+        outputChannel.appendLine(`  Effective Server URL: ${this.getServerUrl()}`, 'verbose');
 
         return apiSettings;
     }
@@ -232,7 +233,7 @@ export class CalcpadSettingsManager {
         try {
             await fs.promises.mkdir(path.dirname(presetPath), { recursive: true });
             await fs.promises.writeFile(presetPath, JSON.stringify(blob, null, 4), 'utf8');
-            getOutputChannel().appendLine(`[Settings] savePreset -> "${name}" file="${presetPath}"`);
+            getOutputChannel().appendLine(`[Settings] savePreset -> "${name}" file="${presetPath}"`, 'verbose');
         } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
             return { ok: false, message: `Failed to write preset: ${msg}` };
@@ -248,10 +249,10 @@ export class CalcpadSettingsManager {
      */
     public async loadPreset(name: string): Promise<void> {
         if (!this.isValidPresetName(name)) {
-            getOutputChannel().appendLine(`[Settings] loadPreset refused invalid name "${name}"`);
+            getOutputChannel().appendLine(`[Settings] loadPreset refused invalid name "${name}"`, 'warning');
             return;
         }
-        getOutputChannel().appendLine(`[Settings] loadPreset("${name}") — was active="${this._activePresetName}"`);
+        getOutputChannel().appendLine(`[Settings] loadPreset("${name}") — was active="${this._activePresetName}"`, 'verbose');
         await this.readPresetInto(name);
         await this.setActivePresetName(name);
         await this.saveActiveSettings();
@@ -267,7 +268,7 @@ export class CalcpadSettingsManager {
             await vscode.env.openExternal(vscode.Uri.file(dir));
         } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
-            getOutputChannel().appendLine(`[Settings] Failed to open settings folder: ${msg}`);
+            getOutputChannel().appendLine(`[Settings] Failed to open settings folder: ${msg}`, 'warning');
         }
     }
 
@@ -318,7 +319,7 @@ export class CalcpadSettingsManager {
                 await fs.promises.writeFile(defaultPath, JSON.stringify(blob, null, 4), 'utf8');
             } catch (err) {
                 const msg = err instanceof Error ? err.message : String(err);
-                getOutputChannel().appendLine(`[Settings] Could not refresh default.json: ${msg}`);
+                getOutputChannel().appendLine(`[Settings] Could not refresh default.json: ${msg}`, 'warning');
             }
         }
     }
@@ -345,12 +346,12 @@ export class CalcpadSettingsManager {
      */
     private async loadFromDisk(): Promise<void> {
         if (!this._context) {
-            getOutputChannel().appendLine(`[Settings] loadFromDisk skipped — no context yet`);
+            getOutputChannel().appendLine(`[Settings] loadFromDisk skipped — no context yet`, 'verbose');
             return;
         }
         await this.ensureSettingsFolder();
         this._activePresetName = this.loadActivePresetName();
-        getOutputChannel().appendLine(`[Settings] loadFromDisk — active-preset="${this._activePresetName}"`);
+        getOutputChannel().appendLine(`[Settings] loadFromDisk — active-preset="${this._activePresetName}"`, 'verbose');
 
         const loaded = await this.readActiveSettings();
         if (!loaded) {
@@ -383,7 +384,7 @@ export class CalcpadSettingsManager {
                 const msg = err instanceof Error ? err.message : String(err);
                 getOutputChannel().appendLine(
                     `[Settings] readActiveSettings failed for ${activePath}: ${msg}`
-                );
+                , 'verbose');
             }
             return false;
         }
@@ -414,7 +415,7 @@ export class CalcpadSettingsManager {
             const msg = err instanceof Error ? err.message : String(err);
             getOutputChannel().appendLine(
                 `[Settings] readPresetInto("${name}") failed, falling back to defaults: ${msg}`
-            );
+            , 'verbose');
             this._settings = getDefaultSettings();
             this._extras = getDefaultExtras();
         }
@@ -430,7 +431,7 @@ export class CalcpadSettingsManager {
             await fs.promises.writeFile(activePath, JSON.stringify(blob, null, 4), 'utf8');
         } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
-            getOutputChannel().appendLine(`[Settings] Failed to write ${activePath}: ${msg}`);
+            getOutputChannel().appendLine(`[Settings] Failed to write ${activePath}: ${msg}`, 'warning');
         }
     }
 
@@ -448,7 +449,7 @@ export class CalcpadSettingsManager {
                 await workspace.update(HOTKEYS_WORKSPACE_KEY, desired, vscode.ConfigurationTarget.Global);
             } catch (err) {
                 const msg = err instanceof Error ? err.message : String(err);
-                getOutputChannel().appendLine(`[Settings] Could not mirror ${HOTKEYS_WORKSPACE_KEY}: ${msg}`);
+                getOutputChannel().appendLine(`[Settings] Could not mirror ${HOTKEYS_WORKSPACE_KEY}: ${msg}`, 'warning');
             }
         }
     }

--- a/Calcpad.Web/frontend/vscode-calcpad/src/calcpadVueUIProvider.ts
+++ b/Calcpad.Web/frontend/vscode-calcpad/src/calcpadVueUIProvider.ts
@@ -2,16 +2,17 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as crypto from 'crypto';
-import { parseHeadings, DEFAULT_PDF_SETTINGS, extractPlotsFromHtml, buildZip, serializeMetadataComment, serializeSettingsDirective, hasMetadataContent, computeMetadataBlock, buildDefinitionResolver, findUiDirectiveBlock, serializeUiDirective, DEFAULT_PREVIEW_SIZE_MB, DEFAULT_CONSOLE_MESSAGES_PER_DOCUMENT, coerceWriteMode, coerceServerLogLevel } from 'calcpad-frontend';
+import { parseHeadings, DEFAULT_PDF_SETTINGS, extractPlotsFromHtml, buildZip, serializeMetadataComment, serializeSettingsDirective, hasMetadataContent, computeMetadataBlock, buildDefinitionResolver, findUiDirectiveBlock, serializeUiDirective, DEFAULT_PREVIEW_SIZE_MB, DEFAULT_CONSOLE_MESSAGES_PER_DOCUMENT, coerceWriteMode, coerceLogLevel } from 'calcpad-frontend';
 import type { CalcpadError, ExtractedPlot, MetadataCommentBlock, MetadataCommentData, MetadataLayout, DefinitionResolver, DefinitionsResponse, SettingsValues, UiDirectiveData, UiControl } from 'calcpad-frontend';
 import { CalcpadSettingsManager } from './calcpadSettings';
 import { CalcpadInsertManager } from './calcpadInsertManager';
+import { VSCodeLogger } from './adapters';
 
 export class CalcpadVueUIProvider implements vscode.WebviewViewProvider {
     public static readonly viewType = 'calcpadVueUI';
 
     private _view?: vscode.WebviewView;
-    private _outputChannel: vscode.OutputChannel;
+    private _outputChannel: VSCodeLogger;
     private _cachedPlots: ExtractedPlot[] = [];
     private _cachedHtml: string = '';
     private _inputMode = false;
@@ -24,7 +25,7 @@ export class CalcpadVueUIProvider implements vscode.WebviewViewProvider {
     public getSourceEditor?: () => vscode.TextEditor | undefined;
     public onPreviewThemeChanged?: () => void | Promise<void>;
     public onSettingsChanged?: () => void | Promise<void>;
-    public onServerLogLevelChanged?: (level: string) => void;
+    public onLogLevelChanged?: (level: string) => void;
     /** Real highlighter definitions for a document URI, used to resolve metadata context. */
     public getDefinitions?: (documentUri: string) => DefinitionsResponse | undefined;
     /**
@@ -42,12 +43,12 @@ export class CalcpadVueUIProvider implements vscode.WebviewViewProvider {
         private readonly _settingsManager: CalcpadSettingsManager,
         private readonly _insertManager: CalcpadInsertManager
     ) {
-        this._outputChannel = vscode.window.createOutputChannel('CalcpadCE Vue');
-        this._outputChannel.appendLine('CalcPad Vue UI Provider initialized');
+        this._outputChannel = new VSCodeLogger(vscode.window.createOutputChannel('CalcpadCE Vue'));
+        this._outputChannel.appendLine('CalcPad Vue UI Provider initialized', 'verbose');
 
         // Register callback to refresh UI when snippets are loaded from server
         this._insertManager.onSnippetsLoaded(() => {
-            this._outputChannel.appendLine('Snippets loaded - refreshing Vue UI');
+            this._outputChannel.appendLine('Snippets loaded - refreshing Vue UI', 'verbose');
             this._sendInitialData();
         });
     }
@@ -58,7 +59,7 @@ export class CalcpadVueUIProvider implements vscode.WebviewViewProvider {
         _token: vscode.CancellationToken,
     ) {
         this._view = webviewView;
-        this._outputChannel.appendLine('Resolving Vue webview view');
+        this._outputChannel.appendLine('Resolving Vue webview view', 'verbose');
 
         webviewView.webview.options = {
             // Allow scripts in the webview
@@ -69,11 +70,11 @@ export class CalcpadVueUIProvider implements vscode.WebviewViewProvider {
         };
 
         webviewView.webview.html = this._getHtmlForWebview(webviewView.webview);
-        this._outputChannel.appendLine('Webview HTML set');
+        this._outputChannel.appendLine('Webview HTML set', 'verbose');
 
         // Handle messages from the webview
         webviewView.webview.onDidReceiveMessage(async (data) => {
-            this._outputChannel.appendLine(`Received message: ${data.type}`);
+            this._outputChannel.appendLine(`Received message: ${data.type}`, 'verbose');
             switch (data.type) {
                 case 'insertText':
                     const insertEditor = vscode.window.activeTextEditor;
@@ -178,9 +179,9 @@ export class CalcpadVueUIProvider implements vscode.WebviewViewProvider {
                     this._settingsManager.setExtra('linterMinSeverity', data.severity);
                     break;
 
-                case 'updateServerLogLevel':
-                    this._settingsManager.setExtra('serverLogLevel', data.level);
-                    this.onServerLogLevelChanged?.(data.level);
+                case 'updateLogLevel':
+                    this._settingsManager.setExtra('logLevel', data.level);
+                    this.onLogLevelChanged?.(data.level);
                     break;
 
                 case 'updateWriteMode':
@@ -230,10 +231,10 @@ export class CalcpadVueUIProvider implements vscode.WebviewViewProvider {
                     try { fs.mkdirSync(logsDir, { recursive: true }); } catch { /* best-effort */ }
                     try {
                         await vscode.env.openExternal(vscode.Uri.file(logsDir));
-                        this._outputChannel.appendLine(`Opened logs folder: ${logsDir}`);
+                        this._outputChannel.appendLine(`Opened logs folder: ${logsDir}`, 'verbose');
                     } catch (err) {
                         const msg = err instanceof Error ? err.message : String(err);
-                        this._outputChannel.appendLine(`Failed to open logs folder: ${msg}`);
+                        this._outputChannel.appendLine(`Failed to open logs folder: ${msg}`, 'warning');
                         vscode.window.showErrorMessage(`Could not open logs folder: ${msg}`);
                     }
                     break;
@@ -338,12 +339,12 @@ export class CalcpadVueUIProvider implements vscode.WebviewViewProvider {
                     break;
 
                 case 'refreshDocument':
-                    this._outputChannel.appendLine('[Vue UI] Run preview requested');
+                    this._outputChannel.appendLine('[Vue UI] Run preview requested', 'verbose');
                     vscode.commands.executeCommand('calcpad.runPreview');
                     break;
 
                 case 'prettifyDocument':
-                    this._outputChannel.appendLine('[Vue UI] Prettify document requested');
+                    this._outputChannel.appendLine('[Vue UI] Prettify document requested', 'verbose');
                     vscode.commands.executeCommand('vscode-calcpad.prettifyDocument');
                     break;
 
@@ -388,7 +389,7 @@ export class CalcpadVueUIProvider implements vscode.WebviewViewProvider {
                     break;
 
                 case 'debug':
-                    this._outputChannel.appendLine(`[Vue Debug] ${data.message}`);
+                    this._outputChannel.appendLine(`[Vue Debug] ${data.message}`, 'verbose');
                     break;
             }
         });
@@ -437,13 +438,13 @@ export class CalcpadVueUIProvider implements vscode.WebviewViewProvider {
             try {
                 await this._insertManager.loadSnippets();
             } catch (error) {
-                this._outputChannel.appendLine('[Vue UI] Failed to load snippets: ' + error);
+                this._outputChannel.appendLine('[Vue UI] Failed to load snippets: ' + error, 'warning');
             }
         }
 
         // Send insert items as flat array
         const insertItems = this._insertManager.getAllItems();
-        this._outputChannel.appendLine('Sending ' + insertItems.length + ' insert items');
+        this._outputChannel.appendLine('Sending ' + insertItems.length + ' insert items', 'verbose');
         this._view.webview.postMessage({
             type: 'insertDataResponse',
             items: insertItems
@@ -472,7 +473,7 @@ export class CalcpadVueUIProvider implements vscode.WebviewViewProvider {
             enablePreviewUiOverrides: sm.getExtraBool('previewUiOverrides', false),
             darkBackground: sm.getExtra('darkBackground', '#1e1e1e'),
             linterMinSeverity: sm.getExtra('linterMinSeverity', 'information'),
-            serverLogLevel: coerceServerLogLevel(sm.getExtra('serverLogLevel', 'warning')),
+            logLevel: coerceLogLevel(sm.getExtra('logLevel', 'warning')),
             writeMode: sm.getWriteMode(),
             maxPreviewSizeMB: sm.getExtraNumber('maxPreviewSizeMB', DEFAULT_PREVIEW_SIZE_MB),
             maxPreviewConsoleMessages: sm.getExtraNumber(
@@ -569,7 +570,7 @@ export class CalcpadVueUIProvider implements vscode.WebviewViewProvider {
 
     public updateVariables(data: { macros: any[], variables: any[], functions: any[], customUnits: any[] }) {
         if (this._view) {
-            this._outputChannel.appendLine(`Updating variables: ${data.macros.length} macros, ${data.variables.length} variables, ${data.functions.length} functions, ${data.customUnits.length} custom units`);
+            this._outputChannel.appendLine(`Updating variables: ${data.macros.length} macros, ${data.variables.length} variables, ${data.functions.length} functions, ${data.customUnits.length} custom units`, 'verbose');
             this._view.webview.postMessage({
                 type: 'updateVariables',
                 data: data
@@ -763,8 +764,8 @@ export class CalcpadVueUIProvider implements vscode.WebviewViewProvider {
         const scriptUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'out', 'CalcpadVuePanel', 'main.js'));
         const styleUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'out', 'CalcpadVuePanel', 'main.css'));
 
-        this._outputChannel.appendLine(`Script URI: ${scriptUri.toString()}`);
-        this._outputChannel.appendLine(`Style URI: ${styleUri.toString()}`);
+        this._outputChannel.appendLine(`Script URI: ${scriptUri.toString()}`, 'verbose');
+        this._outputChannel.appendLine(`Style URI: ${styleUri.toString()}`, 'verbose');
 
         // Use a nonce to only allow a specific script to be run.
         const nonce = getNonce();

--- a/Calcpad.Web/frontend/vscode-calcpad/src/calcpadVueUIProvider.ts
+++ b/Calcpad.Web/frontend/vscode-calcpad/src/calcpadVueUIProvider.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as crypto from 'crypto';
-import { parseHeadings, DEFAULT_PDF_SETTINGS, extractPlotsFromHtml, buildZip, serializeMetadataComment, serializeSettingsDirective, hasMetadataContent, computeMetadataBlock, buildDefinitionResolver, findUiDirectiveBlock, serializeUiDirective, DEFAULT_PREVIEW_SIZE_MB, DEFAULT_CONSOLE_MESSAGES_PER_DOCUMENT, coerceWriteMode } from 'calcpad-frontend';
+import { parseHeadings, DEFAULT_PDF_SETTINGS, extractPlotsFromHtml, buildZip, serializeMetadataComment, serializeSettingsDirective, hasMetadataContent, computeMetadataBlock, buildDefinitionResolver, findUiDirectiveBlock, serializeUiDirective, DEFAULT_PREVIEW_SIZE_MB, DEFAULT_CONSOLE_MESSAGES_PER_DOCUMENT, coerceWriteMode, coerceServerLogLevel } from 'calcpad-frontend';
 import type { CalcpadError, ExtractedPlot, MetadataCommentBlock, MetadataCommentData, MetadataLayout, DefinitionResolver, DefinitionsResponse, SettingsValues, UiDirectiveData, UiControl } from 'calcpad-frontend';
 import { CalcpadSettingsManager } from './calcpadSettings';
 import { CalcpadInsertManager } from './calcpadInsertManager';
@@ -24,6 +24,7 @@ export class CalcpadVueUIProvider implements vscode.WebviewViewProvider {
     public getSourceEditor?: () => vscode.TextEditor | undefined;
     public onPreviewThemeChanged?: () => void | Promise<void>;
     public onSettingsChanged?: () => void | Promise<void>;
+    public onServerLogLevelChanged?: (level: string) => void;
     /** Real highlighter definitions for a document URI, used to resolve metadata context. */
     public getDefinitions?: (documentUri: string) => DefinitionsResponse | undefined;
     /**
@@ -175,6 +176,11 @@ export class CalcpadVueUIProvider implements vscode.WebviewViewProvider {
 
                 case 'updateLinterMinSeverity':
                     this._settingsManager.setExtra('linterMinSeverity', data.severity);
+                    break;
+
+                case 'updateServerLogLevel':
+                    this._settingsManager.setExtra('serverLogLevel', data.level);
+                    this.onServerLogLevelChanged?.(data.level);
                     break;
 
                 case 'updateWriteMode':
@@ -466,6 +472,7 @@ export class CalcpadVueUIProvider implements vscode.WebviewViewProvider {
             enablePreviewUiOverrides: sm.getExtraBool('previewUiOverrides', false),
             darkBackground: sm.getExtra('darkBackground', '#1e1e1e'),
             linterMinSeverity: sm.getExtra('linterMinSeverity', 'information'),
+            serverLogLevel: coerceServerLogLevel(sm.getExtra('serverLogLevel', 'warning')),
             writeMode: sm.getWriteMode(),
             maxPreviewSizeMB: sm.getExtraNumber('maxPreviewSizeMB', DEFAULT_PREVIEW_SIZE_MB),
             maxPreviewConsoleMessages: sm.getExtraNumber(

--- a/Calcpad.Web/frontend/vscode-calcpad/src/commentFormatter.ts
+++ b/Calcpad.Web/frontend/vscode-calcpad/src/commentFormatter.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import type { ILogger } from 'calcpad-frontend';
 import { CalcpadSettingsManager } from './calcpadSettings';
 import {
     HTML_INLINE,
@@ -19,9 +20,9 @@ type CommentFormatSetting = 'html' | 'markdown' | 'auto';
  * Supports HTML and Markdown modes via the calcpad.commentFormat setting.
  */
 export class CommentFormatter {
-    private outputChannel: vscode.OutputChannel;
+    private outputChannel: ILogger;
 
-    constructor(outputChannel: vscode.OutputChannel) {
+    constructor(outputChannel: ILogger) {
         this.outputChannel = outputChannel;
     }
 

--- a/Calcpad.Web/frontend/vscode-calcpad/src/dotnetRuntimeManager.ts
+++ b/Calcpad.Web/frontend/vscode-calcpad/src/dotnetRuntimeManager.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import type { ILogger } from 'calcpad-frontend';
 import * as path from 'path';
 import * as fs from 'fs';
 import { execFile, execSync } from 'child_process';
@@ -49,9 +50,9 @@ function getPlatformRuntimeInfo(): PlatformRuntimeInfo | null {
 }
 
 export class DotnetRuntimeManager {
-    private outputChannel: vscode.OutputChannel;
+    private outputChannel: ILogger;
 
-    constructor(outputChannel: vscode.OutputChannel) {
+    constructor(outputChannel: ILogger) {
         this.outputChannel = outputChannel;
     }
 

--- a/Calcpad.Web/frontend/vscode-calcpad/src/extension.ts
+++ b/Calcpad.Web/frontend/vscode-calcpad/src/extension.ts
@@ -1797,6 +1797,7 @@ export async function activate(context: vscode.ExtensionContext) {
                         settingsManager.setLocalServerUrl(serverUrl);
                         apiClient.setBaseUrl(serverUrl);
                         apiClient.setAuthToken(serverManager!.getAuthToken());
+                        void apiClient.setServerLogLevel(settingsManager.getExtra('serverLogLevel', 'warning'));
                         outputChannel.appendLine(`Local server started at ${serverUrl}`);
                         void refreshAllComponents();
                     }).catch((err) => {
@@ -2070,6 +2071,9 @@ export async function activate(context: vscode.ExtensionContext) {
         const editor = vscode.window.activeTextEditor ?? previewSourceEditor;
         if (!editor) return;
         await refreshPreviewPanels(editor.document);
+    };
+    vueUiProvider.onServerLogLevelChanged = (level: string) => {
+        void sharedApiClient?.setServerLogLevel(level);
     };
     // Rendered on demand rather than served from the cache: this is what the Properties
     // tab asks when it has no answer or wants a fresh one, and the cache is only as new
@@ -2356,6 +2360,7 @@ export async function activate(context: vscode.ExtensionContext) {
             settingsManager.setLocalServerUrl(serverUrl);
             apiClient.setBaseUrl(serverUrl);
             apiClient.setAuthToken(serverManager.getAuthToken());
+            void apiClient.setServerLogLevel(settingsManager.getExtra('serverLogLevel', 'warning'));
             outputChannel.appendLine(`${tag} Server restarted at ${serverUrl}`);
             return true;
         } catch (err) {

--- a/Calcpad.Web/frontend/vscode-calcpad/src/extension.ts
+++ b/Calcpad.Web/frontend/vscode-calcpad/src/extension.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as os from 'os';
-import { pdfResponseError, isBrowserNotFound, installPdfBrowser, CalcpadApiClient, combineSignals, resolveEffectivePdfSettings, pdfSettingsFromDocument, parseConvertErrorHeader, findMetadataCommentBlock, serializeMetadataComment, computeMetadataBlock, buildDefinitionResolver, extractBodyHtml, UiOverrideStore, writeUiOverrides, extractUiControls, variantRender, inlineImageSources, createReferenceResolver, isCompiledPath, documentHasUiDirectives, COMPILED_EXTENSION, MAX_COMPILED_IMAGE_TOTAL_BYTES, DEFAULT_PREVIEW_SIZE_MB, DEFAULT_CONSOLE_MESSAGES_PER_DOCUMENT, MAX_HTML_MIRROR_CHARS, MAX_INLINE_IMAGE_TOTAL_BYTES, previewSizeLimitChars, previewLimitNoticeHtml, formatSize, truncateForOutput, consoleRelayGuardScript } from 'calcpad-frontend';
+import { pdfResponseError, isBrowserNotFound, installPdfBrowser, CalcpadApiClient, combineSignals, resolveEffectivePdfSettings, pdfSettingsFromDocument, parseConvertErrorHeader, findMetadataCommentBlock, serializeMetadataComment, computeMetadataBlock, buildDefinitionResolver, extractBodyHtml, UiOverrideStore, writeUiOverrides, extractUiControls, variantRender, inlineImageSources, createReferenceResolver, isCompiledPath, documentHasUiDirectives, COMPILED_EXTENSION, MAX_COMPILED_IMAGE_TOTAL_BYTES, DEFAULT_PREVIEW_SIZE_MB, DEFAULT_CONSOLE_MESSAGES_PER_DOCUMENT, MAX_HTML_MIRROR_CHARS, MAX_INLINE_IMAGE_TOTAL_BYTES, previewSizeLimitChars, previewLimitNoticeHtml, formatSize, truncateForOutput, consoleRelayGuardScript, coerceLogLevel, setLogLevel, getLogLevel, ConnectionMonitor } from 'calcpad-frontend';
 import type { PdfSettings as FrontendPdfSettings, ExportVariant, UiControl, UiOverrides, CalcpadError } from 'calcpad-frontend';
 import { CalcpadServerLinter } from './calcpadServerLinter';
 import { CalcpadSemanticTokensProvider, semanticTokensLegend } from './calcpadSemanticTokensProvider';
@@ -213,7 +213,7 @@ async function maybeAutoEnterInputMode(document: vscode.TextDocument): Promise<v
     if (!CalcpadSettingsManager.getInstance(extensionContext).getExtraBool('autoInputMode', true)) return;
     if (!documentHasUiDirectives(document.getText())) return;
 
-    outputChannel.appendLine(`[UI] Input mode opened for ${document.uri.fsPath} (#UI document)`);
+    outputChannel.appendLine(`[UI] Input mode opened for ${document.uri.fsPath} (#UI document)`, 'verbose');
     await showPreview('ui', undefined, true);
 }
 
@@ -228,13 +228,55 @@ async function refreshPreviewPanels(document: vscode.TextDocument): Promise<void
 let linter: CalcpadServerLinter;
 let definitionsService: CalcpadDefinitionsService;
 let serverManager: CalcpadServerManager | undefined;
-let outputChannel: vscode.OutputChannel;
+let outputChannel: VSCodeLogger;
 let calcpadOutputHtmlChannel: vscode.OutputChannel;
 let calcpadWebviewConsoleChannel: vscode.OutputChannel;
 let extensionContext: vscode.ExtensionContext;
 let vueUiProvider: CalcpadVueUIProvider | undefined;
 // Set in activate(); the module-level export commands need it outside that scope.
 let sharedApiClient: CalcpadApiClient | undefined;
+
+const NO_SERVER_MESSAGE = 'No CalcpadCE server available — the bundled server did not start '
+    + 'and no remote server URL is configured.';
+
+/** Settles once the server URL is known to be either available or unobtainable. */
+let settleServerUrl: (() => void) | undefined;
+const serverUrlSettled = new Promise<void>((resolve) => { settleServerUrl = resolve; });
+
+/**
+ * The effective server URL, waiting out a local server that is still starting. Empty only when
+ * there is genuinely nothing to talk to — no bundled server and no remote URL configured.
+ *
+ * `activate()` deliberately does not block on the server: resolving .NET and binding a port take
+ * seconds, and the resolver may prompt. Until then `getServerUrl()` is empty, so anything that
+ * rendered in that window — a restored `.cpdz` editor, a preview opened straight away — failed
+ * with "Server URL not configured", which reads like a misconfiguration rather than a server
+ * that has simply not finished starting.
+ */
+async function resolveServerUrl(timeoutMs: number = 30_000): Promise<string> {
+    const settingsManager = CalcpadSettingsManager.getInstance(extensionContext);
+    const url = settingsManager.getServerUrl();
+    if (url) return url;
+    // The timeout is a backstop for a path that settles neither way; every failure branch in
+    // activate() settles, so a server that cannot start does not hold a render for the full wait.
+    let timer: NodeJS.Timeout | undefined;
+    await Promise.race([
+        serverUrlSettled,
+        new Promise<void>((resolve) => { timer = setTimeout(resolve, timeoutMs); }),
+    ]);
+    if (timer) clearTimeout(timer);
+    return settingsManager.getServerUrl();
+}
+
+/**
+ * Applies the level to this extension host's own channels and to the server, which keeps its own
+ * copy. Called on activation and whenever the setting changes, so both sides stay in step.
+ */
+function applyLogLevel(raw: string | undefined | null): void {
+    const level = coerceLogLevel(raw);
+    setLogLevel(level);
+    void sharedApiClient?.setServerLogLevel(level);
+}
 
 /**
  * Auth headers for the handful of requests that bypass the shared client and
@@ -392,7 +434,7 @@ async function buildImageCache(
             const mimeType = IMAGE_MIME_MAP[ext];
 
             if (!mimeType) {
-                outputChannel.appendLine(`[IMAGE CACHE] Skipping unsupported image type: ${src}`);
+                outputChannel.appendLine(`[IMAGE CACHE] Skipping unsupported image type: ${src}`, 'warning');
                 continue;
             }
 
@@ -402,15 +444,15 @@ async function buildImageCache(
             cache[src] = `data:${mimeType};base64,${b64}`;
             inlined += imageData.length;
 
-            outputChannel.appendLine(`[IMAGE CACHE] Cached: ${src} (${imageData.length} bytes)`);
+            outputChannel.appendLine(`[IMAGE CACHE] Cached: ${src} (${imageData.length} bytes)`, 'verbose');
         } catch (error) {
-            outputChannel.appendLine(`[IMAGE CACHE] Could not read image: ${src} (${error instanceof Error ? error.message : 'Unknown error'})`);
+            outputChannel.appendLine(`[IMAGE CACHE] Could not read image: ${src} (${error instanceof Error ? error.message : 'Unknown error'})`, 'warning');
         }
     }
 
     if (skipped) {
         outputChannel.appendLine(
-            `[IMAGE CACHE] Budget of ${formatSize(maxTotalBytes ?? 0)} reached — ${skipped} image(s) left unembedded`);
+            `[IMAGE CACHE] Budget of ${formatSize(maxTotalBytes ?? 0)} reached — ${skipped} image(s) left unembedded`, 'warning');
     }
 
     return cache;
@@ -769,8 +811,8 @@ async function updatePreviewContent(panel: vscode.WebviewPanel, content: string,
     if (enableUi && !standalone) uiPanelDocKey = docKey;
 
     const mode = enableUi ? 'ui' : forPrint ? 'report' : unwrapped ? 'unwrapped' : 'wrapped';
-    outputChannel.appendLine(`Starting updatePreviewContent (${mode})...`);
-    outputChannel.appendLine(`Content length: ${content.length} characters`);
+    outputChannel.appendLine(`Starting updatePreviewContent (${mode})...`, 'verbose');
+    outputChannel.appendLine(`Content length: ${content.length} characters`, 'verbose');
 
     // Update panel title with current file name
     const activeEditor = standalone ? undefined : (vscode.window.activeTextEditor ?? previewSourceEditor);
@@ -784,7 +826,7 @@ async function updatePreviewContent(panel: vscode.WebviewPanel, content: string,
 
     // Check if content is empty
     if (!content || content.trim().length === 0) {
-        outputChannel.appendLine('Content is empty - showing empty state');
+        outputChannel.appendLine('Content is empty - showing empty state', 'verbose');
         const emptyTheme = getEffectivePreviewTheme();
         const c = emptyTheme === 'light'
             ? { fg: '#6e6e6e', bg: '#ffffff', link: '#0066cc' }
@@ -837,21 +879,17 @@ async function updatePreviewContent(panel: vscode.WebviewPanel, content: string,
 
     const endPreviewLoading = showPreviewLoading(panel);
     try {
-        outputChannel.appendLine('Getting settings...');
+        outputChannel.appendLine('Getting settings...', 'verbose');
         const settingsManager = CalcpadSettingsManager.getInstance(extensionContext);
 
         const settings = await settingsManager.getApiSettings();
-        const apiBaseUrl = settingsManager.getServerUrl();
+        const apiBaseUrl = await resolveServerUrl();
 
-        if (!apiBaseUrl) {
-            outputChannel.appendLine('ERROR: Server URL not configured');
-            throw new Error('Server URL not configured');
-        }
-        outputChannel.appendLine(`Server URL: ${apiBaseUrl}`);
-        outputChannel.appendLine(`Settings retrieved: ${JSON.stringify(settings)}`);
+        if (!apiBaseUrl) throw new Error(NO_SERVER_MESSAGE);
+        outputChannel.appendLine(`Server URL: ${apiBaseUrl}`, 'verbose');
 
         const endpoint = unwrapped ? '/api/calcpad/convert?unwrap=true' : '/api/calcpad/convert';
-        outputChannel.appendLine(`Making API call to ${endpoint}...`);
+        outputChannel.appendLine(`Making API call to ${endpoint}...`, 'verbose');
 
         const theme = getEffectivePreviewTheme();
         const requestBody = JSON.stringify({
@@ -899,7 +937,7 @@ async function updatePreviewContent(panel: vscode.WebviewPanel, content: string,
         if (!response.ok) {
             throw new Error(`Server returned ${response.status}`);
         }
-        outputChannel.appendLine('API call successful');
+        outputChannel.appendLine('API call successful', 'verbose');
 
         vueUiProvider?.updateConvertErrors(parseConvertErrorHeader(response));
 
@@ -915,7 +953,7 @@ async function updatePreviewContent(panel: vscode.WebviewPanel, content: string,
                 .getExtraNumber('maxPreviewSizeMB', DEFAULT_PREVIEW_SIZE_MB));
         if (apiResponse.length > sizeLimit) {
             outputChannel.appendLine(
-                `Preview blocked: render is ${formatSize(apiResponse.length)}, limit is ${formatSize(sizeLimit)}`);
+                `Preview blocked: render is ${formatSize(apiResponse.length)}, limit is ${formatSize(sizeLimit)}`, 'warning');
             const notice = previewLimitNoticeHtml({
                 chars: apiResponse.length,
                 limitChars: sizeLimit,
@@ -941,7 +979,7 @@ async function updatePreviewContent(panel: vscode.WebviewPanel, content: string,
         calcpadOutputHtmlChannel.clear();
         calcpadOutputHtmlChannel.appendLine(truncateForOutput(extractBodyHtml(apiResponse), MAX_HTML_MIRROR_CHARS));
 
-        outputChannel.appendLine(`HTML Length: ${apiResponse.length} characters`);
+        outputChannel.appendLine(`HTML Length: ${apiResponse.length} characters`, 'verbose');
 
         // Build image cache: read local image files and convert to base64 data URIs.
         // An untitled document has no folder to join a relative src against, but Core
@@ -998,10 +1036,10 @@ async function updatePreviewContent(panel: vscode.WebviewPanel, content: string,
         // to an opaque origin inside the shell, which holds the only handle to VS Code.
         renderIntoShell(panel, frameHtml, { background: previewBackground() });
 
-        outputChannel.appendLine('Preview document pushed to the shell (sandboxed frame)');
+        outputChannel.appendLine('Preview document pushed to the shell (sandboxed frame)', 'verbose');
 
     } catch (error) {
-        outputChannel.appendLine(`ERROR in updatePreviewContent: ${error instanceof Error ? error.message : 'Unknown error'}`);
+        outputChannel.appendLine(`ERROR in updatePreviewContent: ${error instanceof Error ? error.message : 'Unknown error'}`, 'error');
         const settingsManager = CalcpadSettingsManager.getInstance(extensionContext);
         const errorApiBaseUrl = settingsManager.getServerUrl();
         const endpoint = unwrapped ? 'convert?unwrap=true' : 'convert';
@@ -1047,8 +1085,8 @@ async function renderForExport(
     forceWrite = false,
 ): Promise<{ html: string; errors: CalcpadError[] }> {
     const settingsManager = CalcpadSettingsManager.getInstance(extensionContext);
-    const apiBaseUrl = settingsManager.getServerUrl();
-    if (!apiBaseUrl) throw new Error('Server URL not configured');
+    const apiBaseUrl = await resolveServerUrl();
+    if (!apiBaseUrl) throw new Error(NO_SERVER_MESSAGE);
 
     if (!documentContent || documentContent.trim().length === 0) {
         throw new Error('Document is empty. Please add some CalcpadCE content first.');
@@ -1095,9 +1133,8 @@ async function generatePdfToFile(
     variant: ExportVariant = 'report',
     progress?: vscode.Progress<{ increment?: number; message?: string }>
 ): Promise<void> {
-    const settingsManager = CalcpadSettingsManager.getInstance(extensionContext);
-    const apiBaseUrl = settingsManager.getServerUrl();
-    if (!apiBaseUrl) throw new Error('Server URL not configured');
+    const apiBaseUrl = await resolveServerUrl();
+    if (!apiBaseUrl) throw new Error(NO_SERVER_MESSAGE);
 
     progress?.report({ increment: 20, message: 'Converting to HTML...' });
 
@@ -1194,7 +1231,7 @@ async function runPdfExportCommand(variant: ExportVariant = 'report'): Promise<v
             return;
         } catch (error) {
             const msg = error instanceof Error ? error.message : String(error);
-            outputChannel.appendLine(`[PDF] ${msg}`);
+            outputChannel.appendLine(`[PDF] ${msg}`, 'warning');
 
             if (attempt === 0 && isBrowserNotFound(error) && await offerChromiumDownload(error.downloadSizeMb)) {
                 continue;
@@ -1228,14 +1265,13 @@ async function offerChromiumDownload(downloadSizeMb: number): Promise<boolean> {
     );
 
     if (choice === undefined) {
-        outputChannel.appendLine(`[PDF] Export cancelled — no browser available. ${advice}`);
+        outputChannel.appendLine(`[PDF] Export cancelled — no browser available. ${advice}`, 'warning');
         return false;
     }
 
-    const settingsManager = CalcpadSettingsManager.getInstance(extensionContext);
-    const apiBaseUrl = settingsManager.getServerUrl();
+    const apiBaseUrl = await resolveServerUrl();
     if (!apiBaseUrl) {
-        vscode.window.showErrorMessage('Server URL not configured');
+        vscode.window.showErrorMessage(NO_SERVER_MESSAGE);
         return false;
     }
 
@@ -1245,11 +1281,11 @@ async function offerChromiumDownload(downloadSizeMb: number): Promise<boolean> {
             title: 'Downloading headless Chromium (one time)...',
             cancellable: false
         }, () => installPdfBrowser(apiBaseUrl, apiAuthHeaders()));
-        outputChannel.appendLine(`[PDF] Chromium installed: ${installedPath}`);
+        outputChannel.appendLine(`[PDF] Chromium installed: ${installedPath}`, 'information');
         return true;
     } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
-        outputChannel.appendLine(`[PDF] Chromium download failed: ${msg}`);
+        outputChannel.appendLine(`[PDF] Chromium download failed: ${msg}`, 'warning');
         vscode.window.showErrorMessage(`Chromium download failed: ${msg}. ${advice}`);
         return false;
     }
@@ -1284,7 +1320,7 @@ async function writeDataFiles() {
             vscode.window.showWarningMessage(message);
     } catch (error) {
         const msg = error instanceof Error ? error.message : 'Unknown error';
-        outputChannel.appendLine(`ERROR in writeDataFiles: ${msg}`);
+        outputChannel.appendLine(`ERROR in writeDataFiles: ${msg}`, 'error');
         vueUiProvider?.writeFilesResult(false, `Failed to write the document's output: ${msg}`);
         vscode.window.showErrorMessage(`Failed to write the document's output: ${msg}`);
     }
@@ -1326,7 +1362,7 @@ async function saveSourceHtml(variant: ExportVariant = 'report') {
         }
     } catch (error) {
         const msg = error instanceof Error ? error.message : 'Unknown error';
-        outputChannel.appendLine(`ERROR in saveSourceHtml: ${msg}`);
+        outputChannel.appendLine(`ERROR in saveSourceHtml: ${msg}`, 'error');
         vscode.window.showErrorMessage(`Failed to save HTML: ${msg}`);
     }
 }
@@ -1346,9 +1382,9 @@ async function saveDocx(variant: ExportVariant = 'report') {
         return;
     }
     try {
-        const apiBaseUrl = settingsManager.getServerUrl();
+        const apiBaseUrl = await resolveServerUrl();
         if (!apiBaseUrl) {
-            vscode.window.showErrorMessage('Server URL not configured');
+            vscode.window.showErrorMessage(NO_SERVER_MESSAGE);
             return;
         }
 
@@ -1385,7 +1421,7 @@ async function saveDocx(variant: ExportVariant = 'report') {
         }
     } catch (error) {
         const msg = error instanceof Error ? error.message : 'Unknown error';
-        outputChannel.appendLine(`ERROR in saveDocx: ${msg}`);
+        outputChannel.appendLine(`ERROR in saveDocx: ${msg}`, 'error');
         vscode.window.showErrorMessage(`Failed to save Word document: ${msg}`);
     }
 }
@@ -1442,7 +1478,7 @@ async function saveAsCompiled() {
         vscode.window.showInformationMessage(`Compiled worksheet saved to ${saveUri.fsPath}`);
     } catch (error) {
         const msg = error instanceof Error ? error.message : 'Unknown error';
-        outputChannel.appendLine(`ERROR in saveAsCompiled: ${msg}`);
+        outputChannel.appendLine(`ERROR in saveAsCompiled: ${msg}`, 'error');
         vscode.window.showErrorMessage(`Failed to save compiled worksheet: ${msg}`);
     }
 }
@@ -1481,7 +1517,7 @@ async function exportPortable() {
             const reasons = packaged?.errors ?? ['The server is not running'];
             // A collision or a list of unreadable references runs to several lines, which a
             // notification swallows: the first goes in the toast, the rest to the log.
-            outputChannel.appendLine(`ERROR in exportPortable:\n${reasons.join('\n')}`);
+            outputChannel.appendLine(`ERROR in exportPortable:\n${reasons.join('\n')}`, 'error');
             const choice = await vscode.window.showErrorMessage(
                 `Cannot package this worksheet: ${reasons[0]}`,
                 'Show Details');
@@ -1494,7 +1530,7 @@ async function exportPortable() {
             `Portable package saved to ${saveUri.fsPath} — ${packaged.bundled.length} reference(s) bundled`);
     } catch (error) {
         const msg = error instanceof Error ? error.message : 'Unknown error';
-        outputChannel.appendLine(`ERROR in exportPortable: ${msg}`);
+        outputChannel.appendLine(`ERROR in exportPortable: ${msg}`, 'error');
         vscode.window.showErrorMessage(`Failed to export the portable package: ${msg}`);
     }
 }
@@ -1509,7 +1545,7 @@ function documentHasMacros(text: string): boolean {
 // Jump the source editor to a 1-based line.
 function navigateEditorToLine(sourceEditor: vscode.TextEditor, line: number) {
     const lineIndex = Math.max(0, line - 1);
-    outputChannel.appendLine(`Navigating to source line ${line}`);
+    outputChannel.appendLine(`Navigating to source line ${line}`, 'verbose');
     const position = new vscode.Position(lineIndex, 0);
     const selection = new vscode.Selection(position, position);
     sourceEditor.selection = selection;
@@ -1718,35 +1754,77 @@ export async function activate(context: vscode.ExtensionContext) {
         extensionContext = context;
         
         // Create output channel for debugging
-        outputChannel = vscode.window.createOutputChannel('CalcpadCE Extension');
-        outputChannel.appendLine('CalcPad extension activated');
+        outputChannel = new VSCodeLogger(vscode.window.createOutputChannel('CalcpadCE Extension'));
 
         // Create dedicated output channels for HTML
         calcpadOutputHtmlChannel = vscode.window.createOutputChannel('CalcpadCE Output HTML');
         calcpadWebviewConsoleChannel = vscode.window.createOutputChannel('CalcpadCE Webview Console');
 
         // Create debug channel for linter/highlighter
-        const serverDebugChannel = vscode.window.createOutputChannel('CalcpadCE Server Debug');
+        const serverDebugChannel = new VSCodeLogger(vscode.window.createOutputChannel('CalcpadCE Server Debug'));
 
-        outputChannel.appendLine('Initializing settings manager...');
         const settingsManager = CalcpadSettingsManager.getInstance(context);
+        // Before the first line is written, so every channel honours the stored level from the
+        // start. sharedApiClient is still unset; the server gets its copy in applyServerUrl below.
+        setLogLevel(coerceLogLevel(settingsManager.getExtra('logLevel')));
+        outputChannel.appendLine('CalcPad extension activated', 'information');
 
         // Create shared API client (uses remote URL initially, switches to local when server starts)
-        const apiClient = new CalcpadApiClient(
-            settingsManager.getServerUrl(),
-            new VSCodeLogger(serverDebugChannel)
-        );
+        const apiClient = new CalcpadApiClient(settingsManager.getServerUrl(), serverDebugChannel);
         sharedApiClient = apiClient;
+
+        // Continuous liveness, surfaced as the coloured dot in the CalcpadCE view title. The
+        // server manager pushes lifecycle transitions in; the poll is the backstop for what it
+        // cannot see — a wedged server, or one another window restarted underneath us.
+        const connectionMonitor = new ConnectionMonitor({
+            probe: (timeoutMs) => apiClient.checkHealth(timeoutMs),
+            onStatusChanged: (status) => {
+                void vscode.commands.executeCommand('setContext', 'calcpad.serverStatus', status);
+            },
+            onRecovered: () => { void refreshAllComponents(); },
+            log: (message) => serverDebugChannel.appendLine(`[Server] ${message}`, 'information'),
+        });
+        void vscode.commands.executeCommand('setContext', 'calcpad.serverStatus', 'connecting');
+        context.subscriptions.push({ dispose: () => connectionMonitor.stop() });
+        // Extension-host timers are throttled while the window is in the background, so the
+        // last poll can be well stale by the time the user looks at the dot again.
+        context.subscriptions.push(vscode.window.onDidChangeWindowState((e) => {
+            if (e.focused) connectionMonitor.probeSoon();
+        }));
+
+        /** Nothing local will report to us: poll whatever remote URL is configured, if any. */
+        const monitorRemoteOnly = (reason: string) => {
+            // Whether or not a remote URL is configured, this is the final answer for this
+            // window, so anything waiting on a URL can stop waiting.
+            settleServerUrl?.();
+            if (settingsManager.getServerUrl()) connectionMonitor.start();
+            else connectionMonitor.markStopped(reason);
+        };
+
+        // Point every consumer at the server the manager just brought up. Raised on a fresh
+        // start, on adopting another window's server, and after an auto-restart — which picks a
+        // new port, so skipping it would leave the client addressing a dead one.
+        const applyServerUrl = (serverUrl: string) => {
+            settingsManager.setLocalServerUrl(serverUrl);
+            settleServerUrl?.();
+            apiClient.setBaseUrl(serverUrl);
+            apiClient.setAuthToken(serverManager?.getAuthToken() ?? null);
+            // The server may have started before us, or restarted since, so it does not
+            // necessarily hold the level the user chose. Re-pushing here is idempotent.
+            void apiClient.setServerLogLevel(getLogLevel());
+            // No probe kicked off here: the manager raises 'running' right after this, and
+            // that is what promotes the dot to green.
+        };
 
         // Start bundled server if available
         const serverMode = settingsManager.getSettings().server.mode || 'auto';
-        outputChannel.appendLine(`Server mode: ${serverMode}`);
+        outputChannel.appendLine(`Server mode: ${serverMode}`, 'verbose');
 
         if (serverMode === 'auto' || serverMode === 'local') {
             const dllExists = CalcpadServerManager.dllExists(context.extensionPath);
             const appHostExists = CalcpadServerManager.appHostExists(context.extensionPath);
-            outputChannel.appendLine(`Bundled DLL exists: ${dllExists}`);
-            outputChannel.appendLine(`Bundled apphost exists: ${appHostExists}`);
+            outputChannel.appendLine(`Bundled DLL exists: ${dllExists}`, 'verbose');
+            outputChannel.appendLine(`Bundled apphost exists: ${appHostExists}`, 'verbose');
 
             if (dllExists) {
                 const configuredDotnetPath = settingsManager.getExtra('dotnetPath', 'dotnet');
@@ -1762,20 +1840,23 @@ export async function activate(context: vscode.ExtensionContext) {
                 dotnetPromise.then((resolvedDotnetPath) => {
                     if (!resolvedDotnetPath) {
                         if (serverMode === 'local') {
-                            outputChannel.appendLine('.NET runtime not available, server cannot start');
+                            outputChannel.appendLine('.NET runtime not available, server cannot start', 'warning');
                         } else {
-                            outputChannel.appendLine('.NET runtime not available, falling back to remote API');
+                            outputChannel.appendLine('.NET runtime not available, falling back to remote API', 'warning');
                         }
+                        monitorRemoteOnly('no .NET runtime');
                         return;
                     }
 
                     if (appHostExists) {
-                        outputChannel.appendLine('Using bundled apphost (self-contained, no system dotnet required)');
+                        outputChannel.appendLine('Using bundled apphost (self-contained, no system dotnet required)', 'verbose');
                     } else {
-                        outputChannel.appendLine(`Using dotnet at: ${resolvedDotnetPath}`);
+                        outputChannel.appendLine(`Using dotnet at: ${resolvedDotnetPath}`, 'verbose');
                     }
                     serverManager = new CalcpadServerManager(context.extensionPath, serverDebugChannel, resolvedDotnetPath, outputChannel);
                     context.subscriptions.push(serverManager);
+                    serverManager.onUrlChanged = applyServerUrl;
+                    serverManager.onStatusChanged = (state, detail) => connectionMonitor.applyLifecycle(state, detail);
 
                     // Notify user when server crashes repeatedly
                     serverManager.onCrashExhausted = (crashOutput: string) => {
@@ -1793,16 +1874,14 @@ export async function activate(context: vscode.ExtensionContext) {
 
                     // Start the server in the background so activation isn't blocked
                     serverManager.start().then(() => {
-                        const serverUrl = serverManager!.getBaseUrl();
-                        settingsManager.setLocalServerUrl(serverUrl);
-                        apiClient.setBaseUrl(serverUrl);
-                        apiClient.setAuthToken(serverManager!.getAuthToken());
-                        void apiClient.setServerLogLevel(settingsManager.getExtra('serverLogLevel', 'warning'));
-                        outputChannel.appendLine(`Local server started at ${serverUrl}`);
+                        outputChannel.appendLine(`Local server started at ${serverManager!.getBaseUrl()}`, 'information');
                         void refreshAllComponents();
                     }).catch((err) => {
                         const message = err instanceof Error ? err.message : String(err);
-                        outputChannel.appendLine(`Failed to start local server: ${message}`);
+                        outputChannel.appendLine(`Failed to start local server: ${message}`, 'warning');
+                        // Not every branch below reaches monitorRemoteOnly, and a render waiting
+                        // on a URL should not sit out its timeout once the answer is known.
+                        settleServerUrl?.();
                         // Keep `serverManager` around when Windows blocked the exe —
                         // the user can unblock the file and click refresh to retry.
                         // Discarding it here would leave refresh with nothing to call.
@@ -1837,29 +1916,37 @@ export async function activate(context: vscode.ExtensionContext) {
                                     if (choice === 'Show Output') serverDebugChannel.show();
                                 });
                             } else {
-                                outputChannel.appendLine(`Falling back to remote API at ${remoteUrl}`);
+                                outputChannel.appendLine(`Falling back to remote API at ${remoteUrl}`, 'information');
+                                // The manager reported 'stopped' on its way out, which suspends
+                                // polling; the remote server is a different one to watch.
+                                monitorRemoteOnly('bundled server failed');
                             }
                         }
                     });
                 }).catch((err) => {
                     const message = err instanceof Error ? err.message : String(err);
-                    outputChannel.appendLine(`Dotnet resolution failed: ${message}`);
+                    outputChannel.appendLine(`Dotnet resolution failed: ${message}`, 'warning');
+                    monitorRemoteOnly('dotnet resolution failed');
                 });
             } else if (serverMode === 'local') {
                 vscode.window.showErrorMessage('CalcpadCE: Server mode is "local" but CalcpadServer.dll was not found in the extension.');
+                monitorRemoteOnly('no bundled server');
             } else {
-                outputChannel.appendLine('No bundled DLL found, using remote API');
+                outputChannel.appendLine('No bundled DLL found, using remote API', 'information');
+                monitorRemoteOnly('no bundled server');
             }
+        } else {
+            monitorRemoteOnly('remote server mode');
         }
 
-        outputChannel.appendLine('Initializing linter...');
+        outputChannel.appendLine('Initializing linter...', 'verbose');
         linter = new CalcpadServerLinter(apiClient, serverDebugChannel);
 
-        outputChannel.appendLine('Initializing definitions service...');
+        outputChannel.appendLine('Initializing definitions service...', 'verbose');
         definitionsService = new CalcpadDefinitionsService(apiClient, serverDebugChannel);
 
         // Initialize semantic token provider
-        outputChannel.appendLine('Initializing semantic token provider...');
+        outputChannel.appendLine('Initializing semantic token provider...', 'verbose');
         const semanticTokensProvider = new CalcpadSemanticTokensProvider(apiClient, serverDebugChannel);
         const semanticTokensDisposable = vscode.languages.registerDocumentSemanticTokensProvider(
             { language: 'calcpad' },
@@ -1868,67 +1955,67 @@ export async function activate(context: vscode.ExtensionContext) {
         );
 
         // Initialize operator replacer
-        outputChannel.appendLine('Initializing operator replacer...');
+        outputChannel.appendLine('Initializing operator replacer...', 'verbose');
         const operatorReplacer = new OperatorReplacer(outputChannel);
         const operatorReplacerDisposable = operatorReplacer.registerDocumentChangeListener(context);
 
         // Initialize auto-indenter
-        outputChannel.appendLine('Initializing auto-indenter...');
+        outputChannel.appendLine('Initializing auto-indenter...', 'verbose');
         const autoIndenter = new AutoIndenter(outputChannel);
         const autoIndenterDisposable = autoIndenter.registerDocumentChangeListener(context);
 
         // Initialize image inserter
-        outputChannel.appendLine('Initializing image inserter...');
+        outputChannel.appendLine('Initializing image inserter...', 'verbose');
         const imageInserter = new ImageInserter(outputChannel);
         const imagePasteDisposable = imageInserter.registerPasteProvider();
         const imageInsertCommandDisposable = imageInserter.registerInsertCommand();
 
         // Initialize comment formatter
-        outputChannel.appendLine('Initializing comment formatter...');
+        outputChannel.appendLine('Initializing comment formatter...', 'verbose');
         const commentFormatter = new CommentFormatter(outputChannel);
         const commentFormatterDisposables = commentFormatter.registerCommands();
 
         // Initialize insert manager (snippet service)
-        outputChannel.appendLine('Initializing insert manager...');
+        outputChannel.appendLine('Initializing insert manager...', 'verbose');
         const insertManager = new CalcpadInsertManager(apiClient, outputChannel);
 
         // Initialize quick typer (uses snippet data for quick type map)
-        outputChannel.appendLine('Initializing quick typer...');
+        outputChannel.appendLine('Initializing quick typer...', 'verbose');
         const quickTyper = new QuickTyper(outputChannel, insertManager);
         const quickTyperDisposable = quickTyper.registerDocumentChangeListener(context);
 
         // Initialize autocomplete provider
-        outputChannel.appendLine('Initializing autocomplete provider...');
+        outputChannel.appendLine('Initializing autocomplete provider...', 'verbose');
         const completionProviderDisposable = CalcpadCompletionProvider.register(definitionsService, insertManager, outputChannel);
 
         // Initialize #include file completion provider
-        outputChannel.appendLine('Initializing include file completion provider...');
+        outputChannel.appendLine('Initializing include file completion provider...', 'verbose');
         const includeCompletionDisposable = CalcpadIncludeCompletionProvider.register(definitionsService, outputChannel);
 
         // Initialize definition provider (Go to Definition)
-        outputChannel.appendLine('Initializing definition provider...');
+        outputChannel.appendLine('Initializing definition provider...', 'verbose');
         const definitionProviderDisposable = CalcpadDefinitionProvider.register(apiClient, definitionsService, outputChannel);
 
         // Initialize #include link provider (always-underlined, clickable paths)
-        outputChannel.appendLine('Initializing include link provider...');
+        outputChannel.appendLine('Initializing include link provider...', 'verbose');
         const includeLinkProviderDisposable = CalcpadIncludeLinkProvider.register(definitionsService, outputChannel);
 
         // Initialize reference provider (Find All References)
-        outputChannel.appendLine('Initializing reference provider...');
+        outputChannel.appendLine('Initializing reference provider...', 'verbose');
         const referenceProviderDisposable = CalcpadReferenceProvider.register(apiClient, outputChannel);
 
         // Initialize rename provider (F2 Rename Symbol)
-        outputChannel.appendLine('Initializing rename provider...');
+        outputChannel.appendLine('Initializing rename provider...', 'verbose');
         const renameProviderDisposable = CalcpadRenameProvider.register(apiClient, outputChannel);
 
         // Initialize hover provider (Hover Tooltips)
-        outputChannel.appendLine('Initializing hover provider...');
+        outputChannel.appendLine('Initializing hover provider...', 'verbose');
         const hoverProviderDisposable = CalcpadHoverProvider.register(definitionsService, insertManager, outputChannel);
 
         // Initialize the compiled worksheet editor (.cpdz opens as an input form, with
         // the report available beside it). Both of its panels are standalone: there is no
         // text editor behind a .cpdz for a preview to be *of*.
-        outputChannel.appendLine('Initializing compiled worksheet editor...');
+        outputChannel.appendLine('Initializing compiled worksheet editor...', 'verbose');
         compiledEditor = CalcpadCompiledEditorProvider.register(
             apiClient,
             uiOverrides,
@@ -1954,19 +2041,19 @@ export async function activate(context: vscode.ExtensionContext) {
     }
 
     async function _doProcessDocument(document: vscode.TextDocument) {
-        outputChannel.appendLine('[processDocument] Processing document: ' + document.uri.fsPath);
+        outputChannel.appendLine('[processDocument] Processing document: ' + document.uri.fsPath, 'verbose');
 
         // Run linting and definitions in parallel
         const [, definitions] = await Promise.all([
             linter.lintDocument(document),
             definitionsService.refreshDefinitions(document).catch((error: unknown) => {
-                outputChannel.appendLine('Error fetching definitions: ' + error);
+                outputChannel.appendLine('Error fetching definitions: ' + error, 'warning');
                 return null;
             }),
         ]);
 
         if (definitions) {
-            outputChannel.appendLine('[processDocument] Found ' + definitions.macros.length + ' macros, ' + definitions.variables.length + ' variables, ' + definitions.functions.length + ' functions, ' + definitions.customUnits.length + ' custom units');
+            outputChannel.appendLine('[processDocument] Found ' + definitions.macros.length + ' macros, ' + definitions.variables.length + ' variables, ' + definitions.functions.length + ' functions, ' + definitions.customUnits.length + ' custom units', 'verbose');
 
             vueUiProvider?.updateVariables({
                 macros: definitions.macros.map(m => ({
@@ -2012,25 +2099,25 @@ export async function activate(context: vscode.ExtensionContext) {
                 }))
             });
         } else {
-            outputChannel.appendLine('[processDocument] No definitions returned from server');
+            outputChannel.appendLine('[processDocument] No definitions returned from server', 'verbose');
         }
     }
 
     // Centralized refresh function for when settings change
     async function refreshAllComponents() {
-        outputChannel.appendLine('[Settings] Refreshing all components after settings change');
+        outputChannel.appendLine('[Settings] Refreshing all components after settings change', 'verbose');
 
         // Use the effective server URL (local if running, remote otherwise)
         const effectiveUrl = settingsManager.getServerUrl();
         apiClient.setBaseUrl(effectiveUrl);
-        outputChannel.appendLine(`[Settings] Using server URL: ${effectiveUrl}`);
+        outputChannel.appendLine(`[Settings] Using server URL: ${effectiveUrl}`, 'verbose');
 
         // Reload snippets from server
         try {
             await insertManager.reloadSnippets();
-            outputChannel.appendLine('[Settings] Snippets reloaded');
+            outputChannel.appendLine('[Settings] Snippets reloaded', 'verbose');
         } catch (error) {
-            outputChannel.appendLine('[Settings] Failed to reload snippets: ' + error);
+            outputChannel.appendLine('[Settings] Failed to reload snippets: ' + error, 'warning');
         }
 
         // Refresh semantic tokens for all visible editors
@@ -2049,10 +2136,10 @@ export async function activate(context: vscode.ExtensionContext) {
         // Refresh preview(s) if open
         if (activeEditor && (wrappedPanel || unwrappedPanel || uiPanel || uiReportPanel)) {
             await refreshPreviewPanels(activeEditor.document);
-            outputChannel.appendLine('[Settings] Preview refreshed');
+            outputChannel.appendLine('[Settings] Preview refreshed', 'verbose');
         }
 
-        outputChannel.appendLine('[Settings] All components refreshed');
+        outputChannel.appendLine('[Settings] All components refreshed', 'information');
     }
 
     vueUiProvider = new CalcpadVueUIProvider(context.extensionUri, context, settingsManager, insertManager);
@@ -2072,8 +2159,8 @@ export async function activate(context: vscode.ExtensionContext) {
         if (!editor) return;
         await refreshPreviewPanels(editor.document);
     };
-    vueUiProvider.onServerLogLevelChanged = (level: string) => {
-        void sharedApiClient?.setServerLogLevel(level);
+    vueUiProvider.onLogLevelChanged = (level: string) => {
+        applyLogLevel(level);
     };
     // Rendered on demand rather than served from the cache: this is what the Properties
     // tab asks when it has no answer or wants a fresh one, and the cache is only as new
@@ -2087,7 +2174,7 @@ export async function activate(context: vscode.ExtensionContext) {
             uiControls.set(editor.document.uri.toString(), controls);
             return controls;
         } catch (e) {
-            outputChannel.appendLine('[UI controls] Render failed: ' + e);
+            outputChannel.appendLine('[UI controls] Render failed: ' + e, 'warning');
             return null;
         }
     };
@@ -2123,10 +2210,10 @@ export async function activate(context: vscode.ExtensionContext) {
             // while the message box asks about its values. Cancel leaves it open.
             if (!await discardUiValues(uiPanelDocKey, true)) return;
             uiPanel.dispose();
-            outputChannel.appendLine('[UI] Input mode disabled');
+            outputChannel.appendLine('[UI] Input mode disabled', 'information');
             return;
         }
-        outputChannel.appendLine('[UI] Input mode enabled');
+        outputChannel.appendLine('[UI] Input mode enabled', 'information');
         await showPreview('ui');
         // Opened after the form and while it holds focus, so Beside puts the
         // report in the column to its right rather than replacing it.
@@ -2325,9 +2412,9 @@ export async function activate(context: vscode.ExtensionContext) {
     void maybePromptInstall(context);
 
     const stopServerCommand = vscode.commands.registerCommand('calcpad.stopServer', async () => {
-        outputChannel.appendLine('[Stop] Manual server stop triggered');
+        outputChannel.appendLine('[Stop] Manual server stop triggered', 'information');
         if (!serverManager) {
-            outputChannel.appendLine('[Stop] No serverManager available');
+            outputChannel.appendLine('[Stop] No serverManager available', 'warning');
             vscode.window.showInformationMessage('CalcpadCE server is not configured.');
             return;
         }
@@ -2337,7 +2424,7 @@ export async function activate(context: vscode.ExtensionContext) {
         const wasRunning = serverManager.isRunning;
         try {
             await serverManager.stop();
-            outputChannel.appendLine(`[Stop] Server stopped successfully (wasRunning=${wasRunning})`);
+            outputChannel.appendLine(`[Stop] Server stopped successfully (wasRunning=${wasRunning})`, 'information');
             vscode.window.showInformationMessage(
                 wasRunning
                     ? 'CalcpadCE server stopped. Use the refresh button to restart.'
@@ -2345,7 +2432,7 @@ export async function activate(context: vscode.ExtensionContext) {
             );
         } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
-            outputChannel.appendLine(`[Stop] Server stop failed: ${msg}`);
+            outputChannel.appendLine(`[Stop] Server stop failed: ${msg}`, 'warning');
             vscode.window.showErrorMessage(`CalcpadCE: Failed to stop server: ${msg}`);
         }
     });
@@ -2356,16 +2443,11 @@ export async function activate(context: vscode.ExtensionContext) {
         if (!serverManager) return true;
         try {
             await serverManager.restart();
-            const serverUrl = serverManager.getBaseUrl();
-            settingsManager.setLocalServerUrl(serverUrl);
-            apiClient.setBaseUrl(serverUrl);
-            apiClient.setAuthToken(serverManager.getAuthToken());
-            void apiClient.setServerLogLevel(settingsManager.getExtra('serverLogLevel', 'warning'));
-            outputChannel.appendLine(`${tag} Server restarted at ${serverUrl}`);
+            outputChannel.appendLine(`${tag} Server restarted at ${serverManager.getBaseUrl()}`, 'information');
             return true;
         } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
-            outputChannel.appendLine(`${tag} Server restart failed: ${msg}`);
+            outputChannel.appendLine(`${tag} Server restart failed: ${msg}`, 'warning');
             if (/Windows blocked the executable|EACCES|EPERM/i.test(msg)) {
                 vscode.window.showErrorMessage(
                     `CalcPad: Windows is still blocking Calcpad.Server.exe.\n${serverManager.getExecutablePath()}\n` +
@@ -2387,31 +2469,41 @@ export async function activate(context: vscode.ExtensionContext) {
         await processDocument(activeEditor.document);
         semanticTokensProvider.refresh();
         schedulePreviewUpdate();
-        outputChannel.appendLine(`${tag} Document re-linted, re-highlighted, and preview re-rendered`);
+        outputChannel.appendLine(`${tag} Document re-linted, re-highlighted, and preview re-rendered`, 'verbose');
     };
 
     const runPreviewCommand = vscode.commands.registerCommand('calcpad.runPreview', async () => {
-        outputChannel.appendLine('[Run] Run preview triggered');
+        outputChannel.appendLine('[Run] Run preview triggered', 'information');
 
         // Only restart when the server is actually down — running should not
         // cost a respawn. Use refresh for an unconditional restart.
         if (serverManager && (!serverManager.isRunning || !(await apiClient.checkHealth()))) {
-            outputChannel.appendLine('[Run] Server unavailable, attempting restart...');
+            outputChannel.appendLine('[Run] Server unavailable, attempting restart...', 'warning');
             if (!await restartServer('[Run]')) return;
         }
 
         await runPreview('[Run]');
     });
 
-    const refreshDocumentCommand = vscode.commands.registerCommand('calcpad.refreshDocument', async () => {
-        outputChannel.appendLine('[Refresh] Manual server restart triggered');
+    const refreshDocument = async (): Promise<void> => {
+        outputChannel.appendLine('[Refresh] Manual server restart triggered', 'information');
         if (!serverManager) {
             vscode.window.showInformationMessage('CalcpadCE server is not configured.');
             return;
         }
         if (!await restartServer('[Refresh]')) return;
         await runPreview('[Refresh]');
-    });
+    };
+
+    // The restart button carries the health dot in its icon, and a menu item cannot recolour its
+    // own, so there is one command per state and the `calcpad.serverStatus` context key picks
+    // which appears. All four restart: only the icon and the tooltip differ.
+    const refreshDocumentCommands = [
+        'calcpad.refreshDocument',
+        'calcpad.refreshDocumentConnected',
+        'calcpad.refreshDocumentConnecting',
+        'calcpad.refreshDocumentDisconnected',
+    ].map(id => vscode.commands.registerCommand(id, refreshDocument));
 
     const prettifyDocumentCommand = vscode.commands.registerCommand('vscode-calcpad.prettifyDocument', async () => {
         const editor = vscode.window.activeTextEditor;
@@ -2446,7 +2538,7 @@ export async function activate(context: vscode.ExtensionContext) {
             }
         } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
-            outputChannel.appendLine('[Prettify] Error: ' + msg);
+            outputChannel.appendLine('[Prettify] Error: ' + msg, 'warning');
             vscode.window.showErrorMessage('CalcpadCE: prettify failed — ' + msg);
         }
     });
@@ -2458,12 +2550,12 @@ export async function activate(context: vscode.ExtensionContext) {
 
     // Process document on open
     const onDidOpenTextDocument = vscode.workspace.onDidOpenTextDocument(document => {
-        processDocument(document).catch(e => outputChannel.appendLine('[processDocument] Error: ' + e));
+        processDocument(document).catch(e => outputChannel.appendLine('[processDocument] Error: ' + e, 'warning'));
     });
 
     // Process document on save
     const onDidSaveTextDocument = vscode.workspace.onDidSaveTextDocument(document => {
-        processDocument(document).catch(e => outputChannel.appendLine('[processDocument] Error: ' + e));
+        processDocument(document).catch(e => outputChannel.appendLine('[processDocument] Error: ' + e, 'warning'));
     });
 
     // Lint on document change (with debouncing)
@@ -2475,7 +2567,7 @@ export async function activate(context: vscode.ExtensionContext) {
             }
             lintTimeout = setTimeout(() => {
                 invalidateUiControls(event.document);
-                processDocument(event.document).catch(e => outputChannel.appendLine('[processDocument] Error: ' + e));
+                processDocument(event.document).catch(e => outputChannel.appendLine('[processDocument] Error: ' + e, 'warning'));
             }, 500);
             // Only schedule preview update when auto-run is on. Otherwise the
             // preview updates only when the panel is (re)opened or the user
@@ -2519,7 +2611,7 @@ export async function activate(context: vscode.ExtensionContext) {
                 schedulePreviewUpdate();
             }
             // Update Variables tab
-            processDocument(editor.document).catch(e => outputChannel.appendLine('[processDocument] Error: ' + e));
+            processDocument(editor.document).catch(e => outputChannel.appendLine('[processDocument] Error: ' + e, 'warning'));
             // Last, and after the cancel path above returns: a switch the user backed out of
             // must not open anything.
             await maybeAutoEnterInputMode(editor.document);
@@ -2548,7 +2640,7 @@ export async function activate(context: vscode.ExtensionContext) {
     const onDidChangeConfiguration = vscode.workspace.onDidChangeConfiguration(async event => {
         // Check if any calcpad settings changed
         if (event.affectsConfiguration('calcpad')) {
-            outputChannel.appendLine('[Settings] Calcpad settings changed - triggering refresh');
+            outputChannel.appendLine('[Settings] Calcpad settings changed - triggering refresh', 'information');
             await refreshAllComponents();
         }
     });
@@ -2565,7 +2657,7 @@ export async function activate(context: vscode.ExtensionContext) {
         if (activeDocument) void maybeAutoEnterInputMode(activeDocument);
     }
 
-        outputChannel.appendLine('Registering subscriptions...');
+        outputChannel.appendLine('Registering subscriptions...', 'verbose');
         context.subscriptions.push(
             disposable,
             previewCommand,
@@ -2587,7 +2679,7 @@ export async function activate(context: vscode.ExtensionContext) {
             compiledEditor,
             refreshVariablesCommand,
             runPreviewCommand,
-            refreshDocumentCommand,
+            ...refreshDocumentCommands,
             stopServerCommand,
             exportToPdfCommand,
             prettifyDocumentCommand,
@@ -2623,12 +2715,12 @@ export async function activate(context: vscode.ExtensionContext) {
             installJuliaMonoDisposable
         );
         
-        outputChannel.appendLine('CalcPad extension activation completed successfully');
+        outputChannel.appendLine('CalcPad extension activation completed successfully', 'information');
         
     } catch (error) {
         console.error('CalcPad extension activation failed:', error);
         if (outputChannel) {
-            outputChannel.appendLine(`FATAL ERROR during activation: ${error}`);
+            outputChannel.appendLine(`FATAL ERROR during activation: ${error}`, 'error');
         }
         // Still try to show the error to user
         vscode.window.showErrorMessage(`CalcpadCE extension failed to activate: ${error instanceof Error ? error.message : 'Unknown error'}`);

--- a/Calcpad.Web/frontend/vscode-calcpad/src/imageInserter.ts
+++ b/Calcpad.Web/frontend/vscode-calcpad/src/imageInserter.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import type { ILogger } from 'calcpad-frontend';
 import * as path from 'path';
 import {
     IMAGE_EXTENSIONS,
@@ -17,9 +18,9 @@ const IMAGE_FILE_FILTERS: Record<string, string[]> = {
  * Images are inserted as Calcpad comment lines with HTML img tags: '<img src="...">
  */
 export class ImageInserter {
-    private outputChannel: vscode.OutputChannel;
+    private outputChannel: ILogger;
 
-    constructor(outputChannel: vscode.OutputChannel) {
+    constructor(outputChannel: ILogger) {
         this.outputChannel = outputChannel;
     }
 
@@ -313,7 +314,7 @@ export class ImageInserter {
 class CalcpadImagePasteProvider implements vscode.DocumentPasteEditProvider {
     constructor(
         private imageInserter: ImageInserter,
-        private outputChannel: vscode.OutputChannel
+        private outputChannel: ILogger
     ) {}
 
     async provideDocumentPasteEdits(

--- a/Calcpad.Web/frontend/vscode-calcpad/src/operatorReplacer.ts
+++ b/Calcpad.Web/frontend/vscode-calcpad/src/operatorReplacer.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import type { ILogger } from 'calcpad-frontend';
 import {
     isOperatorTriggerChar,
     isInsideStringOrComment,
@@ -10,9 +11,9 @@ import {
  * Logic is provided by calcpad-frontend; this class handles VS Code event wiring.
  */
 export class OperatorReplacer {
-    private outputChannel: vscode.OutputChannel;
+    private outputChannel: ILogger;
 
-    constructor(outputChannel: vscode.OutputChannel) {
+    constructor(outputChannel: ILogger) {
         this.outputChannel = outputChannel;
     }
 

--- a/Calcpad.Web/frontend/vscode-calcpad/src/quickTyper.ts
+++ b/Calcpad.Web/frontend/vscode-calcpad/src/quickTyper.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import type { ILogger } from 'calcpad-frontend';
 import { findQuickTypeReplacement } from 'calcpad-frontend';
 import type { CalcpadInsertManager } from './calcpadInsertManager';
 import { CalcpadSettingsManager } from './calcpadSettings';
@@ -8,11 +9,11 @@ import { CalcpadSettingsManager } from './calcpadSettings';
  * The quick type map is built dynamically from server-provided snippet data.
  */
 export class QuickTyper {
-    private outputChannel: vscode.OutputChannel;
+    private outputChannel: ILogger;
     private insertManager: CalcpadInsertManager;
     private quickTypeMap: Map<string, string> = new Map();
 
-    constructor(outputChannel: vscode.OutputChannel, insertManager: CalcpadInsertManager) {
+    constructor(outputChannel: ILogger, insertManager: CalcpadInsertManager) {
         this.outputChannel = outputChannel;
         this.insertManager = insertManager;
 

--- a/docs/new-settings.md
+++ b/docs/new-settings.md
@@ -105,6 +105,15 @@ The lowest severity surfaced as a diagnostic.
 ## Diagnostics
 
 - **Open Logs Folder** — opens the folder holding server logs and the most recent crash dump.
+- **Log Level** — how much detail is logged, from *Error* (least) to *Verbose* (most), defaulting to **Warning**. One setting covers everything: the server's log file and the editor's own Output channels.
+
+  | Level | What is logged |
+  | --- | --- |
+  | Error | Only failures |
+  | Warning *(default)* | Failures plus potential problems, such as a missing browser for PDF export |
+  | Information | Adds events: startup, the bound URL, server restarts, shutdown, etc. |
+  | Verbose | Adds a line per request, on both the server and the editor. Useful for tracing problems |
+
 - **Max Output Lines (per channel)** *(web/desktop)* — 10–100000, default 1000. Number of lines retained in each Output panel channel before older lines are dropped. Lower values reduce memory use and keep the UI responsive when logs are noisy.
 - **Max Preview Size (MB)** — 1–256, default 24. A document that renders to more HTML than this is not shown; the preview shows a **Preview blocked** page giving the render's size and the limit instead. Showing it risks running the app out of memory. PDF, HTML, and Word export are unaffected as they don't go through the preview. Raise it to preview a very large document anyway.
 - **Max Preview Console Messages** — 10–100000, default 500. How many console lines one preview render may relay before the rest are dropped. Lines go to the **Preview Console** output channel in the desktop app and to the **CalcpadCE Webview Console** channel in VS Code. A worksheet whose scripts log in a loop can otherwise flood the channel.


### PR DESCRIPTION
- Fixing server instabilities that caused random hangs, making the server unusable
- Adding proper log levels for server, a proper health endpoint for server, and improved server refresh process for calcpad-desktop
- Adding healthcheck visibility to vs code, fixing issue with server pid locking, reducing log noise from frontends and fixing bug with server log levels. Adding ILogger to get more control over log levels with various sources and get more consistency across the frontends.
- Fixing logging bugs